### PR TITLE
Do not snapshot the attachment VM but keep the full clone

### DIFF
--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -704,70 +704,65 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                     LOG.error(err_msg)
                     raise Exception(err_msg)
 
-            # Snapshot the VM
-            snapshotName = "tempVolumeSnapshot"
-            snapshot_ref = self.volumeops.create_snapshot(vm_ref, snapshotName, None)
-            with deferred(self.volumeops.delete_snapshot_ref, snapshot_ref):
+            # Clone from snapshot using full clone and discard all other disks
+            cloned_vm_ref = self.volumeops.clone_vm(vm_ref, device_change=dev_change)
+            with deferred(self.volumeops.delete_backing, cloned_vm_ref):
 
-                # Clone from snapshot using full clone and discard all other disks
-                cloned_vm_ref = self.volumeops.clone_vm(vm_ref, snapshot_ref, dev_change)
-                with deferred(self.volumeops.delete_backing, cloned_vm_ref):
+                # Determine the disk on the snapshot clone vm
+                # note: looking up disk by key because the vcenter
+                # is not honouring the device change specs -
+                # - otherwise there would be a single disk in the cloned vm
+                cloned_disks = self.volumeops._get_disk_devices(cloned_vm_ref)
+                for disk_device in cloned_disks:
+                    if disk_device.key == disk_key:
+                        break # disk found
+                else:
+                    err_msg = "Unable to find matching disk in cloned vm."
 
-                    # Determine the disk on the snapshot clone vm
-                    # note: looking up disk by key because the vcenter
-                    # is not honouring the device change specs -
-                    # - otherwise there would be a single disk in the cloned vm
-                    cloned_disks = self.volumeops._get_disk_devices(cloned_vm_ref)
-                    for disk_device in cloned_disks:
-                        if disk_device.key == disk_key:
-                            break # disk found
-                    else:
-                        err_msg = "Unable to find matching disk in cloned vm."
+                # detach the new disk from the cloned vm
+                LOG.debug("Detaching new disk from cloned vm {}.".format(cloned_vm_ref))
+                self.volumeops.detach_disk_from_backing(cloned_vm_ref, disk_device)
 
-                    # detach the new disk from the cloned vm
-                    LOG.debug("Detaching new disk from cloned vm {}.".format(cloned_vm_ref))
-                    self.volumeops.detach_disk_from_backing(cloned_vm_ref, disk_device)
+                # check if a storage profile needs to be associated with the backing VM
+                storage_profile_id = self._get_storage_profile_id(volume)
 
-                    # check if a storage profile needs to be associated with the backing VM
-                    storage_profile_id = self._get_storage_profile_id(volume)
+                # determine the disk type
+                if disk_device.backing.thinProvisioned:
+                    disk_type = volumeops.VirtualDiskType.THIN
+                else:
+                    disk_type = volumeops.VirtualDiskType.EAGER_ZEROED_THICK
 
-                    # determine the disk type
-                    if disk_device.backing.thinProvisioned:
-                        disk_type = volumeops.VirtualDiskType.THIN
-                    else:
-                        disk_type = volumeops.VirtualDiskType.EAGER_ZEROED_THICK
+                # replace the new disk on the backing vm
+                virtual_disk_spec = self.volumeops._create_virtual_disk_config_spec(
+                    disk_device.capacityInBytes / 1024,
+                    disk_type,
+                    0, # will override
+                    storage_profile_id,
+                    disk_device.backing.fileName)
 
-                    # replace the new disk on the backing vm
-                    virtual_disk_spec = self.volumeops._create_virtual_disk_config_spec(
-                        disk_device.capacityInBytes / 1024,
-                        disk_type,
-                        0, # will override
-                        storage_profile_id,
-                        disk_device.backing.fileName)
+                # Match properties to replace the disk
+                virtual_disk_spec.operation = 'edit'
+                virtual_disk_spec.fileOperation = None
+                virtual_disk_spec.device.controllerKey = backing_disks[0].controllerKey
+                virtual_disk_spec.device.key = backing_disks[0].key
 
-                    # Match properties to replace the disk
-                    virtual_disk_spec.operation = 'edit'
-                    virtual_disk_spec.fileOperation = None
-                    virtual_disk_spec.device.controllerKey = backing_disks[0].controllerKey
-                    virtual_disk_spec.device.key = backing_disks[0].key
+                # snapshot the backing vm before replacing the disk
+                # otherwise nova will have issues detaching the volume
+                backing_snapshot_name = "{}-{}".format(snapshot['name'], time())
+                backing_prior = self.volumeops.create_snapshot(backing_ref,
+                                                               backing_snapshot_name,
+                                                               snapshot['display_description'])
+                with deferred(self.volumeops.delete_snapshot_ref, backing_prior):
+                    with deferred(self.volumeops.revert_to_snapshot, backing_prior):
 
-                    # snapshot the backing vm before replacing the disk
-                    # otherwise nova will have issues detaching the volume
-                    backing_snapshot_name = "{}-{}".format(snapshot['name'], time())
-                    backing_prior = self.volumeops.create_snapshot(backing_ref,
-                                                                   backing_snapshot_name,
-                                                                   snapshot['display_description'])
-                    with deferred(self.volumeops.delete_snapshot_ref, backing_prior):
-                        with deferred(self.volumeops.revert_to_snapshot, backing_prior):
+                        # apply the disk replacement
+                        reconfigure_spec = factory.create('ns0:VirtualMachineConfigSpec')
+                        reconfigure_spec.deviceChange = [virtual_disk_spec]
+                        LOG.debug("Replacing disk on backing vm {}.".format(backing_ref))
+                        self.volumeops._reconfigure_backing(backing_ref, reconfigure_spec)
 
-                            # apply the disk replacement
-                            reconfigure_spec = factory.create('ns0:VirtualMachineConfigSpec')
-                            reconfigure_spec.deviceChange = [virtual_disk_spec]
-                            LOG.debug("Replacing disk on backing vm {}.".format(backing_ref))
-                            self.volumeops._reconfigure_backing(backing_ref, reconfigure_spec)
-
-                            # snapshot the backing vm
-                            self.volumeops.create_snapshot(backing_ref, snapshot['name'],
+                        # snapshot the backing vm
+                        self.volumeops.create_snapshot(backing_ref, snapshot['name'],
                                                            snapshot['display_description'])
         else:
             msg = _("Snapshot of volume not supported in "


### PR DESCRIPTION
Change in the implementation of snapshot of attached volume in VMware Cinder driver addressing the 'already a snapshot' issue with VVol.