### PR TITLE
Vmware datastores as pools

### DIFF
--- a/cinder/tests/unit/volume/drivers/vmware/test_fcd.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_fcd.py
@@ -66,6 +66,7 @@ class VMwareVStorageObjectDriverTestCase(test.TestCase):
         self._config.vmware_max_objects_retrieval = self.MAX_OBJECTS
         self._config.vmware_storage_profile = None
         self._config.reserved_percentage = 0
+        self._config.vmware_datastores_as_pools = False
         self._driver = fcd.VMwareVStorageObjectDriver(
             configuration=self._config)
         self._driver._vc_version = self.VC_VERSION

--- a/cinder/tests/unit/volume/drivers/vmware/test_remote.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_remote.py
@@ -40,7 +40,7 @@ class VmdkDriverRemoteApiTest(test.RPCAPITestCase):
         self._test_rpc_api('select_ds_for_volume',
                            rpc_method='call',
                            server=self._fake_host,
-                           host=self._fake_host,
+                           cinder_host=self._fake_host,
                            volume=self._fake_volume)
 
     def test_move_backing_to_folder(self):
@@ -91,7 +91,7 @@ class VmdkDriverRemoteServiceTest(test.TestCase):
         ret_val = self._service.select_ds_for_volume(self._ctxt,
                                                      self._fake_volume)
         self._driver._select_ds_for_volume.assert_called_once_with(
-            self._fake_volume)
+            self._fake_volume, cinder_host=None)
         self.assertEqual({
             'host': fake_host.value,
             'resource_pool': fake_rp.value,

--- a/cinder/tests/unit/volume/drivers/vmware/test_vmware_datastore.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_vmware_datastore.py
@@ -301,6 +301,8 @@ class DatastoreTest(test.TestCase):
         self.assertIsNone(self._ds_sel._select_best_datastore({}))
 
     @mock.patch('cinder.volume.drivers.vmware.datastore.DatastoreSelector.'
+                '_is_host_usable')
+    @mock.patch('cinder.volume.drivers.vmware.datastore.DatastoreSelector.'
                 'is_host_in_buildup_cluster')
     @mock.patch('cinder.volume.drivers.vmware.datastore.DatastoreSelector.'
                 'get_profile_id')
@@ -312,7 +314,7 @@ class DatastoreTest(test.TestCase):
                 '_select_best_datastore')
     def test_select_datastore(
             self, select_best_datastore, filter_datastores, get_datastores,
-            get_profile_id, is_buildup):
+            get_profile_id, is_buildup, is_usable):
 
         profile_id = mock.sentinel.profile_id
         get_profile_id.return_value = profile_id
@@ -327,6 +329,7 @@ class DatastoreTest(test.TestCase):
         select_best_datastore.return_value = best_datastore
 
         is_buildup.return_value = False
+        is_usable.return_value = True
 
         size_bytes = 1024
         req = {self._ds_sel.SIZE_BYTES: size_bytes}

--- a/cinder/tests/unit/volume/test_capabilities.py
+++ b/cinder/tests/unit/volume/test_capabilities.py
@@ -199,9 +199,9 @@ class VolumeCapabilitiesTestCase(base.BaseVolumeTestCase):
             self.assertTrue(mock_loads.called)
             volume_stats = manager.last_capabilities
             self.assertEqual(fake_capabilities['key1'],
-                             volume_stats['key1'])
+                             volume_stats["pools"][0]['key1'])
             self.assertEqual(fake_capabilities['key2'],
-                             volume_stats['key2'])
+                             volume_stats["pools"][0]['key2'])
 
     def test_extra_capabilities_fail(self):
         with mock.patch.object(jsonutils, 'loads') as mock_loads:

--- a/cinder/volume/drivers/vmware/remote.py
+++ b/cinder/volume/drivers/vmware/remote.py
@@ -41,9 +41,10 @@ class VmdkDriverRemoteApi(rpc.RPCAPI):
         cctxt = self._get_cctxt(host)
         return cctxt.call(ctxt, 'get_service_locator_info')
 
