### PR TITLE
[SAP] Ensure tox is installed for CI unit tests

### DIFF
--- a/concourse_unit_test_task
+++ b/concourse_unit_test_task
@@ -4,6 +4,7 @@ apt-get update && \
 apt-get install -y build-essential python-pip python-dev python3-dev git libpcre++-dev gettext libpq-dev && \
 # pip install -U pip && \
 # pip install tox "six>=1.14.0" && \
+pip install tox && \
 git clone -b stable/train-m3 --single-branch https://github.com/sapcc/cinder.git --depth=1 && \
 cd cinder && \
 tox -e pep8,py3


### PR DESCRIPTION
This patch adds back tox to the CI unit test.