### PR TITLE
SAP: add reporting of thin provisioning

### DIFF
--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -273,7 +273,10 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
     #         improve scalability of querying volumes in backend (bug 1600754)
     # 3.1.0 - support adapter type change using retype
     # 3.2.0 - config option to disable lazy creation of backend volume
-    VERSION = '3.2.0'
+
+    # 3.2.0.99.0 - Added reporting of thin_provisioning_support,
+    #          max_over_subscription_ratio.
+    VERSION = '3.2.0.99.0'
 
     # ThirdPartySystems wiki page
     CI_WIKI_NAME = "VMware_CI"
@@ -343,13 +346,19 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         backend_name = self.configuration.safe_get('volume_backend_name')
         if not backend_name:
             backend_name = self.__class__.__name__
+
+        max_over_subscription_ratio = self.configuration.safe_get(
+            'max_over_subscription_ratio')
         data = {'volume_backend_name': backend_name,
                 'vendor_name': 'VMware',
                 'driver_version': self.VERSION,
                 'storage_protocol': 'vmdk',
                 'reserved_percentage': self.configuration.reserved_percentage,
                 'total_capacity_gb': 'unknown',
-                'free_capacity_gb': 'unknown'}
+                'free_capacity_gb': 'unknown',
+                'thin_provisioning_support': True,
+                'thick_provisioning_support': True,
+                'max_over_subscription_ratio': max_over_subscription_ratio}
         client_factory = self.session.vim.client.factory
         object_specs = []
         if (self._storage_policy_enabled and


### PR DESCRIPTION
This patch adds the capability reporting for
thin provisioning support as well as max over subscription
and reserve percentage.

https://docs.openstack.org/cinder/queens/admin/blockstorage-over-subscription.html