### PR TITLE
[SAP] Remove suds from requirements

### DIFF
--- a/lower-constraints.txt
+++ b/lower-constraints.txt
@@ -149,7 +149,7 @@ sqlparse==0.2.4
 statsd==3.2.2
 stestr==2.2.0
 stevedore==1.20.0
-suds-jurko==0.6
+tabulate==0.8.5
 taskflow==3.2.0
 tempest==17.1.0
 Tempita==0.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,7 +54,7 @@ six>=1.10.0 # MIT
 SQLAlchemy!=1.1.5,!=1.1.6,!=1.1.7,!=1.1.8,>=1.0.10 # MIT
 sqlalchemy-migrate>=0.11.0 # Apache-2.0
 stevedore>=1.20.0 # Apache-2.0
-suds-jurko>=0.6 # LGPLv3+
+tabulate>=0.8.5 # MIT
 WebOb>=1.7.1 # MIT
 oslo.i18n>=3.15.3 # Apache-2.0
 # Double requirements with the sapcc/custom-requirements.txt


### PR DESCRIPTION
The suds-jurko requirement was needed by the Disco and Datacore drivers,
but of which have since been removed. This cleans up the requirements to
remove that library.

Change-Id: I141c2c141aeea84272d2b04610e53822bc3b3371
Signed-off-by: Sean McGinnis <sean.mcginnis@gmail.com>

Cherry picked from upstream 50756ce5de9748277434a171c11a2f2a4901364e