### PR TITLE
[SAP] Add vmware extension for migration

### DIFF
--- a/cinder/api/contrib/vmware_migrate.py
+++ b/cinder/api/contrib/vmware_migrate.py
@@ -17,6 +17,7 @@
 
 
 from oslo_log import log as logging
+from oslo_utils import strutils
 from six.moves import http_client
 
 from cinder.api.contrib import admin_actions
@@ -51,9 +52,12 @@ class VMWareVolumeExtensionsController(admin_actions.VolumeAdminController):
         self.authorize(context, 'migrate_volume', target_obj=volume)
         params = body['os-migrate_volume_by_connector']
         connector = params.get('connector', {})
+        lock_volume = strutils.bool_from_string(
+            params.get('lock_volume', False),
+            strict=True)
 
         self.volume_api.migrate_volume_by_connector(
-            context, volume, connector)
+            context, volume, connector, lock_volume)
 
 
 class Vmware_migrate(extensions.ExtensionDescriptor):

--- a/cinder/api/contrib/vmware_migrate.py
+++ b/cinder/api/contrib/vmware_migrate.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2021 SAP Corporation
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""The Migrate by connector API."""
+
+
+from oslo_log import log as logging
+from six.moves import http_client
+
+from cinder.api.contrib import admin_actions
+from cinder.api import extensions
+from cinder.api.openstack import wsgi
+from cinder.api.schemas import vmware_extension_actions as vmware_actions
+from cinder.api import validation
+
+
+LOG = logging.getLogger(__name__)
+
+
+class VMWareVolumeExtensionsController(admin_actions.VolumeAdminController):
+
+    collection = 'volumes'
+
+    @wsgi.response(http_client.ACCEPTED)
+    @wsgi.action('os-migrate_volume_by_connector')
+    @validation.schema(vmware_actions.migrate_volume_by_connector)
+    def _migrate_volume(self, req, id, body):
+        """Migrate a volume based on connector.
+
+        This is an SAP VMWare extension that requires
+        the connector of the vmware vcenter to be provided.
+        The connector will contain the correct vcenter uuid
+        so that the scheduler can find the right cinder backend
+        to migrate the volume.
+        """
+        context = req.environ['cinder.context']
+        # Not found exception will be handled at the wsgi level
+        volume = self._get(context, id)
+        self.authorize(context, 'migrate_volume', target_obj=volume)
+        params = body['os-migrate_volume_by_connector']
+        connector = params.get('connector', {})
+
+        self.volume_api.migrate_volume_by_connector(
+            context, volume, connector)
+
+
+class Vmware_migrate(extensions.ExtensionDescriptor):
+    """Enable admin actions."""
+
+    name = "Vmware_migrate"
+    alias = "os-vmware-admin-actions"
+    updated = "2021-09-25T00:00:00+00:00"
+
+    def get_controller_extensions(self):
+        controller = VMWareVolumeExtensionsController()
+        extension = extensions.ControllerExtension(
+            self, controller.collection, controller)
+        return [extension]

--- a/cinder/api/contrib/vmware_migrate.py
+++ b/cinder/api/contrib/vmware_migrate.py
@@ -36,7 +36,7 @@ class VMWareVolumeExtensionsController(admin_actions.VolumeAdminController):
     @wsgi.response(http_client.ACCEPTED)
     @wsgi.action('os-migrate_volume_by_connector')
     @validation.schema(vmware_actions.migrate_volume_by_connector)
-    def _migrate_volume(self, req, id, body):
+    def _migrate_volume_by_connector(self, req, id, body):
         """Migrate a volume based on connector.
 
         This is an SAP VMWare extension that requires

--- a/cinder/api/contrib/volume_actions.py
+++ b/cinder/api/contrib/volume_actions.py
@@ -166,6 +166,10 @@ class VolumeActionsController(wsgi.Controller):
         except exception.InvalidInput as err:
             raise webob.exc.HTTPBadRequest(
                 explanation=err.msg)
+        except exception.ConnectorRejected:
+            msg = _("Volume needs to be migrated before attaching to this "
+                    "instance")
+            raise webob.exc.HTTPNotAcceptable(explanation=msg)
         except exception.VolumeBackendAPIException:
             msg = _("Unable to fetch connection information from backend.")
             raise webob.exc.HTTPInternalServerError(explanation=msg)

