### PR TITLE
[SAP] Remove suds-jurko from requirements.

### DIFF
--- a/lower-constraints.txt
+++ b/lower-constraints.txt
@@ -149,7 +149,6 @@ sqlparse==0.2.4
 statsd==3.2.2
 stestr==2.2.0
 stevedore==1.20.0
-suds-jurko==0.6
 taskflow==3.2.0
 tempest==17.1.0
 Tempita==0.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,7 +54,6 @@ six>=1.10.0 # MIT
 SQLAlchemy!=1.1.5,!=1.1.6,!=1.1.7,!=1.1.8,>=1.0.10 # MIT
 sqlalchemy-migrate>=0.11.0 # Apache-2.0
 stevedore>=1.20.0 # Apache-2.0
-suds-jurko>=0.6 # LGPLv3+
 WebOb>=1.7.1 # MIT
 oslo.i18n>=3.15.3 # Apache-2.0
 # Double requirements with the sapcc/custom-requirements.txt


### PR DESCRIPTION
This patch removes suds-jurko from requirements.
oslo.vmware has been changed to use suds-community