### PR TITLE
Fix create from snapshot with larger size

### DIFF
--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -2410,7 +2410,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         disk_type = VMwareVcVmdkDriver._get_disk_type(volume)
         device_changes = None
         if volume['size']:
-            new_size_in_kb = volume['size'] * units.Gi / units.Ki
+            new_size_in_kb = int(volume['size'] * units.Gi / units.Ki)
             disk_device = self.volumeops._get_disk_device(template)
             if new_size_in_kb > disk_device.capacityInKB:
                 device_changes = self.volumeops._create_spec_for_disk_expand(


### PR DESCRIPTION
This patch fixes a problem when creating a volume from snapshot
when the size of the volume is larger than the original snapshot.
The problem was caused by python creating a float value from the
size calculation, and the vmware api not being able to process the
size float.  The value needs to be a whole number/int.