--- a/cinder/api/schemas/vmware_extension_actions.py
+++ b/cinder/api/schemas/vmware_extension_actions.py
@@ -13,6 +13,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from cinder.api.validation import parameter_types
+
 
 migrate_volume_by_connector = {
     'type': 'object',
@@ -21,6 +23,7 @@ migrate_volume_by_connector = {
             'type': 'object',
             'properties': {
                 'connector': {'type': ['string', 'object', 'null']},
+                'lock_volume': parameter_types.boolean,
             },
             'additionalProperties': False,
         },

--- a/cinder/api/schemas/vmware_extension_actions.py
+++ b/cinder/api/schemas/vmware_extension_actions.py
@@ -1,0 +1,30 @@
+# Copyright (C) 2021 SAP
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+
+migrate_volume_by_connector = {
+    'type': 'object',
+    'properties': {
+        'os-migrate_volume_by_connector': {
+            'type': 'object',
+            'properties': {
+                'connector': {'type': ['string', 'object', 'null']},
+            },
+            'additionalProperties': False,
+        },
+    },
+    'required': ['os-migrate_volume_by_connector'],
+    'additionalProperties': False,
+}

--- a/cinder/api/v3/attachments.py
+++ b/cinder/api/v3/attachments.py
@@ -186,6 +186,12 @@ class AttachmentsController(wsgi.Controller):
         except (exception.NotAuthorized,
                 exception.InvalidVolume):
             raise
+        except exception.ConnectorRejected:
+            # Don't use err_msg or it will raise the 500
+            _msg = _("Volume needs to be migrated before attaching to this "
+                     "instance")
+            LOG.exception(_msg)
+            raise webob.exc.HTTPNotAcceptable(explanation=_msg)
         except exception.CinderException as ex:
             err_msg = _(
                 "Unable to create attachment for volume (%s).") % ex.msg
@@ -240,6 +246,12 @@ class AttachmentsController(wsgi.Controller):
                                                   connector))
         except exception.NotAuthorized:
             raise
+        except exception.ConnectorRejected:
+            # Don't use err_msg or it will raise the 500
+            _msg = _("Volume needs to be migrated before attaching to this "
+                     "instance")
+            LOG.exception(_msg)
+            raise webob.exc.HTTPNotAcceptable(explanation=_msg)
         except exception.CinderException as ex:
             err_msg = (
                 _("Unable to update attachment.(%s).") % ex.msg)

--- a/cinder/opts.py
+++ b/cinder/opts.py
@@ -254,7 +254,6 @@ def list_opts():
                 [cinder_volume_api.volume_host_opt],
                 [cinder_volume_api.volume_same_az_opt],
                 [cinder_volume_api.az_cache_time_opt],
-                [cinder_volume_api.migrate_on_attach_opt],
                 cinder_volume_driver.volume_opts,
                 cinder_volume_driver.iser_opts,
                 cinder_volume_driver.nvmet_opts,

--- a/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
@@ -2117,6 +2117,17 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
     def test_initialize_connection_with_no_instance_and_backing(self):
         self._test_initialize_connection(instance_exists=False)
 
+    def test_initialize_connection_connector_rejected(self):
+        connector = {'ip': '0.0.0.0',
+                     "connection_capabilities": {}}
+        volume = self._create_volume_obj()
+
+        self._driver._vcenter_instance_uuid_cache = "11234"
+
+        self.assertRaises(cinder_exceptions.ConnectorRejected,
+                          self._driver.initialize_connection,
+                          volume, connector)
+
     @mock.patch.object(VMDK_DRIVER, 'volumeops')
     def test_terminate_connection(self, vops):
         volume = self._create_volume_obj(status='restoring-backup')

--- a/cinder/tests/unit/volume/test_volume.py
+++ b/cinder/tests/unit/volume/test_volume.py
@@ -3346,59 +3346,6 @@ class VolumeTestCase(base.BaseVolumeTestCase):
         self.assertListEqual([], eventlet.tpool._threads)
         eventlet.tpool._nthreads = 20
 
