### PR TITLE
[SAP] Fix retype with AZ

### DIFF
--- a/cinder/tests/unit/volume/test_volume_retype.py
+++ b/cinder/tests/unit/volume/test_volume_retype.py
@@ -47,6 +47,10 @@ class VolumeRetypeTestCase(base.BaseVolumeTestCase):
                             {},
                             description="fake_type")
         volume_types.create(self.context,
+                            "fake_vol_type2",
+                            {},
+                            description="fake_type2")
+        volume_types.create(self.context,
                             "multiattach-type",
                             {'multiattach': "<is> True"},
                             description="test-multiattach")
@@ -57,6 +61,9 @@ class VolumeRetypeTestCase(base.BaseVolumeTestCase):
         self.default_vol_type = objects.VolumeType.get_by_name_or_id(
             self.context,
             'fake_vol_type')
+        self.fake_vol_type2 = objects.VolumeType.get_by_name_or_id(
+            self.context,
+            'fake_vol_type2')
         self.multiattach_type = objects.VolumeType.get_by_name_or_id(
             self.context,
             'multiattach-type')
@@ -69,8 +76,49 @@ class VolumeRetypeTestCase(base.BaseVolumeTestCase):
             return self.multiattach_type
         elif identifier == 'multiattach-type2':
             return self.multiattach_type2
+        elif identifier == 'fake_vol_type2':
+            return self.fake_vol_type2
         else:
             return self.default_vol_type
+
+    @mock.patch('cinder.scheduler.rpcapi.SchedulerAPI.retype')
+    @mock.patch('cinder.context.RequestContext.authorize')
+    @mock.patch.object(volume_types, 'get_by_name_or_id')
+    def test_retype_has_az(self, _mock_get_types, mock_authorize, mock_rpc):
+        """Verify retype has az in request spec."""
+        _mock_get_types.side_effect = self.fake_get_vtype
+
+        vol = tests_utils.create_volume(
+            self.context,
+            volume_type_id=self.default_vol_type.id,
+            status='available',
+            availability_zone='nova')
+
+        self.volume_api.retype(self.user_context,
+                               vol,
+                               'fake_vol_type2')
+
+        mock_authorize.assert_has_calls(
+            [mock.call(vol_action_policies.RETYPE_POLICY, target_obj=mock.ANY),
+             ])
+
+        fake_spec = {
+            'volume_properties': mock.ANY,
+            'volume_id': mock.ANY,
+            'volume_type': mock.ANY,
+            'migration_policy': mock.ANY,
+            'quota_reservations': mock.ANY,
+            'old_reservations': mock.ANY,
+            'resource_properties': {
+                'availability_zone': 'nova'
+            }
+        }
+
+        mock_rpc.assert_has_calls(
+            [mock.call(self.user_context, mock.ANY,
+                       request_spec=fake_spec,
+                       filter_properties=mock.ANY)]
+        )
 
     @mock.patch('cinder.context.RequestContext.authorize')
     @mock.patch.object(volume_types, 'get_by_name_or_id')

--- a/cinder/volume/api.py
+++ b/cinder/volume/api.py
@@ -1780,7 +1780,10 @@ class API(base.Base):
                         'volume_type': new_type,
                         'migration_policy': migration_policy,
                         'quota_reservations': reservations,
-                        'old_reservations': old_reservations}
+                        'old_reservations': old_reservations,
+                        'resource_properties': {
+                            'availability_zone': volume.availability_zone
+                        }}
 
         self.scheduler_rpcapi.retype(context, volume,
                                      request_spec=request_spec,


### PR DESCRIPTION
Cinder wasn't honoring AZ when doing a retype as described in the
upstream bug here:
https://bugs.launchpad.net/cinder/+bug/1883928

This patch ensures that the AZ is placed inside the request spec
such that the AvailabilityZoneFilter can see it and use it when
determining the host for the new volume.