### PR TITLE
[vmware] Backup: send data needed to build an ImportVApp spec

### DIFF
--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -705,7 +705,8 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         disk_type = VMwareVcVmdkDriver._get_disk_type(volume)
         size_kb = volume['size'] * units.Mi
         adapter_type = self._get_adapter_type(volume)
-        controller_type = self.volumeops.get_controller_type(adapter_type)
+        controller_type = volumeops.ControllerType.get_controller_type(
+            adapter_type)
         controller_key, controller_spec = \
             self.volumeops.get_controller_key_and_spec(adapter_type)
         return {
@@ -714,9 +715,9 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
             'vm': {
                 'path_name': self.volumeops.get_vm_path_name(
                     summary.name),
-                'guest_id': self.volumeops.get_vm_guest_id(),
-                'num_cpus': self.volumeops.get_vm_num_cpus(),
-                'memory_mb': self.volumeops.get_vm_memory_mb(),
+                'guest_id': volumeops.VM_GUEST_ID,
+                'num_cpus': volumeops.VM_NUM_CPUS,
+                'memory_mb': volumeops.VM_MEMORY_MB,
                 'vmx_version': self.volumeops.get_vmx_version(),
                 'extension_key': self.volumeops._extension_key,
                 'extension_type': self.volumeops._extension_type,
@@ -730,9 +731,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                 'shared_bus':
                     self.volumeops.get_controller_device_shared_bus(
                         controller_type),
-                'bus_number':
-                    self.volumeops
-                        .get_controller_device_default_bus_number()
+                'bus_number': volumeops.CONTROLLER_DEVICE_BUS_NUMBER
             },
             'disk': {
                 'type': disk_type,
@@ -813,6 +812,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         if 'platform' in connector and 'os_type' in connector and \
                 volume['status'] == 'restoring-backup':
             backing = self.volumeops.get_backing_by_uuid(volume['id'])
+            self.volumeops.rename_backing(backing, volume['name'])
             self.volumeops.update_backing_disk_uuid(backing, volume['id'])
 
     def create_export(self, context, volume, connector):

--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -809,9 +809,14 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         return self._initialize_connection(volume, connector)
 
     def terminate_connection(self, volume, connector, force=False, **kwargs):
+        # Checking if the connection was used to restore from a backup. In
+        # that case, the VMDK connector in os-brick created a new backing
+        # which will replace the initial one. Here we set the proper name
+        # and backing uuid for the new backing, because os-brick doesn't do it.
         if 'platform' in connector and 'os_type' in connector and \
                 volume['status'] == 'restoring-backup':
             backing = self.volumeops.get_backing_by_uuid(volume['id'])
+
             self.volumeops.rename_backing(backing, volume['name'])
             self.volumeops.update_backing_disk_uuid(backing, volume['id'])
 

--- a/cinder/volume/drivers/vmware/volumeops.py
+++ b/cinder/volume/drivers/vmware/volumeops.py
@@ -799,8 +799,8 @@ class VMwareVolumeOps(object):
                                   not created for the virtual disk.
         :return: list containing controller and disk config specs
         """
-        (controller_key, controller_spec) = self.get_controller_key_and_spec(
-            adapter_type)
+        (controller_key, controller_spec) = \
+            self.get_controller_key_and_spec(adapter_type)
 
         disk_spec = self._create_virtual_disk_config_spec(size_kb,
                                                           disk_type,

--- a/cinder/volume/drivers/vmware/volumeops.py
+++ b/cinder/volume/drivers/vmware/volumeops.py
@@ -38,7 +38,7 @@ MIN_VIRTUAL_DISK_SIZE_KB = 4 * units.Ki
 VM_GUEST_ID = 'otherGuest'
 VM_NUM_CPUS = 1
 VM_MEMORY_MB = 128
-VMX_VERSION = 'vmx-8'
+VMX_VERSION = 'vmx-08'
 CONTROLLER_DEVICE_BUS_NUMBER = 0
 
 def split_datastore_path(datastore_path):
@@ -856,9 +856,9 @@ class VMwareVolumeOps(object):
 
         create_spec = cf.create('ns0:VirtualMachineConfigSpec')
         create_spec.name = name
-        create_spec.guestId = self.get_vm_guest_id()
-        create_spec.numCPUs = self.get_vm_num_cpus()
-        create_spec.memoryMB = self.get_vm_memory_mb()
+        create_spec.guestId = VM_GUEST_ID
+        create_spec.numCPUs = VM_NUM_CPUS
+        create_spec.memoryMB = VM_MEMORY_MB
         create_spec.files = vm_file_info
         # Set the default hardware version to a compatible version supported by
         # vSphere 5.0. This will ensure that the backing VM can be migrated


### PR DESCRIPTION
This is addressing the fix for restoring VVol volumes from swift
backup. cinder-backup needs to upload the backup data to VMWare
via HttpNfc API by performing a ImportVApp call. Since this
operation is about to replace the existing backing, we want to
keep the main logic in cinder-volume. Thus, we instruct
cinder-backup how to build the spec for ImportVApp via a json-like
syntax, since it seems that suds objects can't pe pickled or
simply can't be sent plain over RPC.