### PR TITLE
[SAP] Filter out hosts that are marked buildup

### DIFF
--- a/cinder/tests/unit/volume/drivers/vmware/test_vmware_datastore.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_vmware_datastore.py
@@ -301,6 +301,8 @@ class DatastoreTest(test.TestCase):
         self.assertIsNone(self._ds_sel._select_best_datastore({}))
 
     @mock.patch('cinder.volume.drivers.vmware.datastore.DatastoreSelector.'
+                'is_host_in_buildup_cluster')
+    @mock.patch('cinder.volume.drivers.vmware.datastore.DatastoreSelector.'
                 'get_profile_id')
     @mock.patch('cinder.volume.drivers.vmware.datastore.DatastoreSelector.'
                 '_get_datastores')
@@ -310,7 +312,7 @@ class DatastoreTest(test.TestCase):
                 '_select_best_datastore')
     def test_select_datastore(
             self, select_best_datastore, filter_datastores, get_datastores,
-            get_profile_id):
+            get_profile_id, is_buildup):
 
         profile_id = mock.sentinel.profile_id
         get_profile_id.return_value = profile_id
@@ -324,6 +326,8 @@ class DatastoreTest(test.TestCase):
         best_datastore = mock.sentinel.best_datastore
         select_best_datastore.return_value = best_datastore
 
+        is_buildup.return_value = False
+
         size_bytes = 1024
         req = {self._ds_sel.SIZE_BYTES: size_bytes}
         aff_ds_types = [ds_sel.DatastoreType.VMFS]
@@ -333,7 +337,7 @@ class DatastoreTest(test.TestCase):
         profile_name = mock.sentinel.profile_name
         req[ds_sel.DatastoreSelector.PROFILE_NAME] = profile_name
 
-        hosts = mock.sentinel.hosts
+        hosts = [mock.sentinel.hosts]
         self.assertEqual(best_datastore,
                          self._ds_sel.select_datastore(req, hosts))
         get_datastores.assert_called_once_with()

--- a/cinder/volume/drivers/vmware/datastore.py
+++ b/cinder/volume/drivers/vmware/datastore.py
@@ -17,6 +17,7 @@
 Classes and utility methods for datastore selection.
 """
 
+from collections.abc import Iterable
 import random
 
 from oslo_log import log as logging
@@ -98,6 +99,43 @@ class DatastoreSelector(object):
         hubs = pbm.filter_hubs_by_profile(self._session, hubs, profile_id)
         hub_ids = [hub.hubId for hub in hubs]
         return {k: v for k, v in datastores.items() if k.value in hub_ids}
+
+    def is_host_in_buildup_cluster(self, host_ref, cache=None):
+        host_cluster = self._vops._get_parent(host_ref,
+                                              "ClusterComputeResource")
+        if cache is not None and host_cluster.value in cache:
+            return cache[host_cluster.value]
+
+        attrs = self._vops.get_cluster_custom_attributes(host_cluster)
+        LOG.debug("attrs {}".format(attrs))
+
+        def bool_from_str(bool_str):
+            if bool_str.lower() == "true":
+                return True
+            else:
+                return False
+
+        result = (attrs and 'buildup' in attrs and
+                  bool_from_str(attrs['buildup']['value']))
+        if cache is not None:
+            cache[host_cluster.value] = result
+        return result
+
+    def _filter_hosts(self, hosts):
+        """Filter out any hosts that are in a cluster marked buildup."""
+
+        valid_hosts = []
+        cache = {}
+        if hosts:
+            if isinstance(hosts, Iterable):
+                for host in hosts:
+                    if not self.is_host_in_buildup_cluster(host, cache):
+                        valid_hosts.append(host)
+            else:
+                if not self.is_host_in_buildup_cluster(hosts, cache):
+                    valid_hosts.append(hosts)
+
+        return valid_hosts
 
     def _filter_datastores(self,
                            datastores,
@@ -285,13 +323,18 @@ class DatastoreSelector(object):
             profile_id = self.get_profile_id(profile_name)
 
         datastores = self._get_datastores()
+        # We don't want to use hosts in buildup
+        LOG.debug("FILTER hosts start {}".format(hosts))
+        valid_hosts = self._filter_hosts(hosts)
+        LOG.debug("FILTERED hosts valid {}".format(valid_hosts))
         datastores = self._filter_datastores(datastores,
                                              size_bytes,
                                              profile_id,
                                              hard_anti_affinity_datastores,
                                              hard_affinity_ds_types,
-                                             valid_host_refs=hosts)
-        res = self._select_best_datastore(datastores, valid_host_refs=hosts)
+                                             valid_host_refs=valid_hosts)
+        res = self._select_best_datastore(datastores,
+                                          valid_host_refs=valid_hosts)
         LOG.debug("Selected (host, resourcepool, datastore): %s", res)
         return res
 

--- a/cinder/volume/drivers/vmware/volumeops.py
+++ b/cinder/volume/drivers/vmware/volumeops.py
@@ -1885,6 +1885,33 @@ class VMwareVolumeOps(object):
 
         return host_refs
 
+    def get_cluster_custom_attributes(self, cluster):
+        retrieve_fields = self._session.invoke_api(vim_util,
+                                                   'get_object_property',
+                                                   self._session.vim,
+                                                   cluster,
+                                                   'availableField')
+        if retrieve_fields:
+            custom_fields = {}
+            for field in retrieve_fields:
+                for v in field[1]:
+                    custom_fields[v.key] = v.name
+
+            retrieve_result = self._session.invoke_api(vim_util,
+                                                       'get_object_property',
+                                                       self._session.vim,
+                                                       cluster,
+                                                       'customValue')
+            if retrieve_result:
+                custom_attributes = {}
+                for val in retrieve_result:
+                    for i in val[1]:
+                        custom_attributes[custom_fields[i.key]] = {
+                            "value": i.value, 'id': i.key
+                        }
+
+                return custom_attributes
+
     def get_entity_by_inventory_path(self, path):
         """Returns the managed object identified by the given inventory path.
 


### PR DESCRIPTION
This patch filters out hosts in a cluster that has been
marked by ops as 'buildup'.  This ensures that we don't use
hosts that aren't ready to be used quite yet.

Ops has to set a 'buildup' : 'true' custom attribute in the
cluster.  This patch will reverse lookup which cluster a host is in
and ensure that the cluster isn't marked as buildup.