-    def select_ds_for_volume(self, ctxt, host, volume):
-        cctxt = self._get_cctxt(host)
-        return cctxt.call(ctxt, 'select_ds_for_volume', volume=volume)
+    def select_ds_for_volume(self, ctxt, cinder_host, volume):
+        cctxt = self._get_cctxt(cinder_host)
+        return cctxt.call(ctxt, 'select_ds_for_volume', volume=volume,
+                          cinder_host=cinder_host)
 
     def move_volume_backing_to_folder(self, ctxt, host, volume, folder):
         cctxt = self._get_cctxt(host)
@@ -67,9 +68,15 @@ class VmdkDriverRemoteService(object):
     def get_service_locator_info(self, ctxt):
         return self._driver.service_locator_info
 
-    def select_ds_for_volume(self, ctxt, volume):
+    def select_ds_for_volume(self, ctxt, volume, cinder_host=None):
+        """Select datastore for volume.
+
+        cinder_host is a host@backend_name#pool entry.
+        host is an vmware host, which is returned from the driver call
+        to select_ds_for_volume and returned as part of this call
+        """
         (host, rp, folder, summary) = self._driver._select_ds_for_volume(
-            volume)
+            volume, cinder_host=cinder_host)
 
         profile_id = self._driver._get_storage_profile_id(volume)
 

--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -25,7 +25,6 @@ machine is never powered on and is often referred as the shadow VM.
 import math
 import OpenSSL
 import re
-import six
 import ssl
 
 from oslo_config import cfg
@@ -52,6 +51,7 @@ from cinder.volume.drivers.vmware import exceptions as vmdk_exceptions
 from cinder.volume.drivers.vmware import remote as remote_api
 from cinder.volume.drivers.vmware import volumeops
 from cinder.volume import volume_types
+from cinder.volume import volume_utils
 
 LOG = logging.getLogger(__name__)
 
@@ -137,11 +137,9 @@ vmdk_opts = [
     cfg.MultiStrOpt('vmware_cluster_name',
                     help='Name of a vCenter compute cluster where volumes '
                          'should be created.'),
-    cfg.MultiStrOpt('vmware_storage_profile',
-                    help='Names of storage profiles to be monitored.',
-                    deprecated_for_removal=True,
-                    deprecated_reason='Setting this option results in '
-                                      'significant performance degradation.'),
+    cfg.ListOpt('vmware_storage_profile',
+                default=[],
+                help='Names of storage profiles to be monitored.'),
     cfg.IntOpt('vmware_connection_pool_size',
                default=10,
                help='Maximum number of connections in http connection pool.'),
@@ -192,6 +190,13 @@ vmdk_opts = [
                'datastores, and vmware_random_datastore_range is set to 5 '
                'Then it will filter in 5 datastores prior to randomizing '
                'the datastores to pick from.'),
+    cfg.BoolOpt('vmware_datastores_as_pools',
+                default=False,
+                help='Enable reporting individual datastores as pools. '
+                'This allows the cinder scheduler to pick which datastore '
+                'a volume lives on.  This also enables managing capacity '
+                'for each datastore by cinder.  '
+                )
 ]
 
 CONF = cfg.CONF
@@ -310,7 +315,8 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
     # 3.4.2.99.1 - VMware implementation of volume migration
     # 3.4.2.99.2 - Added soft sharding volume migration, fixed a small issue
     #          in check_for_setup_error where storage_profile not set.
-    VERSION = '3.4.2.99.2'
+    # 3.4.2.99.3 - Add support for reporting each datastore as a pool.
+    VERSION = '3.4.2.99.3'
 
     # ThirdPartySystems wiki page
     CI_WIKI_NAME = "VMware_CI"
@@ -339,6 +345,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
             remote_api.VmdkDriverRemoteService(self)
         ])
         self._remote_api = remote_api.VmdkDriverRemoteApi()
+        self._storage_profiles = []
 
     @staticmethod
     def get_driver_options():
@@ -382,6 +389,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                                   % storage_profile)
                         raise exception.InvalidInput(reason=reason)
 
