### PR TITLE
[SAP] Added admins view all volume_admin_metadata

### DIFF
--- a/cinder/api/api_utils.py
+++ b/cinder/api/api_utils.py
@@ -69,7 +69,7 @@ def remove_invalid_filter_options(context, filters,
 _visible_admin_metadata_keys = ['readonly', 'attached_mode']
 
 
-def add_visible_admin_metadata(volume):
+def add_visible_admin_metadata(volume, all_admin_metadata=False):
     """Add user-visible admin metadata to regular metadata.
 
     Extracts the admin metadata keys that are to be made visible to
@@ -82,16 +82,17 @@ def add_visible_admin_metadata(volume):
         if isinstance(volume['volume_admin_metadata'], dict):
             volume_admin_metadata = volume['volume_admin_metadata']
             for key in volume_admin_metadata:
-                if key in _visible_admin_metadata_keys:
+                if key in _visible_admin_metadata_keys or all_admin_metadata:
                     visible_admin_meta[key] = volume_admin_metadata[key]
         else:
             for item in volume['volume_admin_metadata']:
-                if item['key'] in _visible_admin_metadata_keys:
+                if (item['key'] in _visible_admin_metadata_keys or
+                        all_admin_metadata):
                     visible_admin_meta[item['key']] = item['value']
     # avoid circular ref when volume is a Volume instance
     elif (volume.get('admin_metadata') and
             isinstance(volume.get('admin_metadata'), dict)):
-        for key in _visible_admin_metadata_keys:
+        for key in _visible_admin_metadata_keys or all_admin_metadata:
             if key in volume['admin_metadata'].keys():
                 visible_admin_meta[key] = volume['admin_metadata'][key]
 

--- a/cinder/api/v2/volumes.py
+++ b/cinder/api/v2/volumes.py
@@ -37,6 +37,7 @@ from cinder import group as group_api
 from cinder.i18n import _
 from cinder.image import glance
 from cinder import objects
+from cinder.policies import volume_metadata as metadata_policy
 from cinder import utils
 from cinder import volume as cinder_volume
 from cinder.volume import volume_utils
@@ -65,7 +66,11 @@ class VolumeController(wsgi.Controller):
         vol = self.volume_api.get(context, id, viewable_admin_meta=True)
         req.cache_db_volume(vol)
 
-        api_utils.add_visible_admin_metadata(vol)
+        all_admin_metadata = context.authorize(
+            metadata_policy.GET_ADMIN_METADATA_POLICY, fatal=False)
+
+        api_utils.add_visible_admin_metadata(
+            vol, all_admin_metadata=all_admin_metadata)
 
         return self._view_builder.detail(req, vol)
 
@@ -123,8 +128,12 @@ class VolumeController(wsgi.Controller):
                                           viewable_admin_meta=True,
                                           offset=offset)
 
+        all_admin_metadata = context.authorize(
+            metadata_policy.GET_ADMIN_METADATA_POLICY, fatal=False)
+
         for volume in volumes:
-            api_utils.add_visible_admin_metadata(volume)
+            api_utils.add_visible_admin_metadata(
+                volume, all_admin_metadata=all_admin_metadata)
 
         req.cache_db_volumes(volumes.objects)
 
@@ -310,7 +319,11 @@ class VolumeController(wsgi.Controller):
 
         volume.update(update_dict)
 
-        api_utils.add_visible_admin_metadata(volume)
+        all_admin_metadata = context.authorize(
+            metadata_policy.GET_ADMIN_METADATA_POLICY, fatal=False)
+
+        api_utils.add_visible_admin_metadata(
+            volume, all_admin_metadata=all_admin_metadata)
 
         volume_utils.notify_about_volume_usage(context, volume,
                                                'update.end')

--- a/cinder/api/v3/volumes.py
+++ b/cinder/api/v3/volumes.py
@@ -35,6 +35,7 @@ from cinder import group as group_api
 from cinder.i18n import _
 from cinder.image import glance
 from cinder import objects
+from cinder.policies import volume_metadata as metadata_policy
 from cinder.policies import volumes as policy
 from cinder import utils
 
@@ -135,8 +136,12 @@ class VolumeController(volumes_v2.VolumeController):
             total_count = self.volume_api.calculate_resource_count(
                 context, 'volume', filters)
 
+        all_admin_metadata = context.authorize(
+            metadata_policy.GET_ADMIN_METADATA_POLICY, fatal=False)
+
         for volume in volumes:
-            api_utils.add_visible_admin_metadata(volume)
+            api_utils.add_visible_admin_metadata(
+                volume, all_admin_metadata=all_admin_metadata)
 
         req.cache_db_volumes(volumes.objects)
 

--- a/cinder/policies/volume_metadata.py
+++ b/cinder/policies/volume_metadata.py
@@ -23,6 +23,7 @@ DELETE_POLICY = "volume:delete_volume_metadata"
 UPDATE_POLICY = "volume:update_volume_metadata"
 IMAGE_METADATA_POLICY = "volume_extension:volume_image_metadata"
 UPDATE_ADMIN_METADATA_POLICY = "volume:update_volume_admin_metadata"
+GET_ADMIN_METADATA_POLICY = "volume:get_admin_metadata"
 
 
 BASE_POLICY_NAME = 'volume:volume_metadata:%s'
@@ -116,6 +117,20 @@ volume_metadata_policies = [
                 'method': 'POST',
                 'path': '/volumes/{volume_id}/action (os-attach)'
             }
+        ]),
+    policy.DocumentedRuleDefault(
+        name=GET_ADMIN_METADATA_POLICY,
+        check_str=base.RULE_ADMIN_API,
+        description="get all volume admin metadata.",
+        operations=[
+            {
+                'method': 'GET',
+                'path': '/volumes/detail'
+            },
+            {
+                'method': 'GET',
+                'path': '/volumes/{volume_id}'
+            },
         ]),
 ]
 

--- a/cinder/volume/manager.py
+++ b/cinder/volume/manager.py
@@ -538,13 +538,23 @@ class VolumeManager(manager.CleanableManager,
 
                         try:
                             if volume['status'] in ['in-use']:
-                                self.driver.ensure_export(ctxt, volume)
+                                model_update = self.driver.ensure_export(
+                                    ctxt, volume)
                         except Exception:
                             LOG.exception("Failed to re-export volume, "
                                           "setting to ERROR.",
                                           resource=volume)
                             volume.conditional_update({'status': 'error'},
                                                       {'status': 'in-use'})
+
+                        try:
+                            if model_update:
+                                volume.update(model_update)
+                                volume.save()
+                        except Exception as ex:
+                            LOG.exception("Model update failed.",
+                                          resource=volume)
+
                 # All other cleanups are processed by parent class -
                 # CleanableManager
 


### PR DESCRIPTION
This patch adds the ability for admins to view
volume_admin_metadata when fetching volumes from the API.

This patch ensures that ensure_export at init_host time can
do a model update.

referencing:
https://review.opendev.org/c/openstack/cinder/+/779835

This patch slightly refactors create_export, ensure_export and
initialize_connection to allow saving a model_update back for each
of those calls.

The model update returns some vital information about the volume,
the vcenter uuid, the datastore name, and the vcenter storage profile
associated with that volume.  That information is stored in the
volume_admin_metadata table as key/value pairs that are then returned
(for admin users) when a volume list or show is called from the API.

ensure_export is called for every in-use, available volume at cinder
startup.  So existing volumes will get updated in the db at
cinder startup.

We will then be able to update the host entries later if/when we
migrate to supporting datastores as pools.  Each volume will need
to get updated to change its host entry to include the pool name
(datastore name) as part of the host entry, so cinder knows which
cinder-volume service instance manages that specific volume.