### PR TITLE
FIX vmware migrations issues

### DIFF
--- a/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
@@ -160,6 +160,7 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
                             attachment=None,
                             project_id=PROJECT_ID):
         return {'id': vol_id,
+                'name_id': vol_id,
                 'display_name': display_name,
                 'name': 'volume-%s' % vol_id,
                 'volume_type_id': volume_type_id,
@@ -217,11 +218,13 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
     @mock.patch.object(VMDK_DRIVER, 'volumeops')
     def test_delete_volume_without_backing(self, vops):
         vops.get_backing.return_value = None
+        vops.get_backing_by_uuid.return_value = None
 
-        volume = self._create_volume_dict()
+        volume = self._create_volume_obj()
         self._driver.delete_volume(volume)
 
         vops.get_backing.assert_called_once_with(volume['name'], volume['id'])
+        vops.get_backing_by_uuid.assert_called_once_with(volume['name_id'])
         self.assertFalse(vops.delete_backing.called)
 
     @mock.patch.object(VMDK_DRIVER, 'volumeops')
@@ -3392,17 +3395,17 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
             else:
                 self.assertEqual((True, None), ret_val)
 
-            if capabilities and 'location_info' in capabilities:
-                if capabilities['location_info'].startswith(
-                        '%s:' % vmdk.LOCATION_DRIVER_NAME):
-                    if backing:
-                        _assertions_for_migration()
-                    else:
-                        _assertions_for_no_backing()
+        if capabilities and 'location_info' in capabilities:
+            if capabilities['location_info'].startswith(
+                    '%s:' % vmdk.LOCATION_DRIVER_NAME):
+                if backing:
+                    _assertions_for_migration()
                 else:
-                    _assertions_migration_not_performed()
+                    _assertions_for_no_backing()
             else:
                 _assertions_migration_not_performed()
+        else:
+            _assertions_migration_not_performed()
 
     def test_migrate_volume_relocate_existing_backing(self):
         self.test_migrate_volume(backing=mock.Mock())
@@ -3417,6 +3420,32 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
         self.test_migrate_volume(backing=mock.Mock(), capabilities={
             'location_info': 'invalid-location-info'
         })
+
+    @mock.patch.object(VMDK_DRIVER, 'volumeops')
+    def test_update_migrated_volume(self, vops):
+        volume = self._create_volume_obj()
+        new_volume = self._create_volume_obj(vol_id='new-id')
+        backing = mock.Mock()
+        vops.get_backing.return_value = backing
+        ret_val = self._driver.update_migrated_volume(self._context, volume,
+                                                      new_volume, 'old-status')
+        vops.rename_backing.assert_called_once_with(backing, volume['name'])
+        vops.update_backing_uuid.assert_called_once_with(backing, volume['id'])
+        vops.update_backing_disk_uuid.assert_called_once_with(backing,
+                                                              volume['id'])
+        self.assertIsNone(ret_val)
+
+    @mock.patch.object(VMDK_DRIVER, 'volumeops')
+    def test_update_migrated_volume_without_backing(self, vops):
+        volume = self._create_volume_obj()
+        new_volume = self._create_volume_obj(vol_id='new-id')
+        vops.get_backing.return_value = None
+        ret_val = self._driver.update_migrated_volume(self._context, volume,
+                                                      new_volume, 'old-status')
+        vops.rename_backing.assert_not_called()
+        vops.update_backing_uuid.assert_not_called()
+        vops.update_backing_disk_uuid.assert_not_called()
+        self.assertIsNone(ret_val)
 
 
 @ddt.ddt

--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -305,7 +305,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         self._ds_sel = None
         self._clusters = None
         self._dc_cache = {}
-        self.additional_endpoints.append([
+        self.additional_endpoints.extend([
             remote_api.VmdkDriverRemoteService(self)
         ])
         self._remote_api = remote_api.VmdkDriverRemoteApi()
@@ -506,6 +506,11 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         :param volume: Volume object
         """
         backing = self.volumeops.get_backing(volume['name'], volume['id'])
+        if not backing:
+            # If a volume has just been migrated, the manager assigned the
+            # temporary ID in the `volume` parameter, but instead it has set
+            # the correct ID to _name_id, which we need to perform deletion.
+            backing = self.volumeops.get_backing_by_uuid(volume.name_id)
         if not backing:
             LOG.info("Backing not available, no operation "
                      "to be performed.")
@@ -771,10 +776,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
             #
             # If we are migrating to this volume, we need to
             # create a writeable handle for the migration to work.
-            if (volume['status'] == 'restoring-backup' or
-               (volume['status'] == 'available' and
-                    volume['migration_status'] and
-                    volume['migration_status'].startswith('target:'))):
+            if self._is_volume_subject_to_import_vapp(volume):
                 connection_info['data']['import_data'] = \
                     self._get_connection_import_data(volume)
 
@@ -787,6 +789,12 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                    'connector': connector})
 
         return connection_info
+
+    def _is_volume_subject_to_import_vapp(self, volume):
+        return (volume['status'] == 'restoring-backup' or
+                (volume['status'] == 'available' and
+                 volume['migration_status'] and
+                 volume['migration_status'].startswith('target:')))
 
     def _get_connection_import_data(self, volume):
         (host, rp, folder, summary) = self._select_ds_for_volume(
@@ -918,7 +926,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         # which will replace the initial one. Here we set the proper name
         # and backing uuid for the new backing, because os-brick doesn't do it.
         if (connector and 'platform' in connector and 'os_type' in connector
-                and volume['status'] == 'restoring-backup'):
+                and self._is_volume_subject_to_import_vapp(volume)):
             backing = self.volumeops.get_backing_by_uuid(volume['id'])
 
             self.volumeops.rename_backing(backing, volume['name'])
@@ -2548,9 +2556,11 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         """
 
         false_ret = (False, None)
-        if volume['status'] != 'available':
-            LOG.debug('Only available volumes can be migrated using backend '
-                      'assisted migration. Falling back to generic migration.')
+        allowed_statuses = ['available', 'reserved']
+        if volume['status'] not in allowed_statuses:
+            LOG.debug('Only %s volumes can be migrated using backend '
+                      'assisted migration. Falling back to generic migration.',
+                      " or ".join(allowed_statuses))
             return false_ret
         if 'location_info' not in host['capabilities']:
             LOG.debug('Host capabilities are missing location_info. Falling '
@@ -2608,3 +2618,16 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
             return (True, {'migration_status': 'error'})
 
         return (True, None)
+
+    def update_migrated_volume(self, ctxt, volume, new_volume,
+                               original_volume_status):
+        backing = self.volumeops.get_backing(new_volume['name'],
+                                             new_volume['id'])
+        if not backing:
+            LOG.warning("Backing was not found after migration.")
+
+        self.volumeops.rename_backing(backing, volume['name'])
+        self.volumeops.update_backing_uuid(backing, volume['id'])
+        self.volumeops.update_backing_disk_uuid(backing, volume['id'])
+
+        return None

--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -2625,6 +2625,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                                              new_volume['id'])
         if not backing:
             LOG.warning("Backing was not found after migration.")
+            return None
 
         self.volumeops.rename_backing(backing, volume['name'])
         self.volumeops.update_backing_uuid(backing, volume['id'])


### PR DESCRIPTION
This includes several fixes to make both host migrations and driver
migrations work.
* It allows to migrate_volume for 'reserved' volumes as well, so that
  a volume can be migrated by the driver before it is attached
* It fixes the host migration (with force_host_copy enabled) by
  implementing update_migrated_volume which updates the backing uuids.
  Also fixes the terminate_connection to match the condition from the
  initialize_connection for renaming and updating the backing after a
  migration or a backup restore.
* It fixes a development artifact which was causing the RPC endpoints of
  the VMDK driver to not be advertised (it was appending to the
  additional_endpoints instead of extending the list).