### PR TITLE
SAP: need jaeger-client for osprofiler

### DIFF
--- a/custom-requirements.txt
+++ b/custom-requirements.txt
@@ -2,6 +2,7 @@
 
 # needed for osprofiler
 redis
+jaeger-client
 
 -e git+https://github.com/sapcc/python-agentliveness.git#egg=agentliveness
 -e git+https://github.com/sapcc/raven-python.git@ccloud#egg=raven


### PR DESCRIPTION
This patch adds jaeger-client to the custom-requirements.txt,
which is required when osprofiler uses jaeger as backend.