### PR TITLE
[SAP] Randomize the selection of best datastores

### DIFF
--- a/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
@@ -102,6 +102,7 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
         self._config.vmware_storage_profile = [self.STORAGE_PROFILE]
         self._config.reserved_percentage = 0
         self._config.vmware_profile_check_on_attach = True
+        self._config.vmware_select_random_best_datastore = False
 
         self._db = mock.Mock()
         self._driver = vmdk.VMwareVcVmdkDriver(configuration=self._config,

--- a/cinder/volume/drivers/vmware/datastore.py
+++ b/cinder/volume/drivers/vmware/datastore.py
@@ -54,11 +54,14 @@ class DatastoreSelector(object):
     PROFILE_NAME = "storageProfileName"
 
     # TODO(vbala) Remove dependency on volumeops.
-    def __init__(self, vops, session, max_objects):
+    def __init__(self, vops, session, max_objects, random_ds=False,
+                 random_ds_range=None):
         self._vops = vops
         self._session = session
         self._max_objects = max_objects
         self._profile_id_cache = {}
+        self._random_ds = random_ds
+        self._random_ds_range = random_ds_range
 
     @coordination.synchronized('vmware-datastore-profile-{profile_name}')
     def get_profile_id(self, profile_name):
@@ -241,6 +244,12 @@ class DatastoreSelector(object):
                     return host_mount.key
 
         sorted_ds_props = sorted(datastores.values(), key=_sort_key)
+        if self._random_ds:
+            LOG.debug('Shuffling best datastore selection.')
+            if self._random_ds_range:
+                sorted_ds_props = sorted_ds_props[:self._random_ds_range]
+            random.shuffle(sorted_ds_props)
+
         for ds_props in sorted_ds_props:
             host_ref = _select_host(ds_props['host'])
             if host_ref:


### PR DESCRIPTION
This patch adds a new config option that allows for randomizing
the selection of datastores at backing creation time.  First the
best datastores are chosen, which are the most connected datatstores
with the most space available.  Then that list of datastores is
randomized for selection.  The first datastore in that random list is
chosen.  This helps the driver not always pick the same datastore
when each datastore reports lots of free space.