### PR TITLE
Chunkeddriver - no seek

### DIFF
--- a/cinder/backup/chunkeddriver.py
+++ b/cinder/backup/chunkeddriver.py
@@ -846,14 +846,12 @@ class BackupRestoreHandle(object):
         remove the corresponding object reader, freeing up the memory.
         """
         obj_name = segment.obj['name']
-        for _segment in self._segments[self._idx:]:
+        for _segment in self._segments[self._idx + 1:]:
             if obj_name == _segment.obj['name']:
                 return
 
-        obj_reader = self._object_readers[obj_name]
-        if obj_reader:
-            obj_reader.close()
-            self._object_readers.pop(obj_name)
+        self._object_readers[obj_name].close()
+        self._object_readers.pop(obj_name)
 
     def add_object(self, metadata_object):
         """Merges a backup chunk over the self._segments list.

--- a/cinder/backup/chunkeddriver.py
+++ b/cinder/backup/chunkeddriver.py
@@ -938,6 +938,7 @@ class Segment(object):
 
     @staticmethod
     def of(segment, offset=None, length=None):
+        """Returns a new segment with different offset and/or length."""
         return Segment(segment.obj,
                        segment.offset if offset is None else offset,
                        segment.length if length is None else length)

--- a/cinder/backup/chunkeddriver.py
+++ b/cinder/backup/chunkeddriver.py
@@ -724,6 +724,7 @@ class ChunkedBackupDriver(driver.BackupDriver):
         LOG.debug('delete %s finished.', backup['id'])
 
 
+@six.add_metaclass(abc.ABCMeta)
 class BackupRestoreHandle(object):
     """Class used to reconstruct a backup from chunks."""
     def __init__(self, chunked_driver, volume_id, volume_file):
@@ -734,9 +735,10 @@ class BackupRestoreHandle(object):
         self._object_readers = {}
         self._idx = -1
 
+    @abc.abstractmethod
     def add_backup(self, backup, metadata):
         """This is called for each backup in the incremental backups chain."""
-        raise NotImplementedError()
+        return
 
     def finish_restore(self):
         for segment in self._segments:

--- a/cinder/tests/unit/backup/drivers/test_backup_handle.py
+++ b/cinder/tests/unit/backup/drivers/test_backup_handle.py
@@ -19,12 +19,12 @@ from cinder import test
 import mock
 
 
-class BackupRestoreHandleTestCase(test.TestCase):
+class BackupRestoreHandleV1TestCase(test.TestCase):
 
     BACKUP_RESTORE_HANDLE = chunkeddriver.BackupRestoreHandle
 
     def setUp(self):
-        super(BackupRestoreHandleTestCase, self).setUp()
+        super(BackupRestoreHandleV1TestCase, self).setUp()
         self._driver = mock.Mock()
         self._volume_file = mock.Mock()
         self._volume_id = 'volume-01'
@@ -44,7 +44,7 @@ class BackupRestoreHandleTestCase(test.TestCase):
         # incremental
         obj3 = {'name': 'obj3', 'offset': 50, 'length': 100}
         obj4 = {'name': 'obj4', 'offset': 60, 'length': 50}
