### PR TITLE
SAP: upgrade pip for concourse_unit_test_task

### DIFF
--- a/concourse_unit_test_task
+++ b/concourse_unit_test_task
@@ -2,6 +2,7 @@ export DEBIAN_FRONTEND=noninteractive && \
 export UPPER_CONSTRAINTS_FILE=https://raw.githubusercontent.com/sapcc/requirements/stable/queens-m3/upper-constraints.txt && \
 apt-get update && \
 apt-get install -y build-essential python-pip python-dev python3-dev git libpcre++-dev gettext && \
+pip install -U pip && \
 pip install tox "six>=1.14.0" && \
 git clone -b stable/queens-m3 --single-branch https://github.com/sapcc/cinder.git --depth=1 && \
 cd cinder && \


### PR DESCRIPTION
There is a bug in setuptools that prevents python installs
from working correctly and you end up with an error
"error: 'egg_base' must be a directory name (got `src`)"

This patch upgrades the version of pip for running unit tests,
which should fix the error.