### PR TITLE
[SAP] Force volume create from backup to restoring

### DIFF
--- a/cinder/volume/flows/manager/create_volume.py
+++ b/cinder/volume/flows/manager/create_volume.py
@@ -1057,6 +1057,7 @@ class CreateVolumeFromSpecTask(flow_utils.CinderTask):
                      {'id': backup_id})
             model_update = self._create_raw_volume(
                 context, volume, **kwargs) or {}
+            model_update['status'] = fields.VolumeStatus.RESTORING_BACKUP
             volume.update(model_update)
             volume.save()
 


### PR DESCRIPTION
This patch fixes an issue with calling create volume from backup.
There are 2 ways to create a volume from a backup.
1) calling cinder backup-restore
2) calling cinder create --backup-id

There is a series of issues with using #2 with vmware due to:
A) the volume is put into 'creating' status before calling the
   backup manager to restore the bits to the new raw volume.
B) the vmware driver uses the volume status field to determine if
   it should add required information to be returned in
   initialize_connection() to exist for os-brick to return a
   VmdkWriteHandle vs a VmdkReadHandle.

Both A and B combined results in 100% failure rate for creating a
volume from back up using technique #2.

Changing the volume status to restoring after the raw cinder volume
has been created fixes this issue.