-    @mock.patch('cinder.volume.volume_types.get_volume_type')
-    def test_initialize_connection_with_rejected_connector(
-            self, fake_get_volume_type):
-        ini_ret = {'ip': '1.2.3.4'}
-        connector = {'ip': '0.0.0.0'}
-        volume_type = 'fake-volume-type'
-        volume = tests_utils.create_volume(self.context)
-        host_obj = {'host': 'fake-host',
-                    'cluster_name': 'fake-cluster',
-                    'capabilities': {}}
-
-        self.override_config('allow_migration_on_attach', True)
-        fake_get_volume_type.return_value = volume_type
-
-        volume_api = cinder.volume.api.API()
-        scheduler_rpcapi = mock.Mock()
-        volume_api.scheduler_rpcapi = scheduler_rpcapi
-        volume_api.scheduler_rpcapi.find_backend_for_connector.return_value =\
-            host_obj
-
-        volume_rpcapi = mock.Mock()
-        volume_api.volume_rpcapi = volume_rpcapi
-
-        call_times = {volume.id: -1}
-
-        def _initialize_connection_side_effect(context, volume, connector):
-            call_times[volume.id] += 1
-            if call_times[volume.id] == 0:
-                # First time it rejects the connector
-                raise exception.ConnectorRejected(reason=None)
-            if call_times[volume.id] == 1:
-                # Second time (after migration) it returns the connection data
-                return ini_ret
-
-        volume_rpcapi.initialize_connection.side_effect =\
-            _initialize_connection_side_effect
-
-        conn_result =\
-            volume_api.initialize_connection(self.context, volume, connector)
-
-        self.assertEqual(conn_result, ini_ret)
-        volume_rpcapi.initialize_connection.assert_has_calls([
-            mock.call(self.context, volume, connector),
-            mock.call(self.context, volume, connector)
-        ])
-        volume_rpcapi.migrate_volume.assert_called_once_with(
-            self.context, volume, mock.ANY, force_host_copy=False,
-            wait_for_completion=True)
-        backend = volume_rpcapi.migrate_volume.call_args[0][2]
-        self.assertEqual(backend.host, host_obj['host'])
-        self.assertEqual(backend.cluster_name, host_obj['cluster_name'])
-        self.assertEqual(backend.capabilities, host_obj['capabilities'])
-
 
 class VolumeTestCaseLocks(base.BaseVolumeTestCase):
     MOCK_TOOZ = False

--- a/cinder/volume/api.py
+++ b/cinder/volume/api.py
@@ -85,20 +85,12 @@ az_cache_time_opt = cfg.IntOpt('az_cache_duration',
                                help='Cache volume availability zones in '
                                     'memory for the provided duration in '
                                     'seconds')
-migrate_on_attach_opt = cfg.BoolOpt('allow_migration_on_attach',
-                                    default=False,
-                                    help="A host might recognise a connector "
-                                         "as valid but it can't use it to "
-                                         "initialize a connection. This will "
-                                         "allow to migrate the volume to a "
-                                         "valid host prior to attachment.")
 
 CONF = cfg.CONF
 CONF.register_opt(allow_force_upload_opt)
 CONF.register_opt(volume_host_opt)
 CONF.register_opt(volume_same_az_opt)
 CONF.register_opt(az_cache_time_opt)
-CONF.register_opt(migrate_on_attach_opt)
 CONF.import_opt('glance_core_properties', 'cinder.image.glance')
 
 LOG = logging.getLogger(__name__)
@@ -814,9 +806,7 @@ class API(base.Base):
     def migrate_volume_by_connector(self, ctxt, volume, connector):
         if not connector:
             raise exception.InvalidInput("Must provide a valid Connector")
-        return self._migrate_by_connector(ctxt, volume, connector, wait=False)
 
-    def _migrate_by_connector(self, ctxt, volume, connector, wait=True):
         volume_type = {}
         if volume.volume_type_id:
             volume_type = volume_types.get_volume_type(
@@ -839,7 +829,7 @@ class API(base.Base):
         LOG.debug("Invoking migrate_volume to host=%(host).", dest['host'])
         self.volume_rpcapi.migrate_volume(ctxt, volume, backend,
                                           force_host_copy=False,
-                                          wait_for_completion=wait)
+                                          wait_for_completion=False)
         volume.refresh()
 
     def initialize_connection(self, context, volume, connector):
