### PR TITLE
[SAP] fix randomize datastore selection

### DIFF
--- a/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
@@ -106,6 +106,7 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
         self._config.reserved_percentage = 0
         self._config.vmware_profile_check_on_attach = True
         self._config.vmware_select_random_best_datastore = False
+        self._config.vmware_random_datastore_range = False
 
         self._db = mock.Mock()
         self._driver = vmdk.VMwareVcVmdkDriver(configuration=self._config,
@@ -1803,11 +1804,14 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
                 mock_session.pbm_wsdl_loc_set.assert_called_once_with(pbm_wsdl)
             self.assertEqual(enable_pbm, self._driver._storage_policy_enabled)
             register_extension.assert_called_once()
+            cfg = self._driver.configuration
             ds_sel_cls.assert_called_once_with(
                 vops,
                 session,
                 self._driver.configuration.vmware_max_objects_retrieval,
-                ds_regex=ds_regex)
+                ds_regex=ds_regex,
+                random_ds=cfg.vmware_select_random_best_datastore,
+                random_ds_range=cfg.vmware_random_datastore_range)
             self.assertEqual(ds_sel_cls.return_value, self._driver._ds_sel)
             vops.get_cluster_refs.assert_called_once_with(
                 self._driver.configuration.vmware_cluster_name)

--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -2233,8 +2233,13 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         self._register_extension()
 
         max_objects = self.configuration.vmware_max_objects_retrieval
+        random_ds = self.configuration.vmware_select_random_best_datastore
+        random_ds_range = self.configuration.vmware_random_datastore_range
         self._ds_sel = hub.DatastoreSelector(
-            self.volumeops, self.session, max_objects, ds_regex=self._ds_regex)
+            self.volumeops, self.session, max_objects,
+            ds_regex=self._ds_regex,
+            random_ds=random_ds,
+            random_ds_range=random_ds_range)
 
         # Get clusters to be used for backing VM creation.
         cluster_names = self.configuration.vmware_cluster_name


### PR DESCRIPTION
This patch passes in the randomization settings to the datastore
selector object during driver do_setup() time.  Previously
those values were passed ony if the ds object didn't already exist.