### PR TITLE
Randomize the selection of best datastores

### DIFF
--- a/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
@@ -105,6 +105,7 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
         self._config.vmware_storage_profile = [self.STORAGE_PROFILE]
         self._config.reserved_percentage = 0
         self._config.vmware_profile_check_on_attach = True
+        self._config.vmware_select_random_best_datastore = False
 
         self._db = mock.Mock()
         self._driver = vmdk.VMwareVcVmdkDriver(configuration=self._config,


### PR DESCRIPTION
This patch adds a new config option that allows for randomizing
the selection of datastores at backing creation time.  First the
best datastores are chosen, which are the most connected datatstores
with the most space available.  Then that list of datastores is
randomized for selection.  The first datastore in that random list is
chosen.  This helps the driver not always pick the same datastore
when each datastore reports lots of free space.

Change-Id: I3992fa1a0cb5f059140685c74f70f8047bbb1480