### PR TITLE
Rework backup process to make it async

### DIFF
--- a/cinder/backup/chunkeddriver.py
+++ b/cinder/backup/chunkeddriver.py
@@ -370,10 +370,9 @@ class ChunkedBackupDriver(driver.BackupDriver):
         obj[object_name] = {}
         obj[object_name]['offset'] = data_offset
         obj[object_name]['length'] = len(data)
-        LOG.debug('Backing up chunk of data from volume.')
         algorithm, output_data = self._prepare_output_data(data)
         obj[object_name]['compression'] = algorithm
-        LOG.debug('About to put_object')
+        LOG.debug('About to put_object : %s', obj[object_name])
         with self._get_object_writer(
                 container, object_name, extra_metadata=extra_metadata
         ) as writer:
@@ -587,6 +586,7 @@ class ChunkedBackupDriver(driver.BackupDriver):
                                  win32_disk_size - data_offset)
             else:
                 read_bytes = self.chunk_size_bytes
+            LOG.debug("reading '%s' bytes", read_bytes)
             data = volume_file.read(read_bytes)
 
             if data == b'':

--- a/cinder/backup/manager.py
+++ b/cinder/backup/manager.py
@@ -342,7 +342,6 @@ class BackupManager(manager.ThreadPoolManager):
         snapshot = objects.Snapshot.get_by_id(
             context, snapshot_id) if snapshot_id else None
         previous_status = volume.get('previous_status', None)
-        updates = {}
         if snapshot_id:
             log_message = ('Create backup started, backup: %(backup_id)s '
                            'volume: %(volume_id)s snapshot: %(snapshot_id)s.'
@@ -403,7 +402,12 @@ class BackupManager(manager.ThreadPoolManager):
 
             backup.service = self.driver_name
             backup.save()
-            updates = self._run_backup(context, backup, volume)
+
+            # Backup is done in 3 phases.
+            # _start_backup
+            # continue_backup
+            # _finish_backup
+            self._start_backup(context, backup, volume)
         except Exception as err:
             with excutils.save_and_reraise_exception():
                 if snapshot_id:
@@ -416,41 +420,16 @@ class BackupManager(manager.ThreadPoolManager):
                          'previous_status': 'error_backing-up'})
                 self._update_backup_error(backup, six.text_type(err))
 
-        # Restore the original status.
-        if snapshot_id:
-            self.db.snapshot_update(
-                context, snapshot_id,
-                {'status': fields.SnapshotStatus.AVAILABLE})
-        else:
-            self.db.volume_update(context, volume_id,
-                                  {'status': previous_status,
-                                   'previous_status': 'backing-up'})
+    @utils.trace
+    def _start_backup(self, context, backup, volume):
+        """This starts the backup process.
 
-        # _run_backup method above updated the status for the backup, so it
-        # will reflect latest status, even if it is deleted
-        completion_msg = 'finished'
-        if backup.status in (fields.BackupStatus.DELETING,
-                             fields.BackupStatus.DELETED):
-            completion_msg = 'aborted'
-        else:
-            backup.status = fields.BackupStatus.AVAILABLE
-            backup.size = volume['size']
+           First we have to get the backup device from the volume manager.
+           This can take a long time to complete.  Once the volume manager
+           is done creating/getting the backup device, we get a callback
+           to complete the process of backing up the volume.
 
-            if updates:
-                backup.update(updates)
-            backup.save()
-
-            # Handle the num_dependent_backups of parent backup when child
-            # backup has created successfully.
-            if backup.parent_id:
-                parent_backup = objects.Backup.get_by_id(context,
-                                                         backup.parent_id)
-                parent_backup.num_dependent_backups += 1
-                parent_backup.save()
-        LOG.info('Create backup %s. backup: %s.', completion_msg, backup.id)
-        self._notify_about_backup_usage(context, backup, "create.end")
-
-    def _run_backup(self, context, backup, volume):
+        """
         # Save a copy of the encryption key ID in case the volume is deleted.
         if (volume.encryption_key_id is not None and
                 backup.encryption_key_id is None):
@@ -460,17 +439,36 @@ class BackupManager(manager.ThreadPoolManager):
                 volume.encryption_key_id)
             backup.save()
 
-        backup_service = self.service(context)
+        # This is an async call to the volume manager.  We will get a
+        # callback from the volume manager to continue once it's done.
+        self.volume_rpcapi.get_backup_device(context, backup, volume)
 
