### PR TITLE
[SAP] No need for py27 tests in train

### DIFF
--- a/concourse_unit_test_task
+++ b/concourse_unit_test_task
@@ -6,4 +6,4 @@ pip install -U pip && \
 pip install tox "six>=1.14.0" && \
 git clone -b stable/train-m3 --single-branch https://github.com/sapcc/cinder.git --depth=1 && \
 cd cinder && \
-tox -e py27,py3,pep8
+tox -e pep8,py3


### PR DESCRIPTION
Update the concourse_unit_test_task to remove the py27 tests
as train will run on py3.