### PR TITLE
[vmware] Remove all NICs from snapshot

### DIFF
--- a/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
@@ -2229,7 +2229,7 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
 
         dev_change_disk_remove = mock.sentinel.dev_change_disk_remove
         vops._create_device_change_for_disk_removal.return_value =\
-            dev_change_disk_remove
+            [dev_change_disk_remove]
 
         tmp_name = mock.sentinel.tmp_name
         generate_uuid.return_value = tmp_name
@@ -2256,7 +2256,7 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
         vops.clone_backing.assert_called_once_with(
             tmp_name, instance, None, volumeops.FULL_CLONE_TYPE, datastore,
             host=host, resource_pool=rp, folder=folder,
-            device_changes=dev_change_disk_remove)
+            device_changes=[dev_change_disk_remove])
 
     @mock.patch.object(VMDK_DRIVER, 'volumeops')
     @mock.patch.object(VMDK_DRIVER, '_manage_existing_int')

--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -2234,6 +2234,8 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
 
         device_changes = self.volumeops._create_device_change_for_disk_removal(
             instance, disks_to_clone=[vol_dev_uuid])
+        device_changes.extend(
+            self.volumeops._create_device_change_for_vif_removal(instance))
 
         return self.volumeops.clone_backing(
             tmp_name, instance, None, volumeops.FULL_CLONE_TYPE, datastore,


### PR DESCRIPTION
Until now, when creating a snapshot from an attached volume, only the
additional unwanted disks got remove and the NICs/VIFs were kept. With
nsx-t this is a problem, as it does not allow duplicate MAC addresses
on the same logical switch. Therefore, we now remove all VIFs - or
rather every device that has a "macAddress" attribute - in the
clone-process.