@@ -853,23 +843,9 @@ class API(base.Base):
                     "maintenance mode.")
             raise exception.InvalidVolume(reason=msg)
 
-        def _migrate_and_initialize_connection():
-            self._migrate_by_connector(context, volume, connector)
-            return self.volume_rpcapi.initialize_connection(context, volume,
-                                                            connector)
-        init_results = None
-        try:
-            init_results = self.volume_rpcapi.initialize_connection(context,
-                                                                    volume,
-                                                                    connector)
-        except exception.ConnectorRejected:
-            with excutils.save_and_reraise_exception() as exc_context:
-                if CONF.allow_migration_on_attach:
-                    LOG.info("The connector was rejected by the volume "
-                             "backend while initializing the connection. "
-                             "Attempting to migrate it.")
-                    init_results = _migrate_and_initialize_connection()
-                    exc_context.reraise = False
+        init_results = self.volume_rpcapi.initialize_connection(context,
+                                                                volume,
+                                                                connector)
 
         LOG.info("Initialize volume connection completed successfully.",
                  resource=volume)
@@ -2227,26 +2203,12 @@ class API(base.Base):
         attachment_ref = self._attachment_reserve(ctxt,
                                                   volume_ref,
                                                   instance_uuid)
-        try:
-            if connector:
-                connection_info = (
-                    self.volume_rpcapi.attachment_update(ctxt,
-                                                         volume_ref,
-                                                         connector,
-                                                         attachment_ref.id))
-        except exception.ConnectorRejected:
-            with excutils.save_and_reraise_exception() as exc_context:
-                if CONF.allow_migration_on_attach:
-                    LOG.info("The connector was rejected by the volume "
-                             "backend while updating the attachments. "
-                             "Trying to migrate it.")
-                    exc_context.reraise = False
-                    self._migrate_by_connector(ctxt, volume_ref, connector)
-                    connection_info =\
-                        self.volume_rpcapi.attachment_update(ctxt,
-                                                             volume_ref,
-                                                             connector,
-                                                             attachment_ref.id)
+        if connector:
+            connection_info = (
+                self.volume_rpcapi.attachment_update(ctxt,
+                                                     volume_ref,
+                                                     connector,
+                                                     attachment_ref.id))
         attachment_ref.connection_info = connection_info
 
         # Use of admin_metadata for RO settings is deprecated
@@ -2318,26 +2280,11 @@ class API(base.Base):
                         '%(vol)s') % {'vol': volume_ref.id}
 
                 raise exception.InvalidVolume(reason=msg)
-        connection_info = None
-        try:
-            connection_info = (
-                self.volume_rpcapi.attachment_update(ctxt,
-                                                     volume_ref,
-                                                     connector,
-                                                     attachment_ref.id))
-        except exception.ConnectorRejected:
-            with excutils.save_and_reraise_exception() as exc_context:
-                if CONF.allow_migration_on_attach:
-                    LOG.info("The connector was rejected by the volume "
-                             "backend while updating the attachments. "
-                             "Trying to migrate it.")
-                    exc_context.reraise = False
-                    self._migrate_by_connector(ctxt, volume_ref, connector)
-                    connection_info =\
-                        self.volume_rpcapi.attachment_update(ctxt,
-                                                             volume_ref,
-                                                             connector,
-                                                             attachment_ref.id)
+        connection_info = (
+            self.volume_rpcapi.attachment_update(ctxt,
+                                                 volume_ref,
+                                                 connector,
+                                                 attachment_ref.id))
         attachment_ref.connection_info = connection_info
         attachment_ref.save()
         return attachment_ref

--- a/cinder/volume/api.py
+++ b/cinder/volume/api.py
@@ -803,7 +803,8 @@ class API(base.Base):
                  resource=volume)
         return detach_results
 