+    @utils.trace
+    def continue_backup(self, context, backup, backup_device):
+        """This is the callback from the volume manager to continue.
+
+           If something went wrong on the volume manager getting/creating
+           the backup_device, the backup_device will be None.
+        """
+        volume_id = backup.volume_id
+        volume = objects.Volume.get_by_id(context, volume_id)
+        snapshot_id = backup.snapshot_id
+        snapshot = objects.Snapshot.get_by_id(
+            context, snapshot_id) if snapshot_id else None
+        previous_status = volume.get('previous_status', None)
+
+        backup_service = self.service(context)
         properties = utils.brick_get_connector_properties()
 
-        # NOTE(geguileo): Not all I/O disk operations properly do greenthread
-        # context switching and may end up blocking the greenthread, so we go
-        # with native threads proxy-wrapping the device file object.
+        updates = {}
         try:
-            backup_device = self.volume_rpcapi.get_backup_device(context,
-                                                                 backup,
-                                                                 volume)
+            if not backup_device:
+                # The volume manager didn't provide a backup_device
+                # due to something going wrong.  So we raise here and
+                # cleanup the volume state and the backup state to error.
+                raise exception.BackupOperationError("Failed to get backup "
+                                                     "device from driver.")
+
             attach_info = self._attach_device(context,
                                               backup_device.device_obj,
                                               properties,
@@ -498,12 +496,65 @@ class BackupManager(manager.ThreadPoolManager):
                                     backup_device.device_obj, properties,
                                     backup_device.is_snapshot, force=True,
                                     ignore_errors=True)
+        except Exception as err:
+            with excutils.save_and_reraise_exception():
+                if snapshot_id:
+                    snapshot.status = fields.SnapshotStatus.AVAILABLE
+                    snapshot.save()
+                else:
+                    self.db.volume_update(
+                        context, volume_id,
+                        {'status': previous_status,
+                         'previous_status': 'error_backing-up'})
+                self._update_backup_error(backup, six.text_type(err))
         finally:
             with backup.as_read_deleted():
                 backup.refresh()
             self._cleanup_temp_volumes_snapshots_when_backup_created(
                 context, backup)
-        return updates
+
+        LOG.info("finish backup!")
+        self._finish_backup(context, backup, volume, updates)
+
+    @utils.trace
+    def _finish_backup(self, context, backup, volume, updates):
+        volume_id = backup.volume_id
+        snapshot_id = backup.snapshot_id
+        previous_status = volume.get('previous_status', None)
+
+        # Restore the original status.
+        if snapshot_id:
+            self.db.snapshot_update(
+                context, snapshot_id,
+                {'status': fields.SnapshotStatus.AVAILABLE})
+        else:
+            self.db.volume_update(context, volume_id,
+                                  {'status': previous_status,
+                                   'previous_status': 'backing-up'})
+
+        # continue_backup method above updated the status for the backup, so it
+        # will reflect latest status, even if it is deleted
+        completion_msg = 'finished'
+        if backup.status in (fields.BackupStatus.DELETING,
+                             fields.BackupStatus.DELETED):
+            completion_msg = 'aborted'
+        else:
+            backup.status = fields.BackupStatus.AVAILABLE
+            backup.size = volume['size']
+
+            if updates:
+                backup.update(updates)
+            backup.save()
+
+            # Handle the num_dependent_backups of parent backup when child
+            # backup has created successfully.
+            if backup.parent_id:
+                parent_backup = objects.Backup.get_by_id(context,
+                                                         backup.parent_id)
+                parent_backup.num_dependent_backups += 1
+                parent_backup.save()
+        LOG.info('Create backup %s. backup: %s.', completion_msg, backup.id)
+        self._notify_about_backup_usage(context, backup, "create.end")
 
     def _is_our_backup(self, backup):
         # Accept strings and Service OVO

--- a/cinder/backup/rpcapi.py
+++ b/cinder/backup/rpcapi.py
@@ -46,9 +46,10 @@ class BackupAPI(rpc.RPCAPI):
 
         2.0 - Remove 1.x compatibility
         2.1 - Adds set_log_levels and get_log_levels
