### PR TITLE
Vmware: Create empty backing for live-migration

### DIFF
--- a/cinder/tests/unit/volume/drivers/vmware/test_remote.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_remote.py
@@ -56,7 +56,9 @@ class VmdkDriverRemoteApiTest(test.RPCAPITestCase):
                            rpc_method='call',
                            server=self._fake_host,
                            host=self._fake_host,
-                           volume=self._fake_volume)
+                           volume=self._fake_volume,
+                           create_params=None
+                           )
 
 
 class VmdkDriverRemoteServiceTest(test.TestCase):
@@ -113,4 +115,5 @@ class VmdkDriverRemoteServiceTest(test.TestCase):
 
     def test_create_backing(self):
         self._service.create_backing(self._ctxt, self._fake_volume)
-        self._driver._create_backing.assert_called_once_with(self._fake_volume)
+        self._driver._create_backing.assert_called_once_with(
+            self._fake_volume, create_params=None)

--- a/cinder/volume/drivers/vmware/remote.py
+++ b/cinder/volume/drivers/vmware/remote.py
@@ -50,9 +50,10 @@ class VmdkDriverRemoteApi(rpc.RPCAPI):
         return cctxt.call(ctxt, 'move_volume_backing_to_folder', volume=volume,
                           folder=folder)
 
-    def create_backing(self, ctxt, host, volume):
+    def create_backing(self, ctxt, host, volume, create_params=None):
         cctxt = self._get_cctxt(host)
-        return cctxt.call(ctxt, 'create_backing', volume=volume)
+        return cctxt.call(ctxt, 'create_backing', volume=volume,
+                          create_params=create_params)
 
 
 class VmdkDriverRemoteService(object):
@@ -82,5 +83,6 @@ class VmdkDriverRemoteService(object):
         folder_ref = vim_util.get_moref(folder, 'Folder')
         self._driver.volumeops.move_backing_to_folder(backing, folder_ref)
 
-    def create_backing(self, ctxt, volume):
-        return self._driver._create_backing(volume)
+    def create_backing(self, ctxt, volume, create_params=None):
+        return self._driver._create_backing(volume,
+                                            create_params=create_params)

--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -329,6 +329,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         self._session = None
         self._stats = None
         self._volumeops = None
+        self._vcenter_instance_uuid_cache = None
         self._storage_policy_enabled = False
         self._ds_sel = None
         self._clusters = None
@@ -350,6 +351,14 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
     @property
     def ds_sel(self):
         return self._ds_sel
+
+    @property
+    def _vcenter_instance_uuid(self):
+        if self._vcenter_instance_uuid_cache:
+            return self._vcenter_instance_uuid_cache
+        self._vcenter_instance_uuid_cache = \
+            self.session.vim.service_content.about.instanceUuid
+        return self._vcenter_instance_uuid_cache
 
     def _validate_params(self):
         # Throw error if required parameters are not set.
@@ -383,8 +392,9 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         return self._stats
 
     def _get_connection_capabilities(self):
-        return ['vmware_service_instance_uuid:%s' %
-                self.session.vim.service_content.about.instanceUuid]
+        return [
+            'vmware_service_instance_uuid:%s' %
+            self._vcenter_instance_uuid]
 
     def _get_volume_stats(self):
         backend_name = self.configuration.safe_get('volume_backend_name')
@@ -481,7 +491,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                     break
         location_info = '%(driver_name)s:%(vcenter)s' % {
             'driver_name': LOCATION_DRIVER_NAME,
-            'vcenter': self.session.vim.service_content.about.instanceUuid}
+            'vcenter': self._vcenter_instance_uuid}
 
         data['location_info'] = location_info
         data['total_capacity_gb'] = round(global_capacity / units.Gi)
