### PR TITLE
[SAP] add SAPLargeVolumeFilter

### DIFF
--- a/cinder/scheduler/filters/sap_large_volume_filter.py
+++ b/cinder/scheduler/filters/sap_large_volume_filter.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2020 SAP SE
+#
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -11,14 +12,12 @@
 #    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
-#    under the License
+#    under the License.
 
 from oslo_config import cfg
 from oslo_log import log as logging
 
 from cinder.scheduler import filters
-from cinder.service_auth import SERVICE_USER_GROUP
-from cinder import utils as cinder_utils
 
 
 LOG = logging.getLogger(__name__)
@@ -34,7 +33,7 @@ class SAPLargeVolumeFilter(filters.BaseBackendFilter):
         volume_size = req_spec["volume"]["size"]
 
         if 'vvol' in host.lower() and volume_size > 2000:
-            LOG.warning("Cannot allow volumes larger than 2000 on vVol.")
+            LOG.info("Cannot allow volumes larger than 2000 GiB on vVol.")
             return False
         else:
             return True

--- a/cinder/scheduler/filters/sap_large_volume_filter.py
+++ b/cinder/scheduler/filters/sap_large_volume_filter.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2020 SAP SE
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License
+
+from oslo_config import cfg
+from oslo_log import log as logging
+
+from cinder.scheduler import filters
+from cinder.service_auth import SERVICE_USER_GROUP
+from cinder import utils as cinder_utils
+
+
+LOG = logging.getLogger(__name__)
+CONF = cfg.CONF
+
+
+class SAPLargeVolumeFilter(filters.BaseBackendFilter):
+    """Filter out volumes from landing on vvol datastores for > 2TB"""
+
+    def backend_passes(self, backend_state, filter_properties):
+        host = backend_state.host
+        req_spec = filter_properties.get('request_spec')
+        volume_size = req_spec["volume"]["size"]
+
+        if 'vvol' in host.lower() and volume_size > 2000:
+            LOG.warning("Cannot allow volumes larger than 2000 on vVol.")
+            return False
+        else:
+            return True

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ cinder.scheduler.filters =
     SameBackendFilter = cinder.scheduler.filters.affinity_filter:SameBackendFilter
     InstanceLocalityFilter = cinder.scheduler.filters.instance_locality_filter:InstanceLocalityFilter
     ShardFilter = cinder.scheduler.filters.shard_filter:ShardFilter
+    SAPLargeVolumeFilter = cinder.scheduler.filters.sap_large_volume_filter:SAPLargeVolumeFilter
 cinder.scheduler.weights =
     AllocatedCapacityWeigher = cinder.scheduler.weights.capacity:AllocatedCapacityWeigher
     CapacityWeigher = cinder.scheduler.weights.capacity:CapacityWeigher


### PR DESCRIPTION
This filter disallows any volumes larger than 2TB to be created on
any datastore that has 'vvol' in it's name.