-        handle = chunkeddriver.BackupRestoreHandle(self._driver,
+        handle = chunkeddriver.BackupRestoreHandleV1(self._driver,
                                                    self._volume_id,
                                                    self._volume_file)
         handle.add_object(obj1)
@@ -79,7 +79,7 @@ class BackupRestoreHandleTestCase(test.TestCase):
         buff_reader_mock.read.return_value = b"foo"
         get_reader.return_value = buff_reader_mock
 
-        handle = chunkeddriver.BackupRestoreHandle(self._driver,
+        handle = chunkeddriver.BackupRestoreHandleV1(self._driver,
                                                    self._volume_id,
                                                    self._volume_file)
         data = handle._read_segment(self._segment)
@@ -94,7 +94,7 @@ class BackupRestoreHandleTestCase(test.TestCase):
     def test_get_reader(self, get_new_reader):
         new_reader = mock.Mock()
         get_new_reader.return_value = new_reader
-        handle = chunkeddriver.BackupRestoreHandle(self._driver,
+        handle = chunkeddriver.BackupRestoreHandleV1(self._driver,
                                                    self._volume_id,
                                                    self._volume_file)
         handle._get_reader(self._segment)
@@ -112,7 +112,7 @@ class BackupRestoreHandleTestCase(test.TestCase):
         get_obj_reader.__enter__ = mock.Mock(return_value=obj_reader)
         get_obj_reader.__exit__ = mock.Mock(return_value=False)
         self._driver._get_object_reader.return_value = get_obj_reader
-        handle = chunkeddriver.BackupRestoreHandle(self._driver,
+        handle = chunkeddriver.BackupRestoreHandleV1(self._driver,
                                                    self._volume_id,
                                                    self._volume_file)
         bytes_io = handle._get_new_reader(self._segment)
@@ -134,7 +134,7 @@ class BackupRestoreHandleTestCase(test.TestCase):
         reader.read.return_value = reader_ret
         self._driver._get_compressor.return_value = compressor
 
-        handle = chunkeddriver.BackupRestoreHandle(self._driver,
+        handle = chunkeddriver.BackupRestoreHandleV1(self._driver,
                                                    self._volume_id,
                                                    self._volume_file)
         handle._get_raw_bytes(reader, obj)
@@ -157,7 +157,7 @@ class BackupRestoreHandleTestCase(test.TestCase):
         obj_readers_mock = mock.MagicMock()
         obj_readers_mock.__getitem__.side_effect = obj_readers.__getitem__
 
-        handle = chunkeddriver.BackupRestoreHandle(self._driver,
+        handle = chunkeddriver.BackupRestoreHandleV1(self._driver,
                                                    self._volume_id,
                                                    self._volume_file)
         handle._object_readers = obj_readers_mock

--- a/cinder/tests/unit/backup/drivers/test_backup_handle.py
+++ b/cinder/tests/unit/backup/drivers/test_backup_handle.py
@@ -1,0 +1,161 @@
+# Copyright (C) 2020 SAP SE
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+
+from cinder.backup import chunkeddriver
+from cinder import test
+import mock
+
+
+class BackupRestoreHandleTestCase(test.TestCase):
+
+    BACKUP_RESTORE_HANDLE = chunkeddriver.BackupRestoreHandle
+
+    def setUp(self):
+        super(BackupRestoreHandleTestCase, self).setUp()
+        self._driver = mock.Mock()
+        self._obj = {
+            'offset': 100,
+            'length': 50,
+            'container': 'obj_container',
+            'name': 'obj_name',
+            'extra_metadata': {'foo': 'bar'},
+            'compression': None
+        }
+        self._segment = chunkeddriver.Segment(self._obj)
+
+    def test_add_object(self):
+        obj1 = {'name': 'obj1', 'offset': 0, 'length': 100}
+        obj2 = {'name': 'obj2', 'offset': 100, 'length': 100}
+        # incremental
+        obj3 = {'name': 'obj3', 'offset': 50, 'length': 100}
+        obj4 = {'name': 'obj4', 'offset': 60, 'length': 50}
+        handle = chunkeddriver.BackupRestoreHandle(self._driver)
+        handle.add_object(obj1)
+        handle.add_object(obj2)
+        handle.add_object(obj3)
+        handle.add_object(obj4)
+
+        ranges = handle._segments
+
+        self.assertEqual(0, ranges[0].offset)
+        self.assertEqual(50, ranges[0].end)
+
+        self.assertEqual(50, ranges[1].offset)
+        self.assertEqual(60, ranges[1].end)
+
+        self.assertEqual(60, ranges[2].offset)
+        self.assertEqual(100, ranges[2].end)
+
+        self.assertEqual(100, ranges[3].offset)
+        self.assertEqual(110, ranges[3].end)
+
+        self.assertEqual(110, ranges[4].offset)
+        self.assertEqual(150, ranges[4].end)
+
+        self.assertEqual(150, ranges[5].offset)
+        self.assertEqual(200, ranges[5].end)
+
+    @mock.patch.object(BACKUP_RESTORE_HANDLE, '_get_reader')
+    @mock.patch.object(BACKUP_RESTORE_HANDLE, '_clear_reader')
+    def test_read(self, clear_reader, get_reader):
+        buff_reader_mock = mock.Mock()
+        buff_reader_mock.read.return_value = b"foo"
+        get_reader.return_value = buff_reader_mock
+
+        handle = chunkeddriver.BackupRestoreHandle(self._driver)
+        data = handle.read(self._segment)
+
+        get_reader.assert_called_once_with(self._segment)
+        buff_reader_mock.seek.assert_called_once_with(
+            self._segment.offset - self._segment.obj['offset'])
+        clear_reader.assert_called_once_with(self._segment)
+        self.assertEqual(data, b"foo")
+
+    @mock.patch.object(BACKUP_RESTORE_HANDLE, '_get_new_reader')
+    def test_get_reader(self, get_new_reader):
+        new_reader = mock.Mock()
+        get_new_reader.return_value = new_reader
+        handle = chunkeddriver.BackupRestoreHandle(self._driver)
+        handle._get_reader(self._segment)
+        get_new_reader.assert_called_once_with(self._segment)
+        self.assertEqual(handle._object_readers, {
+            self._segment.obj['name']: new_reader
+        })
+
+    @mock.patch.object(BACKUP_RESTORE_HANDLE, '_get_raw_bytes')
+    def test_get_new_reader(self, get_raw_bytes):
+        raw_bytes = b'data'
+        get_raw_bytes.return_value = raw_bytes
+        obj_reader = mock.Mock()
+        get_obj_reader = mock.Mock()
+        get_obj_reader.__enter__ = mock.Mock(return_value=obj_reader)
+        get_obj_reader.__exit__ = mock.Mock(return_value=False)
+        self._driver._get_object_reader.return_value = get_obj_reader
+        handle = chunkeddriver.BackupRestoreHandle(self._driver)
+        bytes_io = handle._get_new_reader(self._segment)
+        self._driver._get_object_reader.assert_called_once_with(
+            self._segment.obj['container'],
+            self._segment.obj['name'],
+            extra_metadata=self._segment.obj['extra_metadata'])
+        get_raw_bytes.assert_called_once_with(obj_reader, self._segment.obj)
+        self.assertEqual(bytes_io.getvalue(), raw_bytes)
+
+    def test_get_raw_bytes(self, decompress=False):
+        compressor = None
+        obj = self._obj.copy()
+        if decompress:
+            compressor = mock.Mock()
+            obj['compression'] = 'zlib'
+        reader = mock.Mock()
+        reader_ret = mock.Mock()
+        reader.read.return_value = reader_ret
+        self._driver._get_compressor.return_value = compressor
+
+        handle = chunkeddriver.BackupRestoreHandle(self._driver)
+        handle._get_raw_bytes(reader, obj)
+
+        self._driver._get_compressor.\
+            assert_called_once_with(obj['compression'])
+        reader.read.assert_called_once_with()
+
+        if decompress:
+            compressor.decompress.assert_called_once_with(reader_ret)
+
+    def test_get_raw_bytes_decompressed(self):
+        self.test_get_raw_bytes(decompress=True)
+
+    def test_clear_reader(self):
+        obj_reader = mock.Mock()
+        obj = self._obj.copy()
+        obj['name'] = 'obj_name_2'
+        obj_readers = {self._obj['name']: obj_reader}
+        obj_readers_mock = mock.MagicMock()
+        obj_readers_mock.__getitem__.side_effect = obj_readers.__getitem__
+
+        handle = chunkeddriver.BackupRestoreHandle(self._driver)
+        handle._object_readers = obj_readers_mock
+        handle._segments = [self._segment, chunkeddriver.Segment(obj)]
+        handle._idx = 0
+        handle._clear_reader(self._segment)
+        obj_readers_mock.__getitem__.assert_not_called()
+        obj_reader.close.assert_not_called()
+        obj_readers_mock.pop.assert_not_called()
+
+        handle._idx = 1
+        handle._clear_reader(self._segment)
+        obj_readers_mock.__getitem__.assert_called_once_with(self._obj['name'])
+        obj_reader.close.assert_called_once_with()
+        obj_readers_mock.pop.assert_called_once_with(self._obj['name'])

--- a/cinder/tests/unit/backup/drivers/test_backup_handle.py
+++ b/cinder/tests/unit/backup/drivers/test_backup_handle.py
@@ -147,7 +147,10 @@ class BackupRestoreHandleTestCase(test.TestCase):
 
         handle = chunkeddriver.BackupRestoreHandle(self._driver)
         handle._object_readers = obj_readers_mock
-        handle._segments = [self._segment, chunkeddriver.Segment(obj)]
+        handle._segments = [self._segment,
+                            chunkeddriver.Segment(obj),
+                            chunkeddriver.Segment(self._obj)]
+
         handle._idx = 0
         handle._clear_reader(self._segment)
         obj_readers_mock.__getitem__.assert_not_called()
@@ -155,6 +158,12 @@ class BackupRestoreHandleTestCase(test.TestCase):
         obj_readers_mock.pop.assert_not_called()
 
         handle._idx = 1
+        handle._clear_reader(self._segment)
+        obj_readers_mock.__getitem__.assert_not_called()
+        obj_reader.close.assert_not_called()
+        obj_readers_mock.pop.assert_not_called()
+
+        handle._idx = 2
         handle._clear_reader(self._segment)
         obj_readers_mock.__getitem__.assert_called_once_with(self._obj['name'])
         obj_reader.close.assert_called_once_with()

--- a/cinder/tests/unit/backup/drivers/test_backup_handle.py
+++ b/cinder/tests/unit/backup/drivers/test_backup_handle.py
@@ -45,8 +45,8 @@ class BackupRestoreHandleV1TestCase(test.TestCase):
         obj3 = {'name': 'obj3', 'offset': 50, 'length': 100}
         obj4 = {'name': 'obj4', 'offset': 60, 'length': 50}
         handle = chunkeddriver.BackupRestoreHandleV1(self._driver,
-                                                   self._volume_id,
-                                                   self._volume_file)
+                                                     self._volume_id,
+                                                     self._volume_file)
         handle.add_object(obj1)
         handle.add_object(obj2)
         handle.add_object(obj3)
@@ -80,8 +80,8 @@ class BackupRestoreHandleV1TestCase(test.TestCase):
         get_reader.return_value = buff_reader_mock
 
         handle = chunkeddriver.BackupRestoreHandleV1(self._driver,
-                                                   self._volume_id,
-                                                   self._volume_file)
+                                                     self._volume_id,
+                                                     self._volume_file)
         data = handle._read_segment(self._segment)
 
         get_reader.assert_called_once_with(self._segment)
@@ -95,8 +95,8 @@ class BackupRestoreHandleV1TestCase(test.TestCase):
         new_reader = mock.Mock()
         get_new_reader.return_value = new_reader
         handle = chunkeddriver.BackupRestoreHandleV1(self._driver,
-                                                   self._volume_id,
-                                                   self._volume_file)
+                                                     self._volume_id,
+                                                     self._volume_file)
         handle._get_reader(self._segment)
         get_new_reader.assert_called_once_with(self._segment)
         self.assertEqual(handle._object_readers, {
@@ -113,8 +113,8 @@ class BackupRestoreHandleV1TestCase(test.TestCase):
         get_obj_reader.__exit__ = mock.Mock(return_value=False)
         self._driver._get_object_reader.return_value = get_obj_reader
         handle = chunkeddriver.BackupRestoreHandleV1(self._driver,
-                                                   self._volume_id,
-                                                   self._volume_file)
+                                                     self._volume_id,
+                                                     self._volume_file)
         bytes_io = handle._get_new_reader(self._segment)
         self._driver._get_object_reader.assert_called_once_with(
             self._segment.obj['container'],
@@ -135,8 +135,8 @@ class BackupRestoreHandleV1TestCase(test.TestCase):
         self._driver._get_compressor.return_value = compressor
 
         handle = chunkeddriver.BackupRestoreHandleV1(self._driver,
-                                                   self._volume_id,
-                                                   self._volume_file)
+                                                     self._volume_id,
+                                                     self._volume_file)
         handle._get_raw_bytes(reader, obj)
 
         self._driver._get_compressor.\
@@ -158,8 +158,8 @@ class BackupRestoreHandleV1TestCase(test.TestCase):
         obj_readers_mock.__getitem__.side_effect = obj_readers.__getitem__
 
         handle = chunkeddriver.BackupRestoreHandleV1(self._driver,
-                                                   self._volume_id,
-                                                   self._volume_file)
+                                                     self._volume_id,
+                                                     self._volume_file)
         handle._object_readers = obj_readers_mock
         handle._segments = [self._segment,
                             chunkeddriver.Segment(obj),

--- a/cinder/tests/unit/backup/drivers/test_backup_handle.py
+++ b/cinder/tests/unit/backup/drivers/test_backup_handle.py
@@ -26,6 +26,8 @@ class BackupRestoreHandleTestCase(test.TestCase):
     def setUp(self):
         super(BackupRestoreHandleTestCase, self).setUp()
         self._driver = mock.Mock()
+        self._volume_file = mock.Mock()
+        self._volume_id = 'volume-01'
         self._obj = {
             'offset': 100,
             'length': 50,
@@ -42,7 +44,9 @@ class BackupRestoreHandleTestCase(test.TestCase):
         # incremental
         obj3 = {'name': 'obj3', 'offset': 50, 'length': 100}
         obj4 = {'name': 'obj4', 'offset': 60, 'length': 50}
-        handle = chunkeddriver.BackupRestoreHandle(self._driver)
+        handle = chunkeddriver.BackupRestoreHandle(self._driver,
+                                                   self._volume_id,
+                                                   self._volume_file)
         handle.add_object(obj1)
         handle.add_object(obj2)
         handle.add_object(obj3)
@@ -70,13 +74,15 @@ class BackupRestoreHandleTestCase(test.TestCase):
 
     @mock.patch.object(BACKUP_RESTORE_HANDLE, '_get_reader')
     @mock.patch.object(BACKUP_RESTORE_HANDLE, '_clear_reader')
-    def test_read(self, clear_reader, get_reader):
+    def test_read_segment(self, clear_reader, get_reader):
         buff_reader_mock = mock.Mock()
         buff_reader_mock.read.return_value = b"foo"
         get_reader.return_value = buff_reader_mock
 
-        handle = chunkeddriver.BackupRestoreHandle(self._driver)
-        data = handle.read(self._segment)
+        handle = chunkeddriver.BackupRestoreHandle(self._driver,
+                                                   self._volume_id,
+                                                   self._volume_file)
+        data = handle._read_segment(self._segment)
 
         get_reader.assert_called_once_with(self._segment)
         buff_reader_mock.seek.assert_called_once_with(
@@ -88,7 +94,9 @@ class BackupRestoreHandleTestCase(test.TestCase):
     def test_get_reader(self, get_new_reader):
         new_reader = mock.Mock()
         get_new_reader.return_value = new_reader
-        handle = chunkeddriver.BackupRestoreHandle(self._driver)
+        handle = chunkeddriver.BackupRestoreHandle(self._driver,
+                                                   self._volume_id,
+                                                   self._volume_file)
         handle._get_reader(self._segment)
         get_new_reader.assert_called_once_with(self._segment)
         self.assertEqual(handle._object_readers, {
@@ -104,7 +112,9 @@ class BackupRestoreHandleTestCase(test.TestCase):
         get_obj_reader.__enter__ = mock.Mock(return_value=obj_reader)
         get_obj_reader.__exit__ = mock.Mock(return_value=False)
         self._driver._get_object_reader.return_value = get_obj_reader
-        handle = chunkeddriver.BackupRestoreHandle(self._driver)
+        handle = chunkeddriver.BackupRestoreHandle(self._driver,
+                                                   self._volume_id,
+                                                   self._volume_file)
         bytes_io = handle._get_new_reader(self._segment)
         self._driver._get_object_reader.assert_called_once_with(
             self._segment.obj['container'],
@@ -124,7 +134,9 @@ class BackupRestoreHandleTestCase(test.TestCase):
         reader.read.return_value = reader_ret
         self._driver._get_compressor.return_value = compressor
 
-        handle = chunkeddriver.BackupRestoreHandle(self._driver)
+        handle = chunkeddriver.BackupRestoreHandle(self._driver,
+                                                   self._volume_id,
+                                                   self._volume_file)
         handle._get_raw_bytes(reader, obj)
 
         self._driver._get_compressor.\
@@ -145,7 +157,9 @@ class BackupRestoreHandleTestCase(test.TestCase):
         obj_readers_mock = mock.MagicMock()
         obj_readers_mock.__getitem__.side_effect = obj_readers.__getitem__
 
-        handle = chunkeddriver.BackupRestoreHandle(self._driver)
+        handle = chunkeddriver.BackupRestoreHandle(self._driver,
+                                                   self._volume_id,
+                                                   self._volume_file)
         handle._object_readers = obj_readers_mock
         handle._segments = [self._segment,
                             chunkeddriver.Segment(obj),

--- a/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
@@ -1929,10 +1929,8 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
 
         controller_type.get_controller_type.return_value = mock_data[
             'controller']['type']
-        vops.get_controller_key_and_spec.return_value = (mock_data[
-                                                             'controller'][
-                                                             'key'],
-                                                         mock.Mock())
+        vops.get_controller_key_and_spec.return_value = \
+            (mock_data['controller']['key'], mock.Mock())
         vops.get_vm_path_name.return_value = mock_data['vm']['path_name']
         vops.get_vmx_version.return_value = mock_data['vm']['vmx_version']
         vops._extension_key = mock_data['vm']['extension_key']
@@ -1956,7 +1954,6 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
         data = self._driver._get_connection_import_data(volume)
 
         self.assertEqual(mock_data, data)
-
 
     @mock.patch.object(VMDK_DRIVER, 'volumeops')
     @mock.patch('oslo_vmware.vim_util.get_moref')

--- a/cinder/volume/drivers/vmware/volumeops.py
+++ b/cinder/volume/drivers/vmware/volumeops.py
@@ -41,6 +41,7 @@ VM_MEMORY_MB = 128
 VMX_VERSION = 'vmx-08'
 CONTROLLER_DEVICE_BUS_NUMBER = 0
 
+
 def split_datastore_path(datastore_path):
     """Split the datastore path to components.
 


### PR DESCRIPTION
Removes the need of `seek()` for every chunk that is being restored.
Instead, all the chunks are merged into a single sequence which is eventually written in a row.
It improves the write operation and allows connectors which don't support `seek()` (for now the vmdk connector) to support restoring of incremental backups.