### PR TITLE
Remove the backing snapshot after reverting. Made snapshot removal more robust.

### DIFF
--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -769,7 +769,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         """
 
         volume = snapshot['volume']
-        if volume['status'] != 'available':
+        if volume['status'] not in ('available', 'in-use'):
             msg = _("Delete snapshot of volume not supported in "
                     "state: %s.") % volume['status']
             LOG.error(msg)

--- a/cinder/volume/drivers/vmware/volumeops.py
+++ b/cinder/volume/drivers/vmware/volumeops.py
@@ -1102,15 +1102,20 @@ class VMwareVolumeOps(object):
                          "%(backing)s. Need not delete anything."),
                      {'name': name, 'backing': backing})
             return
-        task = self._session.invoke_api(self._session.vim,
-                                        'RemoveSnapshot_Task',
-                                        snapshot, removeChildren=False)
         LOG.debug("Initiated snapshot: %(name)s deletion for backing: "
                   "%(backing)s.",
                   {'name': name, 'backing': backing})
-        self._session.wait_for_task(task)
+        self.delete_snapshot_ref(snapshot)
         LOG.info(_LI("Successfully deleted snapshot: %(name)s of backing: "
                      "%(backing)s."), {'backing': backing, 'name': name})
+
+    def delete_snapshot_ref(self, snapshot_ref):
+        """Deletes a snapshot by its managed object reference"""
+        task = self._session.invoke_api(self._session.vim,
+                                        'RemoveSnapshot_Task',
+                                        snapshot_ref, removeChildren=False)
+
+        self._session.wait_for_task(task)
 
     def _get_folder(self, backing):
         """Get parent folder of the backing.


### PR DESCRIPTION
This keeps the snapshots tree in the state if was in the beginning, except for the newly-created snapshot.