### PR TITLE
SAP: need redis for osprofiler

### DIFF
--- a/custom-requirements.txt
+++ b/custom-requirements.txt
@@ -1,4 +1,8 @@
 # Any custom requirements that we need for ccloud
+
+# needed for osprofiler
+redis
+
 -e git+https://github.com/sapcc/python-agentliveness.git#egg=agentliveness
 -e git+https://github.com/sapcc/raven-python.git@ccloud#egg=raven
 -e git+https://github.com/sapcc/openstack-watcher-middleware.git#egg=watcher-middleware


### PR DESCRIPTION
This patch adds redis to the custom-requirements.txt which is
needed by osprofiler