### PR TITLE
SAP: Make tox -e pep8 work again

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 minversion = 2.0
 skipsdist = True
 envlist = py35,py27,compliance,pep8
+requires = virtualenv<20
 
 [testenv]
 # Note the hash seed is set to 0 until cinder can be tested with a


### PR DESCRIPTION
It failed to install the dependencies even with a pinned setuptools<45
in the upper constraints:

      File "/tmp/pip-install-jx7q3ls5/MarkupSafe/setup.py", line 6, in <module>
        from setuptools import setup, Extension, Feature
    ImportError: cannot import name 'Feature'

The problem is, that a newer versions of `virtualenv` also pull in a new
version of setuptools. I haven't found a way to constrain the setuptools
version used by tox's creation of a virtualenv. Therefore, we now limit
the virtualenv version, which should bring us back to supported
territory.