### PR TITLE
[SAP] downgrade the pycodestyle

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -11,7 +11,7 @@ fixtures>=3.0.0 # Apache-2.0/BSD
 mock>=2.0.0 # BSD
 os-api-ref>=1.4.0 # Apache-2.0
 oslotest>=3.2.0 # Apache-2.0
-pycodestyle==2.6.0 # MIT License
+pycodestyle>=2.0.0 # MIT License
 PyMySQL>=0.7.6 # MIT License
 psycopg2>=2.7 # LGPL/ZPL
 SQLAlchemy-Utils>=0.33.11 # BSD License


### PR DESCRIPTION
This patch downgrades the pycodestyle from 2.6.0, which caused
a conflict with flake8.