### PR TITLE
SAP: Adds support for min/max volume size on vol_type

### DIFF
--- a/cinder/volume/api.py
+++ b/cinder/volume/api.py
@@ -236,6 +236,9 @@ class API(base.Base):
                     'than zero).') % size
             raise exception.InvalidInput(reason=msg)
 
+        # ensure we pass the volume_type provisioning filter on size
+        volume_types.provision_filter_on_size(context, volume_type, size)
+
         if consistencygroup and (not cgsnapshot and not source_cg):
             if not volume_type:
                 msg = _("volume_type must be provided when creating "
@@ -1379,6 +1382,14 @@ class API(base.Base):
                                                     'size': volume.size})
             raise exception.InvalidInput(reason=msg)
 
+        # Make sure we pass the potential size limitations in the volume type
+        try:
+            volume_type = volume_types.get_volume_type(context,
+                                                       volume.volume_type_id)
+        except (exception.InvalidVolumeType, exception.VolumeTypeNotFound):
+            volume_type = None
+        volume_types.provision_filter_on_size(context, volume_type, new_size)
+
         result = volume.conditional_update(value, expected)
         if not result:
             msg = (_("Volume %(vol_id)s status must be '%(expected)s' "
@@ -1629,6 +1640,9 @@ class API(base.Base):
             raise exception.InvalidInput(reason=msg)
 
         new_type_id = new_type['id']
+
+        # Make sure we pass the potential size limitations in the volume type
+        volume_types.provision_filter_on_size(context, new_type, volume.size)
 
         # NOTE(jdg): We check here if multiattach is involved in either side
         # of the retype, we can't change multiattach on an in-use volume

--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -1641,6 +1641,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         return (volume['volume_attachment'] and
                 len(volume['volume_attachment']) > 0)
 
+    @utils.trace
     def retype(self, ctxt, volume, new_type, diff, host):
         """Convert the volume to be of the new type.
 

--- a/releasenotes/notes/min-max-vol-size-on-type-bc7c75ea73a74d02.yaml
+++ b/releasenotes/notes/min-max-vol-size-on-type-bc7c75ea73a74d02.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - Ability to add minimum and maximum volume size restrictions which
+    can be set on a per volume-type granularity.  New volume type keys of
+    'provisioning:min_vol_size' and 'provisioning:max_vol_size'.


### PR DESCRIPTION
Allows support for setting a minimum and/or maximum vol size that
can be created in extra_specs for each volume_type. This allows
setting size restrictions on different "tiers" of storage.
If configured, the size restrictions will be checked at the API level
as part of volume creation or retype.

2 new volume type keys are supported for setting the minimum volume
size and maximum volume size for that type.
'provisioning:min_vol_size'
'provisioning:max_vol_size'

Implements: blueprint min-max-vol-size-by-vol-type

This patch cherry-picked from master and conflicts resolved to merge into queens-m3
https://review.opendev.org/#/c/713710/

Change-Id: I222e778902a41e552e812896d7afd0516ee7fe68