+    @utils.trace
     def get_volume_stats(self, refresh=False):
         """Obtain status of the volume service.
 
@@ -396,56 +404,16 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
             'vmware_service_instance_uuid:%s' %
             self._vcenter_instance_uuid]
 
-    def _get_volume_stats(self):
-        backend_name = self.configuration.safe_get('volume_backend_name')
-        if not backend_name:
-            backend_name = self.__class__.__name__
+    def _collect_backend_stats(self):
+        """Build the call and return the results for stats."""
 
-        max_over_subscription_ratio = self.configuration.safe_get(
-            'max_over_subscription_ratio')
-        data = {'volume_backend_name': backend_name,
-                'vendor_name': 'VMware',
-                'driver_version': self.VERSION,
-                'storage_protocol': 'vmdk',
-                'reserved_percentage': self.configuration.reserved_percentage,
-                'total_capacity_gb': 'unknown',
-                'free_capacity_gb': 'unknown',
-                'thin_provisioning_support': True,
-                'thick_provisioning_support': True,
-                'max_over_subscription_ratio': max_over_subscription_ratio,
-                'connection_capabilities': self._get_connection_capabilities()}
         client_factory = self.session.vim.client.factory
         object_specs = []
-        if (self._storage_policy_enabled and
-                self.configuration.vmware_storage_profile):
-            # Get all available storage profiles on the vCenter and extract
-            # the IDs of those that we want to observe
-            profiles_ids = []
-            for profile in pbm.get_all_profiles(self.session):
-                if profile.name in self.configuration.vmware_storage_profile:
-                    profiles_ids.append(profile.profileId)
+        result = []
+        if (self._storage_policy_enabled and self._storage_profiles):
             # Get all matching Datastores for each profile
-            datastores = {}
-            for profile_id in profiles_ids:
-                for h in pbm.filter_hubs_by_profile(self.session,
-                                                    None,
-                                                    profile_id):
-                    if h.hubType != "Datastore":
-                        # We are not interested in Datastore Clusters for now
-                        continue
-                    if h.hubId not in datastores:
-                        # Reconstruct a managed object reference to that
-                        # datastore
-                        datastores[h.hubId] = vim_util.get_moref(h.hubId,
-                                                                 "Datastore")
-            # Build property collector object specs out of them
-            for datastore_ref in six.itervalues(datastores):
-                object_specs.append(
-                    vim_util.build_object_spec(
-                        client_factory,
-                        datastore_ref,
-                        []))
-
+            LOG.debug("Storage Profile = '%s'", self._storage_profiles)
+            datastores = self._get_datastores_for_profiles()
             if not datastores:
                 LOG.warning("No Datastores found for storage profile(s) "
                             "''%s'",
@@ -453,6 +421,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                                 self.configuration.safe_get(
                                     'vmware_storage_profile')))
 
+            return None, datastores
         else:
             # Build a catch-all object spec that would reach all datastores
             object_specs.append(
@@ -461,8 +430,6 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                     self.session.vim.service_content.rootFolder,
                     [vim_util.build_recursive_traversal_spec(client_factory)]))
 
-        global_capacity = 0
-        global_free = 0
         # If there are no datastores, then object specs are empty
         # we can't query vcenter with empty object specs, or we'll
         # get errors.
@@ -478,19 +445,86 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                 self.session.vim.service_content.propertyCollector,
                 specSet=[filter_spec],
                 options=options)
+
+        return (result, {})
+
+    def _get_volume_stats(self):
+        backend_name = self.configuration.safe_get('volume_backend_name')
+        if not backend_name:
+            backend_name = self.__class__.__name__
+
+        location_info = '%(driver_name)s:%(vcenter)s' % {
+            'driver_name': LOCATION_DRIVER_NAME,
+            'vcenter': self.session.vim.service_content.about.instanceUuid}
+        reserved_percentage = self.configuration.reserved_percentage
+        max_over_subscription_ratio = self.configuration.safe_get(
+            'max_over_subscription_ratio')
+
+        data = {'volume_backend_name': backend_name,
+                'vendor_name': 'VMware',
+                'driver_version': self.VERSION,
+                'storage_protocol': 'vmdk',
+                'location_info': location_info,
+                }
+
+        result, datastores = self._collect_backend_stats()
+        if self.configuration.vmware_datastores_as_pools:
+            pools = []
+            for ds_name in datastores:
+                datastore = datastores[ds_name]
+                summary = datastore["summary"]
+                pool_state = "up" if summary.accessible is True else "down"
+                pool = {'pool_name': summary.name,
+                        'total_capacity_gb': round(
+                            summary.capacity / units.Gi),
+                        'free_capacity_gb': round(
+                            summary.freeSpace / units.Gi),
+                        'thin_provisioning_support': True,
+                        'max_over_subscription_ratio': (
+                            max_over_subscription_ratio),
+                        'reserved_percentage': reserved_percentage,
+                        'Multiattach': False,
+                        'datastore_type': summary.type,
+                        'location_url': summary.url,
+                        'location_info': location_info,
+                        'backend_state': pool_state,
+                        'storage_profile': datastore["storage_profile"],
+                        'connection_capabilities': (
+                            self._get_connection_capabilities(),)
+                        }
+                pools.append(pool)
+            data['pools'] = pools
+            return data
+
+        if (self._storage_policy_enabled and self._storage_profiles):
+            global_capacity = global_free = 0
+            # Pools are disabled, but storage profiles are enabled.
+            # so we collect all the stats from all the datastores returned
+            for ds_name in datastores:
+                datastore = datastores[ds_name]
+                summary = datastore["summary"]
+                global_capacity += summary.capacity
+                global_free += summary.freeSpace
+
+        else:
+            global_capacity = global_free = 0
             with vim_util.WithRetrieval(self.session.vim, result) as objects:
                 for ds in objects:
                     summary = ds.propSet[0].val
                     global_capacity += summary.capacity
                     global_free += summary.freeSpace
 
-        location_info = '%(driver_name)s:%(vcenter)s' % {
-            'driver_name': LOCATION_DRIVER_NAME,
-            'vcenter': self._vcenter_instance_uuid}
+        data_no_pools = {
+            'reserved_percentage': self.configuration.reserved_percentage,
+            'total_capacity_gb': round(global_capacity / units.Gi),
+            'free_capacity_gb': round(global_free / units.Gi),
+            'thin_provisioning_support': True,
+            'thick_provisioning_support': True,
+            'max_over_subscription_ratio': max_over_subscription_ratio,
+            'connection_capabilities': self._get_connection_capabilities(),
+        }
+        data.update(data_no_pools)
 
-        data['location_info'] = location_info
-        data['total_capacity_gb'] = round(global_capacity / units.Gi)
-        data['free_capacity_gb'] = round(global_free / units.Gi)
         return data
 
     def _verify_volume_creation(self, volume):
@@ -617,6 +651,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         return {EXTRA_CONFIG_VOLUME_ID_KEY: volume['id'],
                 volumeops.BACKING_UUID_KEY: volume['id']}
 
+    @utils.trace
     def _create_backing(self, volume, host=None, create_params=None):
         """Create volume backing under the given host.
 