@@ -747,8 +757,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         return {
             'url': url,
             'ssl_thumbprint': x509.digest("sha1"),
-            'instance_uuid':
-                self.session.vim.service_content.about.instanceUuid,
+            'instance_uuid': self._vcenter_instance_uuid,
             'credential': {
                 'username': self.configuration.vmware_host_username,
                 'password': self.configuration.vmware_host_password
@@ -761,7 +770,8 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
             'volume': backing.value,
             'volume_id': volume.id,
             'name': volume.name,
-            'profile_id': self._get_storage_profile_id(volume)
+            'profile_id': self._get_storage_profile_id(volume),
+            'datastore': self.volumeops.get_datastore(backing).value,
         }
 
         # vmdk connector in os-brick needs additional connection info.
@@ -770,9 +780,6 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
 
             vmdk_path = self.volumeops.get_vmdk_path(backing)
             connection_info['data']['vmdk_path'] = vmdk_path
-
-            datastore = self.volumeops.get_datastore(backing)
-            connection_info['data']['datastore'] = datastore.value
 
             datacenter = self.volumeops.get_dc(backing)
             connection_info['data']['datacenter'] = datacenter.value
@@ -2609,12 +2616,13 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         """
 
         false_ret = (False, None)
-        allowed_statuses = ['available', 'reserved']
+        allowed_statuses = ['available', 'reserved', 'in-use']
         if volume['status'] not in allowed_statuses:
             LOG.debug('Only %s volumes can be migrated using backend '
                       'assisted migration. Falling back to generic migration.',
                       " or ".join(allowed_statuses))
             return false_ret
+
         if 'location_info' not in host['capabilities']:
             LOG.debug('Host capabilities are missing location_info. Falling '
                       'back to generic migration.')
@@ -2645,10 +2653,21 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                      {'volume_name': volume.name, 'dest_host': dest_host})
             return (True, None)
 
-        service_locator = self._remote_api.get_service_locator_info(context,
-                                                                    dest_host)
+        if volume['status'] == 'in-use':
+            if self._vcenter_instance_uuid != vcenter:
+                return self._migrate_attached_cross_vc(context, dest_host,
+                                                       volume, backing)
+            else:
+                raise NotImplementedError()
+        else:
+            return self._migrate_unattached(context, dest_host, volume,
+                                            backing)
+
+    def _migrate_unattached(self, context, dest_host, volume, backing):
         ds_info = self._remote_api.select_ds_for_volume(context, dest_host,
                                                         volume)
+        service_locator = self._remote_api.get_service_locator_info(context,
+                                                                    dest_host)
         host_ref = vim_util.get_moref(ds_info['host'], 'HostSystem')
         rp_ref = vim_util.get_moref(ds_info['resource_pool'], 'ResourcePool')
         ds_ref = vim_util.get_moref(ds_info['datastore'], 'Datastore')
@@ -2658,6 +2677,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         try:
             self._remote_api.move_volume_backing_to_folder(
                 context, dest_host, volume, ds_info['folder'])
+            return (True, None)
         except Exception:
             # At this point the backing has been migrated to the new host.
             # If this movement to folder fails, we let the manager know the
@@ -2670,10 +2690,30 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                            'folder': ds_info['folder']},)
             return (True, {'migration_status': 'error'})
 
-        return (True, None)
+    def _migrate_attached_cross_vc(self, context, dest_host, volume, backing):
+        try:
+            # Create a diskless backing vm, so we can attach the
+            # backing moved in a live migration back to it
+            self._remote_api.create_backing(
+                context, dest_host, volume, create_params={
+                    CREATE_PARAM_DISK_LESS: True
+                })
+            return (True, None)
+        except Exception:
+            # At this point the backing has been "migrated" to the new host.
+            # If this creation fails, return True so it will save the new host,
+            # but we update its status to 'error' so that someone can check
+            # the logs and perform a manual action.
+            LOG.exception("Failed to create the backing %(volume_id)s.",
+                          {'volume_id': volume['id'], }, )
+            return (True, {'migration_status': 'error'})
 
     def update_migrated_volume(self, ctxt, volume, new_volume,
                                original_volume_status):
+        if original_volume_status == 'in-use':
+            # Everything should be taken care in nova
+            return None
+
         backing = self.volumeops.get_backing(new_volume['name'],
                                              new_volume['id'])
         if not backing:


### PR DESCRIPTION
The actual live-migration is happening in nova
But nova needs to know, where to place the volume.
An empty backing vm will be created, and nova takes care of the rest