### PR TITLE
[SAP] ShardFilter passes everything for find_backend_for_connector

### DIFF
--- a/cinder/scheduler/filters/shard_filter.py
+++ b/cinder/scheduler/filters/shard_filter.py
@@ -156,6 +156,13 @@ class ShardFilter(filters.BaseBackendFilter):
             LOG.debug('Ignoring snapshot.')
             return True
 
+        if spec.get('operation') == 'find_backend_for_connector':
+            # We don't care about shards here, as we want to move a volume to
+            # an instance sitting in a specific vCenter. Shards are only used
+            # if we don't know where the volume is needed.
+            LOG.debug('Ignoring find_backend_for_connector scheduling.')
+            return True
+
         # allow an override of the automatic shard-detection like nova does for
         # its compute-hosts
         scheduler_hints = filter_properties.get('scheduler_hints') or {}


### PR DESCRIPTION
When we try to find a backend for a connector, we got called by an admin
to migrate a volume towards a connector - a specific vCenter housing a
specific VM. In those cases, we don't want to prohibit the migration
just because the volume's project doesn't have the appropriate shards
set, as the shards should more steer where we put volumes initially, not
prohibit the user from attaching a volume if it's necessary on a "stray"
instance.

Change-Id: Iccf5f5287eda536adafe925c76054f14827c467e

---

For reference: [This decorator](https://github.com/sapcc/cinder/blob/3f9e139e8077a11168e82fa97f7c773c8e55b6a3/cinder/scheduler/manager.py#L358) sets the `operation` key in the RequestSpec. There's another example using this in [the CapabilitiesFilter](https://github.com/sapcc/cinder/blob/3f9e139e8077a11168e82fa97f7c773c8e55b6a3/cinder/scheduler/filters/capabilities_filter.py#L36).