### PR TITLE
Improve the deletion of object readers in BackupRestoreHandle

### DIFF
--- a/cinder/backup/chunkeddriver.py
+++ b/cinder/backup/chunkeddriver.py
@@ -751,7 +751,7 @@ class BackupRestoreHandle(object):
                           'object_name': segment.obj['name'],
                           'volume_id': self._volume_id,
                       })
-
+            self._idx += 1
             # write the segment bytes to the file
             self._volume_file.write(self._read_segment(segment))
 
@@ -824,9 +824,9 @@ class BackupRestoreHandle(object):
         for _segment in self._segments[self._idx + 1:]:
             if obj_name == _segment.obj['name']:
                 return
-
         self._object_readers[obj_name].close()
         del self._object_readers[obj_name]
+        LOG.debug("Cleared reader for object %s" % segment.obj['name'])
 
     def add_object(self, metadata_object):
         """Merges a backup chunk over the self._segments list.

--- a/cinder/backup/chunkeddriver.py
+++ b/cinder/backup/chunkeddriver.py
@@ -826,7 +826,7 @@ class BackupRestoreHandle(object):
                 return
 
         self._object_readers[obj_name].close()
-        self._object_readers.pop(obj_name)
+        del self._object_readers[obj_name]
 
     def add_object(self, metadata_object):
         """Merges a backup chunk over the self._segments list.

--- a/cinder/backup/chunkeddriver.py
+++ b/cinder/backup/chunkeddriver.py
@@ -826,7 +826,7 @@ class BackupRestoreHandle(object):
                 return
         self._object_readers[obj_name].close()
         del self._object_readers[obj_name]
-        LOG.debug("Cleared reader for object %s" % segment.obj['name'])
+        LOG.debug("Cleared reader for object %s", segment.obj['name'])
 
     def add_object(self, metadata_object):
         """Merges a backup chunk over the self._segments list.


### PR DESCRIPTION
* Fix a bug which was causing object readers to be kept in memory 
* Use `del` to delete object readers from the internal map, as we shouldn't wait for the garbage collector to remove them from the memory.

This should help decreasing the memory consumption while restoring backups.