### PR TITLE
[SAP] Don't upgrade pip to run unit tests

### DIFF
--- a/concourse_unit_test_task
+++ b/concourse_unit_test_task
@@ -2,8 +2,8 @@ export DEBIAN_FRONTEND=noninteractive && \
 export UPPER_CONSTRAINTS_FILE=https://raw.githubusercontent.com/sapcc/requirements/stable/train-m3/upper-constraints.txt && \
 apt-get update && \
 apt-get install -y build-essential python-pip python-dev python3-dev git libpcre++-dev gettext libpq-dev && \
-pip install -U pip && \
-pip install tox "six>=1.14.0" && \
+# pip install -U pip && \
+# pip install tox "six>=1.14.0" && \
 git clone -b stable/train-m3 --single-branch https://github.com/sapcc/cinder.git --depth=1 && \
 cd cinder && \
 tox -e pep8,py3


### PR DESCRIPTION
When I ran this locally on 18.04 all the tests pass.  If pip gets
upgraded, then it can't resolve conflicts.