### PR TITLE
SAP: add concourse_unit_test_task

### DIFF
--- a/concourse_unit_test_task
+++ b/concourse_unit_test_task
@@ -1,0 +1,8 @@
+export DEBIAN_FRONTEND=noninteractive && \
+export UPPER_CONSTRAINTS_FILE=https://raw.githubusercontent.com/sapcc/requirements/stable/queens-m3/upper-constraints.txt && \
+apt-get update && \
+apt-get install -y build-essential python-pip python-dev python3-dev git libpcre++-dev gettext && \
+pip install tox "six>=1.14.0" && \
+git clone -b stable/queens-m3 --single-branch https://github.com/sapcc/cinder.git --depth=1 && \
+cd cinder && \
+tox -e py27,pep8


### PR DESCRIPTION
This patch adds the concourse_unit_test_task file so we can run
unit tests during the loci image build process.