### PR TITLE
[SAP] WIP call correct host for live migration

### DIFF
--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -761,7 +761,8 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
             'volume': backing.value,
             'volume_id': volume.id,
             'name': volume.name,
-            'profile_id': self._get_storage_profile_id(volume)
+            'profile_id': self._get_storage_profile_id(volume),
+            'volume_host': volume.host
         }
 
         # vmdk connector in os-brick needs additional connection info.

--- a/cinder/volume/rpcapi.py
+++ b/cinder/volume/rpcapi.py
@@ -208,11 +208,13 @@ class VolumeAPI(rpc.RPCAPI):
             msg_args.pop('volume')
         return cctxt.call(ctxt, 'attach_volume', **msg_args)
 
-    def detach_volume(self, ctxt, volume, attachment_id):
+    def detach_volume(self, ctxt, volume, attachment_id, host=None):
         msg_args = {'volume_id': volume.id,
                     'attachment_id': attachment_id,
                     'volume': volume}
-        cctxt = self._get_cctxt(volume.service_topic_queue, ('3.4', '3.0'))
+        if not host:
+            host = volume.service_topic_queue
+        cctxt = self._get_cctxt(host, ('3.4', '3.0'))
         if not self.client.can_send_version('3.4'):
             msg_args.pop('volume')
         return cctxt.call(ctxt, 'detach_volume', **msg_args)


### PR DESCRIPTION
This patch alters the cinder volume api detach call to check the
attachment info of a volume to ensure that the
connection_info['data']['volume_host'] is the same as the
volume.service_topic_queue.  If it's not, then ensure the entry in
the connection_info is the target of the rpc call.