@@ -628,9 +663,11 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                               backing VM creation
         :return: Reference to the created backing
         """
-        create_params = create_params or {}
+
         (host_ref, resource_pool, folder,
-         summary) = self._select_ds_for_volume(volume, host)
+            summary) = self._select_ds_for_volume(volume, host)
+
+        create_params = create_params or {}
 
         # check if a storage profile needs to be associated with the backing VM
         profile_id = self._get_storage_profile_id(volume)
@@ -675,6 +712,17 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                                                 extra_config=extra_config)
 
         self.volumeops.update_backing_disk_uuid(backing, volume['id'])
+        if (self.configuration.vmware_datastores_as_pools and
+                self._is_pool_outdated_for_volume(volume)):
+            # TODO(walt) - this writes the volume update to the db. :(
+            # This sucks, but don't have any other way
+            new_host = self._new_host_for_volume(volume)
+            LOG.info("Changing volume host from {} to {}".format(
+                volume.host, new_host
+            ))
+            model_update = {'host': new_host}
+            volume.update(model_update)
+            volume.save()
         return backing
 
     def _get_hosts(self, clusters):
@@ -714,25 +762,108 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
             self._dc_cache[resource_pool.value] = dc
         return dc
 
-    def _select_ds_for_volume(self, volume, host=None, create_params=None):
+    @utils.trace
+    def _select_ds_by_name_for_volume(self, datastore_name, volume):
+
+        # we need a host_ref, resource_pool, folder and summary
+        (host_ref,
+         resource_pool,
+         summary) = self.ds_sel.select_datastore_by_name(datastore_name)
+
+        if not summary:
+            # couldn't find the datastore by name
+            return (None, None, None, None)
+
+        # Get the host_ref
+        dc = self._get_dc(resource_pool)
+        folder = self._get_volume_group_folder(dc, volume['project_id'])
+
+        return (host_ref, resource_pool, folder, summary)
+
+    @utils.trace
+    def _is_pool_outdated_for_volume(self, volume):
+        """When datastores as pools is enabled.
+
+        This check determines if the pool name is the same as the
+        volume_backend_name when vmware_datastores_as_pools is enabled.
+
+        This can happen when lazy create is enabled, vmware_datastores_as_pools
+        is disabled and a volume is created.  There will be no backing for
+        the volume.  Then you enable vmware_datastores_as_pools and the driver
+        tries to automatically update the host entry for the volume.  Since
+        the volume has no backing, there is no datastore chosen for the
+        volume, and then the host will still remain as
+        service@backend_name#backend_name instead of
+        service@backend_name#pool
+
+        We have to ensure that if we do create the backing finally for
+        this volume, that we force a cinder db update for the host.
+        """
+
+        host_entry = volume_utils.extract_host(volume['host'], 'backend')
+        backend_name = host_entry.split('@')[1]
+        datastore_name = volume_utils.extract_host(volume['host'], 'pool')
+        if self.configuration.vmware_datastores_as_pools:
+            return backend_name == datastore_name
+        else:
+            return False
+
+    @utils.trace
+    def _select_ds_for_volume(self, volume, host=None, create_params=None,
+                              cinder_host=None):
         """Select datastore that can accommodate the given volume's backing.
