### PR TITLE
Rename sharding- to resourcepools_enabled tag

### DIFF
--- a/cinder/scheduler/filters/shard_filter.py
+++ b/cinder/scheduler/filters/shard_filter.py
@@ -48,8 +48,8 @@ class ShardFilter(filters.BaseBackendFilter):
     in. This filter filters out any backend that's not configured for the shard
     of a project.
 
-    Alternatively the project may have the "sharding_enabled" tag set, which
-    enables the project for backends in all shards.
+    Alternatively the project may have the "resourcepools_enabled" tag set,
+    which enables the project for backends in all shards.
     """
 
     # project shards do not change within a request
@@ -59,7 +59,7 @@ class ShardFilter(filters.BaseBackendFilter):
     _PROJECT_SHARD_CACHE_RETENTION_TIME = 10 * 60
     _SHARD_PREFIX = 'vc-'
     _CAPABILITY_NAME = 'vcenter-shard'
-    _ALL_SHARDS = "sharding_enabled"
+    _ALL_SHARDS = 'resourcepools_enabled'
 
     def _get_keystone_adapter(self):
         """Return a keystone adapter

--- a/cinder/tests/unit/scheduler/test_shard_filter.py
+++ b/cinder/tests/unit/scheduler/test_shard_filter.py
@@ -136,23 +136,23 @@ class ShardFilterTestCase(BackendFiltersTestCase):
         self.props['scheduler_hints'] = {'vcenter-shard': None}
         self.assertFalse(self.filt_cls.backend_passes(host, self.props))
 
-    def test_sharding_enabled_any_backend_match(self):
-        self.filt_cls._PROJECT_SHARD_CACHE['baz'] = ['sharding_enabled']
+    def test_resourcepools_enabled_any_backend_match(self):
+        self.filt_cls._PROJECT_SHARD_CACHE['baz'] = ['resourcepools_enabled']
         self.props['request_spec']['volume_properties']['project_id'] = 'baz'
         caps = {'vcenter-shard': 'vc-a-0'}
         host = fakes.FakeBackendState('host1', {'capabilities': caps})
         self.assertTrue(self.filt_cls.backend_passes(host, self.props))
 
-    def test_sharding_enabled_and_single_shard_any_backend_match(self):
-        self.filt_cls._PROJECT_SHARD_CACHE['baz'] = ['sharding_enabled',
+    def test_resourcepools_enabled_and_single_shard_any_backend_match(self):
+        self.filt_cls._PROJECT_SHARD_CACHE['baz'] = ['resourcepools_enabled',
                                                      'vc-a-1']
         self.props['request_spec']['volume_properties']['project_id'] = 'baz'
         caps = {'vcenter-shard': 'vc-a-0'}
         host = fakes.FakeBackendState('host1', {'capabilities': caps})
         self.assertTrue(self.filt_cls.backend_passes(host, self.props))
 
-    def test_scheduler_hints_override_sharding_enabled(self):
-        self.filt_cls._PROJECT_SHARD_CACHE['baz'] = ['sharding_enabled']
+    def test_scheduler_hints_override_resourcepools_enabled(self):
+        self.filt_cls._PROJECT_SHARD_CACHE['baz'] = ['resourcepools_enabled']
         self.props['scheduler_hints'] = {'vcenter-shard': 'vc-a-1'}
         self.props['request_spec']['volume_properties']['project_id'] = 'baz'
         caps0 = {'vcenter-shard': 'vc-a-0'}


### PR DESCRIPTION
The customer-facing wording was changed. Reflect this in the
project tag string.

Fixup for bcdd56ae9:
    "[SAP] Handle sharding-enabled in scheduler shard filter"
