### PR TITLE
SAP: Fix when migration status is None

### DIFF
--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -706,6 +706,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
             # create a writeable handle for the migration to work.
             if (volume['status'] == 'restoring-backup' or
                (volume['status'] == 'available' and
+                    volume['migration_status'] and
                     volume['migration_status'].startswith('target:'))):
                 connection_info['data']['import_data'] = \
                     self._get_connection_import_data(volume)


### PR DESCRIPTION
This patch fixes an issue that tempest found during
test_volume_snapshot_backup and the volume['migration_status'] was None
and can't be dereferenced as a string.