### PR TITLE
VmWare: Use WithRetrieval instead of own continue_/cancel_retrieval

### DIFF
--- a/cinder/tests/unit/volume/drivers/vmware/test_vmware_volumeops.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_vmware_volumeops.py
@@ -125,7 +125,7 @@ class VolumeOpsTestCase(test.TestCase):
         backing.propSet = [name_prop, instance_uuid_prop, vol_id_prop]
         return backing
 
-    @mock.patch('cinder.volume.drivers.vmware.volumeops.VMwareVolumeOps.'
+    @mock.patch('oslo_vmware.vim_util.'
                 'continue_retrieval', return_value=None)
     def test_build_backing_ref_cache(self, continue_retrieval):
         uuid1 = 'd68cbee0-c1f7-4886-98a4-cf2201461c6e'
@@ -163,7 +163,7 @@ class VolumeOpsTestCase(test.TestCase):
                 'name',
                 'config.instanceUuid',
                 'config.extraConfig["cinder.volume.id"]'])
-        continue_retrieval.assert_called_once_with(result)
+        continue_retrieval.assert_called_once_with(self.session.vim, result)
 
     def test_delete_backing(self):
         backing = mock.sentinel.backing
@@ -193,8 +193,10 @@ class VolumeOpsTestCase(test.TestCase):
                          inMaintenanceMode=in_maintenance)
 
     def test_get_hosts(self):
-        hosts = mock.sentinel.hosts
-        self.session.invoke_api.return_value = hosts
+        retrieve_results = mock.sentinel.retrieve_results
+        hosts = [mock.sentinel.hosts]
+        retrieve_results.objects = hosts
+        self.session.invoke_api.return_value = retrieve_results
         result = self.vops.get_hosts()
         self.assertEqual(hosts, result)
         self.session.invoke_api.assert_called_once_with(vim_util,
@@ -202,26 +204,6 @@ class VolumeOpsTestCase(test.TestCase):
                                                         self.session.vim,
                                                         'HostSystem',
                                                         self.MAX_OBJECTS)
-
-    def test_continue_retrieval(self):
-        retrieve_result = mock.sentinel.retrieve_result
-        self.session.invoke_api.return_value = retrieve_result
-        result = self.vops.continue_retrieval(retrieve_result)
-        self.assertEqual(retrieve_result, result)
-        self.session.invoke_api.assert_called_once_with(vim_util,
-                                                        'continue_retrieval',
-                                                        self.session.vim,
-                                                        retrieve_result)
-
-    def test_cancel_retrieval(self):
-        retrieve_result = mock.sentinel.retrieve_result
-        self.session.invoke_api.return_value = retrieve_result
-        result = self.vops.cancel_retrieval(retrieve_result)
-        self.assertIsNone(result)
-        self.session.invoke_api.assert_called_once_with(vim_util,
-                                                        'cancel_retrieval',
-                                                        self.session.vim,
-                                                        retrieve_result)
 
     def test_is_usable(self):
         mount_info = mock.Mock(spec=object)
@@ -1818,7 +1800,7 @@ class VolumeOpsTestCase(test.TestCase):
                                                         cluster,
                                                         'host')
 
-    @mock.patch('cinder.volume.drivers.vmware.volumeops.VMwareVolumeOps.'
+    @mock.patch('oslo_vmware.vim_util.'
                 'continue_retrieval', return_value=None)
     def test_get_all_clusters(self, continue_retrieval):
         prop_1 = mock.Mock(val='test_cluster_1')
@@ -1836,7 +1818,8 @@ class VolumeOpsTestCase(test.TestCase):
         self.session.invoke_api.assert_called_once_with(
             vim_util, 'get_objects', self.session.vim,
             'ClusterComputeResource', self.MAX_OBJECTS)
-        continue_retrieval.assert_called_once_with(retrieve_result)
+        continue_retrieval.assert_called_once_with(self.session.vim,
+                                                   retrieve_result)
 
     def test_get_entity_by_inventory_path(self):
         self.session.invoke_api.return_value = mock.sentinel.ref

--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -468,17 +468,12 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                 self.session.vim.service_content.propertyCollector,
                 specSet=[filter_spec],
                 options=options)
-            while True:
-                for ds in result.objects:
+            with vim_util.WithRetrieval(self.session.vim, result) as objects:
+                for ds in objects:
                     summary = ds.propSet[0].val
                     global_capacity += summary.capacity
                     global_free += summary.freeSpace
