### PR TITLE
VmWare: Relocate with Storage IO Profile

### DIFF
--- a/cinder/tests/unit/volume/drivers/vmware/test_remote.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_remote.py
@@ -80,9 +80,12 @@ class VmdkDriverRemoteServiceTest(test.TestCase):
         fake_rp = mock.Mock(value='fake-rp')
         fake_folder = mock.Mock(value='fake-folder')
         fake_summary = mock.Mock(datastore=mock.Mock(vlaue='fake-ds'))
+        fake_profile_id = 'fake-uuid'
 
         self._driver._select_ds_for_volume.return_value = \
             (fake_host, fake_rp, fake_folder, fake_summary)
+        self._driver._get_storage_profile_id.return_value = \
+            fake_profile_id
         ret_val = self._service.select_ds_for_volume(self._ctxt,
                                                      self._fake_volume)
         self._driver._select_ds_for_volume.assert_called_once_with(
@@ -91,7 +94,8 @@ class VmdkDriverRemoteServiceTest(test.TestCase):
             'host': fake_host.value,
             'resource_pool': fake_rp.value,
             'folder': fake_folder.value,
-            'datastore': fake_summary.datastore.value
+            'profile_id': fake_profile_id,
+            'datastore': fake_summary.datastore.value,
         }, ret_val)
 
     @mock.patch('oslo_vmware.vim_util.get_moref')

--- a/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
@@ -3461,7 +3461,9 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
             'capabilities': capabilities
         }
         ds_info = {'host': 'fake-ds-host', 'resource_pool': 'fake-rp',
-                   'datastore': 'fake-ds-name', 'folder': 'fake-folder'}
+                   'datastore': 'fake-ds-name', 'folder': 'fake-folder',
+                   'profile_id': 'fake-profile-id',
+                   }
         get_moref.side_effect = [
             mock.sentinel.host_ref,
             mock.sentinel.rp_ref,
@@ -3509,7 +3511,8 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
 
             vops.relocate_backing.assert_called_once_with(
                 backing, mock.sentinel.ds_ref, mock.sentinel.rp_ref,
-                mock.sentinel.host_ref, service=mock.sentinel.service_locator)
+                mock.sentinel.host_ref, profile_id='fake-profile-id',
+                service=mock.sentinel.service_locator)
 
             r_api.move_volume_backing_to_folder.assert_called_once_with(
                 mock.sentinel.context, dest_host, volume, ds_info['folder'])

--- a/cinder/tests/unit/volume/drivers/vmware/test_vmware_volumeops.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_vmware_volumeops.py
@@ -854,6 +854,7 @@ class VolumeOpsTestCase(test.TestCase):
         get_relocate_spec.assert_called_once_with(datastore, resource_pool,
                                                   host, disk_move_type,
                                                   disk_type, disk_device,
+                                                  profile_id=None,
                                                   service=None)
         self.session.invoke_api.assert_called_once_with(self.session.vim,
                                                         'RelocateVM_Task',

--- a/cinder/volume/drivers/vmware/remote.py
+++ b/cinder/volume/drivers/vmware/remote.py
@@ -69,11 +69,15 @@ class VmdkDriverRemoteService(object):
     def select_ds_for_volume(self, ctxt, volume):
         (host, rp, folder, summary) = self._driver._select_ds_for_volume(
             volume)
+
+        profile_id = self._driver._get_storage_profile_id(volume)
+
         return {
             'host': host.value,
             'resource_pool': rp.value,
             'folder': folder.value,
-            'datastore': summary.datastore.value
+            'datastore': summary.datastore.value,
+            'profile_id': profile_id,
         }
 
     def move_volume_backing_to_folder(self, ctxt, volume, folder):

--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -2654,6 +2654,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         ds_ref = vim_util.get_moref(ds_info['datastore'], 'Datastore')
 
         self.volumeops.relocate_backing(backing, ds_ref, rp_ref, host_ref,
+                                        profile_id=ds_info.get('profile_id'),
                                         service=service_locator)
         try:
             self._remote_api.move_volume_backing_to_folder(

--- a/cinder/volume/drivers/vmware/volumeops.py
+++ b/cinder/volume/drivers/vmware/volumeops.py
@@ -1004,19 +1004,26 @@ class VMwareVolumeOps(object):
                                         'summary')
 
     def _create_relocate_spec_disk_locator(self, datastore, disk_type,
-                                           disk_device):
+                                           disk_device, profile_id=None):
         """Creates spec for disk type conversion during relocate."""
         cf = self._session.vim.client.factory
         disk_locator = cf.create("ns0:VirtualMachineRelocateSpecDiskLocator")
         disk_locator.datastore = datastore
         disk_locator.diskId = disk_device.key