+        2.2 - Adds continue_backup call
     """
 
-    RPC_API_VERSION = '2.1'
+    RPC_API_VERSION = '2.2'
     RPC_DEFAULT_VERSION = '2.0'
     TOPIC = constants.BACKUP_TOPIC
     BINARY = 'cinder-backup'
@@ -57,6 +58,12 @@ class BackupAPI(rpc.RPCAPI):
         LOG.debug("create_backup in rpcapi backup_id %s", backup.id)
         cctxt = self._get_cctxt(server=backup.host)
         cctxt.cast(ctxt, 'create_backup', backup=backup)
+
+    def continue_backup(self, ctxt, backup, backup_device):
+        LOG.debug("continue_backup in rpcapi backup_id %s", backup.id)
+        cctxt = self._get_cctxt(server=backup.host)
+        cctxt.cast(ctxt, 'continue_backup', backup=backup,
+                   backup_device=backup_device)
 
     def restore_backup(self, ctxt, volume_host, backup, volume_id):
         LOG.debug("restore_backup in rpcapi backup_id %s", backup.id)

--- a/cinder/volume/manager.py
+++ b/cinder/volume/manager.py
@@ -54,6 +54,7 @@ profiler = importutils.try_import('osprofiler.profiler')
 import six
 from taskflow import exceptions as tfe
 
+from cinder.backup import rpcapi as backup_rpcapi
 from cinder.common import constants
 from cinder import compute
 from cinder import context
@@ -4451,18 +4452,43 @@ class VolumeManager(manager.CleanableManager,
         LOG.debug("Obtained capabilities list: %s.", capabilities)
         return capabilities
 
-    def get_backup_device(self, ctxt, backup, want_objects=False):
-        (backup_device, is_snapshot) = (
-            self.driver.get_backup_device(ctxt, backup))
+    @utils.trace
+    def get_backup_device(self, ctxt, backup, want_objects=False,
+                          async_call=False):
+        try:
+            (backup_device, is_snapshot) = (
+                self.driver.get_backup_device(ctxt, backup))
+        except Exception as ex:
+            if async_call:
+                LOG.exception("Failed to get backup device. "
+                              "Calling backup continue_backup to cleanup")
+                rpcapi = backup_rpcapi.BackupAPI()
+                rpcapi.continue_backup(ctxt, backup, backup_device=None)
+                return
+            else:
+                while excutils.save_and_reraise_exception():
+                    LOG.exception("Failed to get backup device.")
+
         secure_enabled = self.driver.secure_file_operations_enabled()
         backup_device_dict = {'backup_device': backup_device,
                               'secure_enabled': secure_enabled,
                               'is_snapshot': is_snapshot, }
         # TODO(sborkows): from_primitive method will be removed in O, so there
         # is a need to clean here then.
-        return (objects.BackupDeviceInfo.from_primitive(backup_device_dict,
-                                                        ctxt)
-                if want_objects else backup_device_dict)
+        backup_device = (
+            objects.BackupDeviceInfo.from_primitive(backup_device_dict, ctxt)
+            if want_objects else backup_device_dict)
+
+        if async_call:
+            # we have to use an rpc call back to the backup manager to
+            # continue the backup
+            LOG.info("Calling backup continue_backup for: {}".format(backup))
+            rpcapi = backup_rpcapi.BackupAPI()
+            rpcapi.continue_backup(ctxt, backup, backup_device)
+        else:
+            # The rpc api version doesn't support the async callback
+            # so we fallback to returning the value itself.
+            return backup_device
 
     def secure_file_operations_enabled(self, ctxt, volume):
         secure_enabled = self.driver.secure_file_operations_enabled()

--- a/cinder/volume/rpcapi.py
+++ b/cinder/volume/rpcapi.py
@@ -134,9 +134,10 @@ class VolumeAPI(rpc.RPCAPI):
                failover_replication, and list_replication_targets.
         3.15 - Add revert_to_snapshot method
         3.16 - Add no_snapshots to accept_transfer method
+        3.17 - Make get_backup_device a cast (async)
     """
 
-    RPC_API_VERSION = '3.16'
+    RPC_API_VERSION = '3.17'
     RPC_DEFAULT_VERSION = '3.0'
     TOPIC = constants.VOLUME_TOPIC
     BINARY = constants.VOLUME_BINARY
@@ -343,8 +344,13 @@ class VolumeAPI(rpc.RPCAPI):
         return cctxt.call(ctxt, 'get_capabilities', discover=discover)
 
     def get_backup_device(self, ctxt, backup, volume):
-        cctxt = self._get_cctxt(volume.service_topic_queue, ('3.2', '3.0'))
-        if cctxt.can_send_version('3.2'):
+        cctxt = self._get_cctxt(volume.service_topic_queue,
+                                ('3.17', '3.2', '3.0'))
+        if cctxt.can_send_version('3.17'):
+            cctxt.cast(ctxt, 'get_backup_device', backup=backup,
+                       want_objects=True, async_call=True)
+            backup_obj = None
+        elif cctxt.can_send_version('3.2'):
             backup_obj = cctxt.call(ctxt, 'get_backup_device', backup=backup,
                                     want_objects=True)
         else:


### PR DESCRIPTION
This patch updates the backup process to call the volume manager
asynchronously to get the backup device in which to do the backup on.
This fixes a major issue with certain cinder drivers that take a long
time to create a temporary clone of the volume being backed up.