### PR TITLE
SAP: add cinder host to notify log line

### DIFF
--- a/cinder/manager.py
+++ b/cinder/manager.py
@@ -191,7 +191,8 @@ class SchedulerDependentManager(ThreadPoolManager):
     def _publish_service_capabilities(self, context):
         """Pass data back to the scheduler at a periodic interval."""
         if self.last_capabilities:
-            LOG.debug('Notifying Schedulers of capabilities ...')
+            LOG.debug('Notifying Schedulers of capabilities for %(host)s...',
+                      {'host': self.host})
             self.scheduler_rpcapi.update_service_capabilities(
                 context,
                 self.service_name,


### PR DESCRIPTION
This patch adds the cinder host to the update volume stats
notification in the log, so we can track which cinder host
is updating at what time.