### PR TITLE
fix - scheduler manager find_backend_for_connector return value

### DIFF
--- a/cinder/scheduler/manager.py
+++ b/cinder/scheduler/manager.py
@@ -327,9 +327,9 @@ class SchedulerManager(manager.CleanableManager, manager.Manager):
         backend = self.driver.find_backend_for_connector(context,
                                                          connector,
                                                          request_spec)
-        return {'host': backend.obj.host,
-                'cluster_name': backend.obj.cluster_name,
-                'capabilities': backend.obj.capabilities}
+        return {'host': backend.host,
+                'cluster_name': backend.cluster_name,
+                'capabilities': backend.capabilities}
 
     def manage_existing(self, context, volume, request_spec,
                         filter_properties=None):

--- a/cinder/tests/unit/scheduler/test_scheduler.py
+++ b/cinder/tests/unit/scheduler/test_scheduler.py
@@ -508,18 +508,17 @@ class SchedulerManagerTestCase(test.TestCase):
     def test_find_backend_for_connector(self, _mock_find_backend_for_conector):
         connector = mock.Mock()
         request_spec = mock.Mock()
-        backend_obj = mock.Mock(host='fake-host',
+        backend_ret = mock.Mock(host='fake-host',
                                 cluster_name='fake-cluster', capabilities=[])
-        backend_ret = mock.Mock(obj=backend_obj)
         _mock_find_backend_for_conector.return_value = backend_ret
         ret = self.manager.find_backend_for_connector(self.context,
                                                       connector, request_spec)
         _mock_find_backend_for_conector.assert_called_once_with(
             self.context, connector, request_spec)
         self.assertEqual(ret, {
-            'host': backend_ret.obj.host,
-            'cluster_name': backend_ret.obj.cluster_name,
-            'capabilities': backend_ret.obj.capabilities
+            'host': backend_ret.host,
+            'cluster_name': backend_ret.cluster_name,
+            'capabilities': backend_ret.capabilities
         })
 
 


### PR DESCRIPTION
This fixes the bug of manager trying to access .obj of a PoolState,
instead it should access the PoolState properties directly, because
that's what the scheduler driver returns.