-        disk_locator.diskBackingInfo = self._create_disk_backing(disk_type,
-                                                                 None)
+
+        if disk_type:
+            disk_locator.diskBackingInfo = self._create_disk_backing(disk_type,
+                                                                     None)
+        if profile_id:
+            profile_spec = cf.create("ns0:VirtualMachineDefinedProfileSpec")
+            profile_spec.profileId = profile_id
+            disk_locator.profile = [profile_spec]
+
         return disk_locator
 
     def _get_relocate_spec(self, datastore, resource_pool, host,
                            disk_move_type, disk_type=None, disk_device=None,
-                           service=None):
+                           profile_id=None, service=None):
         """Return spec for relocating volume backing.
 
         :param datastore: Reference to the datastore
@@ -1025,6 +1032,8 @@ class VMwareVolumeOps(object):
         :param disk_move_type: Disk move type option
         :param disk_type: Destination disk type
         :param disk_device: Virtual device corresponding to the disk
+        :param profile_id: ID of the profile to use (Cross vCenter Vmotion)
+        :param service: Service Locator (Cross vCenter Vmotion)
         :return: Spec for relocation
         """
         cf = self._session.vim.client.factory
@@ -1034,10 +1043,14 @@ class VMwareVolumeOps(object):
         relocate_spec.host = host
         relocate_spec.diskMoveType = disk_move_type
 
-        if disk_type is not None and disk_device is not None:
+        # Either we want to convert the disk by specifing the disk_type
+        # or we need to determine the profile-id in the disk-locator
+        if not (disk_type is None and profile_id is None) \
+                and disk_device is not None:
             disk_locator = self._create_relocate_spec_disk_locator(datastore,
                                                                    disk_type,
-                                                                   disk_device)
+                                                                   disk_device,
+                                                                   profile_id)
             relocate_spec.disk = [disk_locator]
 
         if service is not None:
@@ -1062,7 +1075,7 @@ class VMwareVolumeOps(object):
 
     def relocate_backing(
             self, backing, datastore, resource_pool, host, disk_type=None,
-            service=None):
+            profile_id=None, service=None):
         """Relocates backing to the input datastore and resource pool.
 
         The implementation uses moveAllDiskBackingsAndAllowSharing disk move
@@ -1073,6 +1086,7 @@ class VMwareVolumeOps(object):
         :param resource_pool: Reference to the resource pool
         :param host: Reference to the host
         :param disk_type: destination disk type
+        :param profile_id: Id of the profile (for cross vCenter)
         :param service: destination service (for cross vCenter)
         """
         LOG.debug("Relocating backing: %(backing)s to datastore: %(ds)s "
@@ -1090,13 +1104,17 @@ class VMwareVolumeOps(object):
         if service is not None:
             disk_move_type = 'moveAllDiskBackingsAndDisallowSharing'
 
+        # In case of a cross-vcenter vmotion with a profile-id,
+        # We need to specify the profile specifically for the disk
         disk_device = None
-        if disk_type is not None:
+        if disk_type is not None or profile_id is not None:
             disk_device = self._get_disk_device(backing)
 
         relocate_spec = self._get_relocate_spec(datastore, resource_pool, host,
                                                 disk_move_type, disk_type,
-                                                disk_device, service=service)
+                                                disk_device,
+                                                profile_id=profile_id,
+                                                service=service)
 
         task = self._session.invoke_api(self._session.vim, 'RelocateVM_Task',
                                         backing, spec=relocate_spec)


### PR DESCRIPTION
If we have a cinder volume type resulting in a disk with storage IO profile,
then we also need to specify the target vcenter uuid of the storage profile in
the disk-locator.

Specifying it on the VM as profile is not enough, it will raise an unsupported
operation error (as does not specifying it at all)