+
+        host is a vmware esxi host
+        cinder_host is a service@backend_name#pool
 
         Returns the selected datastore summary along with a compute host and
         its resource pool and folder where the volume can be created
         :return: (host, resource_pool, folder, summary)
         """
-        # Form requirements for datastore selection.
-        create_params = create_params or {}
-        size = create_params.get(CREATE_PARAM_DISK_SIZE, volume['size'])
+        datastore_picked = False
+        if self.configuration.vmware_datastores_as_pools:
+            # we pick the datastore from the pool name
+            if not cinder_host:
+                cinder_host = volume['host']
 
-        req = {}
-        req[hub.DatastoreSelector.SIZE_BYTES] = size * units.Gi
-        req[hub.DatastoreSelector.PROFILE_NAME] = self._get_storage_profile(
-            volume)
+            host_entry = volume_utils.extract_host(cinder_host, 'backend')
+            host_parts = host_entry.split('@')
+            datastore_name = volume_utils.extract_host(cinder_host, 'pool')
+            # we might be a volume that has no backing yet that couldn't
+            # have had their host entry updated due to lazy create.
+            # IF so the backend name and pool name are the same, so a
+            # datastore wasn't picked for this volume.
+            if datastore_name != host_parts[1]:
+                (host_ref, resource_pool,
+                    folder, summary) = self._select_ds_by_name_for_volume(
+                        datastore_name, volume)
+                if summary:
+                    # we were able to use the datastore from the host entry
+                    # so don't use fallback.
+                    datastore_picked = True
+                else:
+                    raise exception.InvalidInput(
+                        "Couldn't find datastore with name '%s'" %
+                        datastore_name)
+            else:
+                LOG.info("Volume backend name and pool name are same.  Using "
+                         "Fallback mechanism to pick a datastore.")
 
-        (host_ref, resource_pool, summary) = self._select_datastore(req, host)
-        dc = self._get_dc(resource_pool)
-        folder = self._get_volume_group_folder(dc, volume['project_id'])
+        if not datastore_picked:
+            # Form requirements for datastore selection.
+            create_params = create_params or {}
+            size = create_params.get(CREATE_PARAM_DISK_SIZE, volume['size'])
+
+            req = {}
+            req[hub.DatastoreSelector.SIZE_BYTES] = size * units.Gi
+            req[hub.DatastoreSelector.PROFILE_NAME] = (
+                self._get_storage_profile(volume)
+            )
+
+            (host_ref, resource_pool, summary) = self._select_datastore(req,
+                                                                        host)
+            dc = self._get_dc(resource_pool)
+            folder = self._get_volume_group_folder(dc, volume['project_id'])
 
         return (host_ref, resource_pool, folder, summary)
 
@@ -2236,9 +2367,165 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
 
         self.volumeops.build_backing_ref_cache()
 
+        # Cache the storage profiles, so we don't
+        # have to fetch them every time.
+        if self.configuration.vmware_storage_profile:
+            self._get_storage_profiles()
+
         LOG.info("Successfully setup driver: %(driver)s for server: "
                  "%(ip)s.", {'driver': self.__class__.__name__,
                              'ip': self.configuration.vmware_host_ip})
+
+    def _get_storage_profiles(self):
+        """Fetch the list of configured storage profiles we use."""
+
+        LOG.debug("Profiles = '%s'", self.configuration.vmware_storage_profile)
+        for profile in pbm.get_all_profiles(self.session):
+            if profile.name in self.configuration.vmware_storage_profile:
+                profile_dict = {"name": profile.name,
+                                "id": profile.profileId}
+                self._storage_profiles.append(profile_dict)
+
+    def _volume_provider_metadata(self, volume, backing=None):
+        if not backing:
+            backing = self.volumeops.get_backing(volume.name, volume.id)
+
+        ds = self.volumeops.get_datastore(backing)
+        summary = self.volumeops.get_summary(ds)
+        profile = self._get_storage_profile(volume)
+        vcenter_uuid = (
+            self.session.vim.service_content.about.instanceUuid
+        )
+        provider_info = {
+            'vmware_vcenter_id': vcenter_uuid,
+            'vmware_ds_name': summary.name,
+            'vmware_profile_name': profile,
+        }
+
+        return provider_info
+
+    @utils.trace
+    def _get_datastores_for_profiles(self):
+        datastores = {}
+        for profile in self._storage_profiles:
+            for h in pbm.filter_hubs_by_profile(self.session,
+                                                None,
+                                                profile['id']):
+                if h.hubType != "Datastore":
+                    # We are not interested in Datastore Clusters for now
+                    continue
+                if h.hubId not in datastores:
+                    # Reconstruct a managed object reference to that
+                    # datastore
+                    ds = vim_util.get_moref(h.hubId, "Datastore")
+                    summary = self.volumeops.get_summary(ds)
+                    datastores[summary.name] = {'summary': summary,
+                                                'storage_profile': profile}
+
+        return datastores
+
+    def _new_host_for_volume(self, volume):
+        pool_info = volume_utils.extract_host(
+            volume.host, level='pool', default_pool_name=True)
+        model = self._volume_provider_metadata(volume)
+        if pool_info != model['vmware_ds_name']:
+            host = volume_utils.extract_host(
+                volume.host, level='host')
+            back = volume_utils.extract_host(volume.host)
+            backend = back.split('@')[1]
+
+            new_host = '{}@{}#{}'.format(
+                host, backend,
+                model['vmware_ds_name']
+            )
+            return new_host
+
+    @utils.trace
+    def update_provider_info(self, volumes, snapshots):
+        """Ensure we have a provider_id set on volumes.
+
+        If there is a provider_id already set then skip, if it is missing then
+        we will update it based on the volume object. We can always compute
+        the id if we have the full volume object, but not all driver API's
+        give us that info.
+
+        We have to save each volume entry if they update their host, otherwise
+        cinder volume manager doesn't see that volume as part of the host
+        allocated_capacity calculation, which happens right after this call
+        completes.
+
+        We don't care about snapshots, they just use the volume's provider_id.
+        """
+        LOG.info("HOST {} : volumes {}".format(self.host, len(volumes)))
+        if self.configuration.vmware_datastores_as_pools:
+            LOG.info("vmware_datastores_as_pools is enabled. "
+                     "Checking host entries for volumes and snapshots.")
+            datastores = self._get_datastores_for_profiles()
+            ds_keys = datastores.keys()
+            vol_updates = []
+            LOG.info("Process {} volumes".format(len(volumes)))
+            for vol in volumes:
+                # make sure we have the correc host info
+                if vol['status'] in ['in-use', 'available']:
+                    # do we need to update the host?
+                    pool_info = volume_utils.extract_host(
+                        vol.host, level='pool', default_pool_name=True)
+
+                    # IF the pool has already been set correctly, then
+                    # no need to make api calls to vcenter to fetch the
+                    # datastore name from the volume backing information.
+                    # this will save time on every startup
+                    if (pool_info not in ds_keys or
+                            pool_info == volume_utils.DEFAULT_POOL_NAME):
+                        LOG.debug("Updating host for volume {}".format(vol.id))
+
+                        try:
+                            new_host = self._new_host_for_volume(vol)
+                            if new_host:
+                                vol.update({'host': new_host})
+                                vol.save()
+                        except Exception as ex:
+                            LOG.warning("Couldn't update host for {} because "
+                                        " {}".format(vol.id, ex))
+                    else:
+                        LOG.debug("Keeping host for volume {}".format(vol.id))
+
+            LOG.info("HOST COMPLETE {}".format(self.host))
+            return vol_updates, None
+        else:
+            # Since pools are not enabled, we should ensure that the datastore
+            # isn't part of the host.  This allows us to go backwards to
+            # not using datastores as pools.
+            LOG.info("vmware_datastores_as_pools is disabled.")
+
+            vol_updates = []
+            for vol in volumes:
+                # make sure we have the correc host info
+                if vol['status'] in ['in-use', 'available']:
+                    # do we need to update the host?
+                    pool_info = volume_utils.extract_host(
+                        vol.host, level='pool')
+                    backend_info = volume_utils.extract_host(
+                        vol.host, level='backend'
+                    )
+                    backend = backend_info.split("@")
+                    LOG.info("Volume host '{}' backend '{}'  pool '{}'".format(
+                        vol.host, backend[1], pool_info))
+
+                    # we need to force the host back to
+                    # host@backend#backend
+                    new_host = "{}@{}#{}".format(
+                        backend[0],
+                        backend[1],
+                        backend[1]
+                    )
+                    if new_host != vol.host:
+                        LOG.info("Setting host to {}".format(new_host))
+                        vol.update({'host': new_host})
+                        vol.save()
+
+            LOG.info("HOST COMPLETE {}".format(self.host))
+            return vol_updates, None
 
     def _get_volume_group_folder(self, datacenter, project_id, snapshot=False):
         """Get inventory folder for organizing volume backings and snapshots.
