### PR TITLE
[SAP] fix driver init of additional_endpoints

### DIFF
--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -334,7 +334,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         self._clusters = None
         self._dc_cache = {}
         self._ds_regex = None
-        self.additional_endpoints.append([
+        self.additional_endpoints.extend([
             remote_api.VmdkDriverRemoteService(self)
         ])
         self._remote_api = remote_api.VmdkDriverRemoteApi()


### PR DESCRIPTION
This patch fixes a queens -> train driver issue.
The additional_endpoints needs to be extended, not appended.