-    def migrate_volume_by_connector(self, ctxt, volume, connector):
+    def migrate_volume_by_connector(self, ctxt, volume, connector,
+                                    lock_volume):
         if not connector:
             raise exception.InvalidInput("Must provide a valid Connector")
 
@@ -826,6 +827,45 @@ class API(base.Base):
         backend = host_manager.BackendState(host=dest['host'],
                                             cluster_name=dest['cluster_name'],
                                             capabilities=dest['capabilities'])
+
+        # Build required conditions for conditional update
+        expected = {'status': ('available', 'reserved'),
+                    'migration_status': self.AVAILABLE_MIGRATION_STATUS,
+                    'replication_status': (
+                        None,
+                        fields.ReplicationStatus.DISABLED,
+                        fields.ReplicationStatus.NOT_CAPABLE),
+                    'consistencygroup_id': (None, ''),
+                    'group_id': (None, '')}
+
+        expected['host'] = db.Not(dest['host'])
+        filters = [~db.volume_has_snapshots_filter()]
+
+        updates = {'migration_status': 'starting',
+                   'previous_status': volume.model.status}
+
+        # When the migration of an available volume starts, both the status
+        # and the migration status of the volume will be changed.
+        # If the admin sets lock_volume flag to True, the volume
+        # status is changed to 'maintenance', telling users
+        # that this volume is in maintenance mode, and no action is allowed
+        # on this volume, e.g. attach, detach, retype, migrate, etc.
+        if lock_volume:
+            updates['status'] = db.Case(
+                [(volume.model.status.in_(('available', 'reserved')),
+                  'maintenance')],
+                else_=volume.model.status)
+
+        result = volume.conditional_update(updates, expected, filters)
+
+        if not result:
+            msg = _('Volume %s status must be available or reserved, must not '
+                    'be migrating, have snapshots, be replicated, be part of '
+                    'a group and destination host/cluster must be different '
+                    'than the current one') % volume.id
+            LOG.error(msg)
+            raise exception.InvalidVolume(reason=msg)
+
         LOG.debug("Invoking migrate_volume to host=%(host).", dest['host'])
         self.volume_rpcapi.migrate_volume(ctxt, volume, backend,
                                           force_host_copy=False,

--- a/cinder/volume/api.py
+++ b/cinder/volume/api.py
@@ -811,7 +811,12 @@ class API(base.Base):
                  resource=volume)
         return detach_results
 
-    def _migrate_by_connector(self, ctxt, volume, connector):
+    def migrate_volume_by_connector(self, ctxt, volume, connector):
+        if not connector:
+            raise exception.InvalidInput("Must provide a valid Connector")
+        return self._migrate_by_connector(ctxt, volume, connector, wait=False)
+
+    def _migrate_by_connector(self, ctxt, volume, connector, wait=True):
         volume_type = {}
         if volume.volume_type_id:
             volume_type = volume_types.get_volume_type(
@@ -834,7 +839,7 @@ class API(base.Base):
         LOG.debug("Invoking migrate_volume to host=%(host).", dest['host'])
         self.volume_rpcapi.migrate_volume(ctxt, volume, backend,
                                           force_host_copy=False,
-                                          wait_for_completion=True)
+                                          wait_for_completion=wait)
         volume.refresh()
 
     def initialize_connection(self, context, volume, connector):

--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -2611,7 +2611,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         """
 
         false_ret = (False, None)
-        allowed_statuses = ['available', 'reserved', 'in-use']
+        allowed_statuses = ['available', 'reserved', 'in-use', 'maintenance']
         if volume['status'] not in allowed_statuses:
             LOG.debug('Only %s volumes can be migrated using backend '
                       'assisted migration. Falling back to generic migration.',


### PR DESCRIPTION
This is a POC/WIP to add the extension to the cinder API
to allow calling os-migrate_volume_by_connector.  This will
still be an admin API endpoint as it will call migrate_volume
underneath it.

Notes:
  I tested this on my home devstack and was able to manually issue the call 
to migrate via connector.   It worked. :)


For using this manually you can do this:

```
connector = {"connection_capabilities": ["vmware_service_instance_uuid:......"]}
body = {"connector": connector}
client.volumes._action('os-migrate_volume_by_connector', volume, body)
```