### PR TITLE
[SAP] Remove the tracing from _get_datastores_for_profiles

### DIFF
--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -2404,7 +2404,6 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
 
         return provider_info
 
-    @utils.trace
     def _get_datastores_for_profiles(self):
         datastores = {}
         for profile in self._storage_profiles:


### PR DESCRIPTION
This tracing was useful during development of the datastores
as pool, now it's just noise.