### PR TITLE
[SAP] Add libpq-dev to concourse_unit_test_task

### DIFF
--- a/concourse_unit_test_task
+++ b/concourse_unit_test_task
@@ -1,9 +1,9 @@
 export DEBIAN_FRONTEND=noninteractive && \
 export UPPER_CONSTRAINTS_FILE=https://raw.githubusercontent.com/sapcc/requirements/stable/train-m3/upper-constraints.txt && \
 apt-get update && \
-apt-get install -y build-essential python-pip python-dev python3-dev git libpcre++-dev gettext && \
+apt-get install -y build-essential python-pip python-dev python3-dev git libpcre++-dev gettext libpq-dev && \
 pip install -U pip && \
 pip install tox "six>=1.14.0" && \
 git clone -b stable/train-m3 --single-branch https://github.com/sapcc/cinder.git --depth=1 && \
 cd cinder && \
-tox -e py27,pep8
+tox -e py27,py3,pep8


### PR DESCRIPTION
This patch updates the running of the concourse unit test task
against train to include the libpq-dev package as well as make
sure we run py3 tox.