### PR TITLE
[SAP] Update connection_capabilities reporting in stats

### DIFF
--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -468,6 +468,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                 }
 
         result, datastores = self._collect_backend_stats()
+        connection_capabilities = self._get_connection_capabilities()
         if self.configuration.vmware_datastores_as_pools:
             pools = []
             for ds_name in datastores:
@@ -489,8 +490,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                         'location_info': location_info,
                         'backend_state': pool_state,
                         'storage_profile': datastore["storage_profile"],
-                        'connection_capabilities': (
-                            self._get_connection_capabilities(),)
+                        'connection_capabilities': connection_capabilities,
                         }
                 pools.append(pool)
             data['pools'] = pools
@@ -521,7 +521,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
             'thin_provisioning_support': True,
             'thick_provisioning_support': True,
             'max_over_subscription_ratio': max_over_subscription_ratio,
-            'connection_capabilities': self._get_connection_capabilities(),
+            'connection_capabilities': connection_capabilities,
         }
         data.update(data_no_pools)
 


### PR DESCRIPTION
This patch fixes an issue with reporting the connection capabilities
in pools enabled stats for vmdk driver.