-                if getattr(result, 'token', None):
-                    result = self.session.vim.ContinueRetrievePropertiesEx(
-                        self.session.vim.service_content.propertyCollector,
-                        result.token)
-                else:
-                    break
+
         location_info = '%(driver_name)s:%(vcenter)s' % {
             'driver_name': LOCATION_DRIVER_NAME,
             'vcenter': self.session.vim.service_content.about.instanceUuid}

--- a/cinder/volume/drivers/vmware/volumeops.py
+++ b/cinder/volume/drivers/vmware/volumeops.py
@@ -331,7 +331,6 @@ class VMwareVolumeOps(object):
             return result[0]
 
     def build_backing_ref_cache(self, name_regex=None):
-
         LOG.debug("Building backing ref cache.")
         result = self._session.invoke_api(
             vim_util,
@@ -344,8 +343,8 @@ class VMwareVolumeOps(object):
                 'config.instanceUuid',
                 'config.extraConfig["cinder.volume.id"]'])
 
-        while result:
-            for backing in result.objects:
+        with vim_util.WithRetrieval(self._session.vim, result) as objects:
+            for backing in objects:
                 instance_uuid = None
                 vol_id = None
 
@@ -365,8 +364,6 @@ class VMwareVolumeOps(object):
                     continue
 
                 self._backing_ref_cache[name] = backing.obj
-
-            result = self.continue_retrieval(result)
         LOG.debug("Backing ref cache size: %d.", len(self._backing_ref_cache))
 
     def delete_backing(self, backing):
@@ -407,27 +404,11 @@ class VMwareVolumeOps(object):
 
         :return: All the hosts from the inventory
         """
-        return self._session.invoke_api(vim_util, 'get_objects',
-                                        self._session.vim,
-                                        'HostSystem', self._max_objects)
-
-    def continue_retrieval(self, retrieve_result):
-        """Continue retrieval of results if necessary.
-
-        :param retrieve_result: Result from RetrievePropertiesEx
-        """
-
-        return self._session.invoke_api(vim_util, 'continue_retrieval',
-                                        self._session.vim, retrieve_result)
-
-    def cancel_retrieval(self, retrieve_result):
-        """Cancel retrieval of results if necessary.
-
-        :param retrieve_result: Result from RetrievePropertiesEx
-        """
-
-        self._session.invoke_api(vim_util, 'cancel_retrieval',
-                                 self._session.vim, retrieve_result)
+        result = self._session.invoke_api(vim_util, 'get_objects',
+                                          self._session.vim,
+                                          'HostSystem', self._max_objects)
+        with vim_util.WithRetrieval(self._session.vim, result) as objects:
+            return list(objects)
 
     # TODO(vbala): move this method to datastore module
     def _is_usable(self, mount_info):
@@ -1840,17 +1821,16 @@ class VMwareVolumeOps(object):
         LOG.info("Deleted vmdk file: %s.", vmdk_file_path)
 
     def _get_all_clusters(self):
+        vim = self._session.vim
         clusters = {}
         retrieve_result = self._session.invoke_api(vim_util, 'get_objects',
-                                                   self._session.vim,
+                                                   vim,
                                                    'ClusterComputeResource',
                                                    self._max_objects)
-        while retrieve_result:
-            if retrieve_result.objects:
-                for cluster in retrieve_result.objects:
-                    name = urllib.parse.unquote(cluster.propSet[0].val)
-                    clusters[name] = cluster.obj
-            retrieve_result = self.continue_retrieval(retrieve_result)
+        with vim_util.WithRetrieval(vim, retrieve_result) as objects:
+            for cluster in objects:
+                name = urllib.parse.unquote(cluster.propSet[0].val)
+                clusters[name] = cluster.obj
         return clusters
 
     def get_cluster_refs(self, names):


### PR DESCRIPTION
`WithRetrieval` ensures, that `cancel_retrieval` is called also when there is an exception.
If that isn't done, the VSphere server is leaking resources.

It also fixes `VMwareVolumeOps.get_hosts` when there are more than `vmware_max_objects_retrieval`
hosts. The function does neither call `continue_`- nor `cancel_retrieval`.
So, if there are more hosts, you will only get the first `vmware_max_objects_retrieval`,
and on top of it, leak a view on vserver side.