### PR TITLE
Set purge_props=False by default in GlanceImageService update

### DIFF
--- a/cinder/image/glance.py
+++ b/cinder/image/glance.py
@@ -346,7 +346,7 @@ class GlanceImageService(object):
         return self._translate_from_glance(context, recv_service_image_meta)
 
     def update(self, context, image_id,
-               image_meta, data=None, purge_props=True):
+               image_meta, data=None, purge_props=False):
         """Modify the given image with the new data."""
         # For v2, _translate_to_glance stores custom properties in image meta
         # directly. We need the custom properties to identify properties to

--- a/cinder/tests/unit/image/test_glance.py
+++ b/cinder/tests/unit/image/test_glance.py
@@ -397,7 +397,8 @@ class TestGlanceImageService(test.TestCase):
         show.return_value = {'properties': {'k2': 'v2'}}
         translate_from_glance.return_value = image_meta.copy()
 
-        ret = service.update(self.context, image_id, image_meta)
+        ret = service.update(self.context, image_id, image_meta,
+                             purge_props=True)
         self.assertDictEqual(image_meta, ret)
         client.call.assert_called_once_with(
             self.context, 'update', image_id, k1='v1', remove_props=['k2'])


### PR DESCRIPTION
The glance service update() method removes by default all the
existing properties and overwrites with the ones passed as parameter.
This is against what calling services expect to [1] and opposite to
how the image service is implemented in nova [2].
Therefore, the expectation is that the update() actually updates the
image properties dict. Purging the image properties that are not
specified in the input parameter should be optional and should be
controlled by the caller when it knows what it's doing.

[1] https://github.com/openstack/oslo.vmware/blob/543ef8ba36295d7079c594adb80d252f9e689d83/oslo_vmware/image_transfer.py#L327
[2] https://github.com/openstack/nova/blob/1516fdd3944dc8bb655664c136bb16715b0c1df2/nova/image/glance.py#L531