### PR TITLE
[SAP] Fix py3 unit tests

### DIFF
--- a/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
@@ -2288,6 +2288,10 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
         tmp_backing = mock.sentinel.tmp_backing
         vops.clone_backing.return_value = tmp_backing
 
+        disk_device = mock.sentinel.disk_device
+        disk_device.capacityInKB = self.VOL_SIZE + 11111111
+        vops._get_disk_device.return_value = disk_device
+
         volume = self._create_volume_obj()
         inv_path = mock.sentinel.inv_path
         self._driver._create_volume_from_template(volume, inv_path)


### PR DESCRIPTION
This patch updates one of the unit tests that fails py3 due to a
change in our version of the vmdk driver.