@@ -2364,9 +2651,11 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         host = None
         rp = None
         folder = None
-        if clone_type != volumeops.LINKED_CLONE_TYPE:
-            # Pick a datastore where to create the full clone under any host
-            (host, rp, folder, summary) = self._select_ds_for_volume(volume)
+        if not clone_type == volumeops.LINKED_CLONE_TYPE:
+            # Pick a datastore where to create the full clone under
+            # any host
+            (host, rp, folder, summary) = self._select_ds_for_volume(
+                volume)
             datastore = summary.datastore
         extra_config = self._get_extra_config(volume)
         clone = self.volumeops.clone_backing(volume['name'], backing,
@@ -2396,6 +2685,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                                  VMwareVcVmdkDriver._get_disk_type(volume))
         LOG.info("Successfully created clone: %s.", clone)
 
+    @utils.trace
     def _create_volume_from_template(self, volume, path):
         LOG.debug("Creating backing for volume: %(volume_id)s from template "
                   "at path: %(path)s.",
@@ -2405,6 +2695,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
 
         # Create temporary backing by cloning the template.
         tmp_name = uuidutils.generate_uuid()
+
         (host, rp, folder, summary) = self._select_ds_for_volume(volume)
         datastore = summary.datastore
         disk_type = VMwareVcVmdkDriver._get_disk_type(volume)
@@ -2604,6 +2895,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         else:
             self.volumeops.revert_to_snapshot(backing, snapshot.name)
 
+    @utils.trace
     def migrate_volume(self, context, volume, host):
         """Migrate a volume to the specified host.
 
@@ -2659,8 +2951,9 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                                             backing)
 
     def _migrate_unattached(self, context, dest_host, volume, backing):
-        ds_info = self._remote_api.select_ds_for_volume(context, dest_host,
-                                                        volume)
+        ds_info = self._remote_api.select_ds_for_volume(context,
+                                                        cinder_host=dest_host,
+                                                        volume=volume)
         service_locator = self._remote_api.get_service_locator_info(context,
                                                                     dest_host)
         host_ref = vim_util.get_moref(ds_info['host'], 'HostSystem')

--- a/cinder/volume/manager.py
+++ b/cinder/volume/manager.py
@@ -2566,6 +2566,11 @@ class VolumeManager(manager.CleanableManager,
             volume_stats = self.driver.get_volume_stats(refresh=True)
             if self.extra_capabilities:
                 volume_stats.update(self.extra_capabilities)
+                if "pools" in volume_stats:
+                    for pool in volume_stats["pools"]:
+                        pool.update(self.extra_capabilities)
+                else:
+                    volume_stats.update(self.extra_capabilities)
             if volume_stats:
 
                 # NOTE(xyang): If driver reports replication_status to be


### PR DESCRIPTION
This adds the ability to expose datastores as pools.  This patchset also supports enabling and disabling pools.  The host entries for all backing created volumes will get updated when pools is enabled or disabled.

TODO:
I will rebase this set into a single commit prior to merging.

In order to support switching from non-pools to pools seamlessly, I had to find a mechanism to automatically the host entries for every volume to include the correct datastore that the backing lives on.   Not all volumes have a backing, since our deployment includes the setting for lazy backing creation.  This means a volume's backing isn't created at create_volume() time, but during any portion of the volume's lifecycle needs to write data to it (clone, create image from volume, attach, etc.)

Major modifications:

- update_provider_info - This method is called at volume manager startup to allow the driver to go through all volumes to update the provider_info attribute of the volume.  I used this mechanism to update the host entry for every volume associated with that backend.  Each volume that needs to update it's host entry, will have a write to the DB.   Cinder driver's aren't supposed to write to the DB, but there is no other way to do this when we have to allow switching from no pools support to pools and back.   This also ensures that the volume manger gets an accurate count of the allocated space used by the host or host/pool.  For volumes that don't have backing yet, looking for the datastore will fail, so those volumes don't get update hosts yet.  This is taken care of later when the backing is created.  provisioning requests will still get to the correct driver instance.
- _create_backing() - This function was modified to update the host entry for the volume before it returns.  This is due to the lazy create problem.  Volumes created when pools was disabled, that have no backing yet, have an incorrect host entry after the backing is created.  When the backing is created, we know what datastore it now lives on, so the host entry has to be updated.
- _select_ds_for_volume() - this method is the central place where datastores are chosen during backing create calls.  This function was altered to account for the datastore (service@backend_name#pool) already being chosen by the scheduler (when vmware_datastores_as_pools is enabled in config).   This function also had to account for the lazy create problem where there is no backing yet for a volume and the host entry doesn't yet have a datastore (vmware_datatsores_as_pools wasn't enabled when this volume was created).  In this case the old mechanism for picking a datastore is chosen by the driver itself.  