### PR TITLE
Fix live migration

### DIFF
--- a/cinder/tests/unit/volume/drivers/vmware/test_remote.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_remote.py
@@ -57,7 +57,8 @@ class VmdkDriverRemoteApiTest(test.RPCAPITestCase):
                            server=self._fake_host,
                            host=self._fake_host,
                            volume=self._fake_volume,
-                           create_params=None
+                           create_params=None,
+                           cinder_host=self._fake_host,
                            )
 
 
@@ -120,4 +121,4 @@ class VmdkDriverRemoteServiceTest(test.TestCase):
     def test_create_backing(self):
         self._service.create_backing(self._ctxt, self._fake_volume)
         self._driver._create_backing.assert_called_once_with(
-            self._fake_volume, create_params=None)
+            self._fake_volume, create_params=None, cinder_host=None)

--- a/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
@@ -2896,7 +2896,11 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
         ret = self._driver._create_backing(volume, host, create_params)
 
         self.assertEqual(backing, ret)
-        select_ds_for_volume.assert_called_once_with(volume, host)
+        select_ds_for_volume.assert_called_once_with(
+            volume,
+            host,
+            cinder_host=None,
+            create_params=create_params)
         get_storage_profile_id.assert_called_once_with(volume)
 
         exp_extra_config = {vmdk.EXTRA_CONFIG_VOLUME_ID_KEY: volume['id'],

--- a/cinder/volume/api.py
+++ b/cinder/volume/api.py
@@ -828,8 +828,9 @@ class API(base.Base):
                                             cluster_name=dest['cluster_name'],
                                             capabilities=dest['capabilities'])
 
+        states = ('available', 'reserved', 'in-use')
         # Build required conditions for conditional update
-        expected = {'status': ('available', 'reserved'),
+        expected = {'status': states,
                     'migration_status': self.AVAILABLE_MIGRATION_STATUS,
                     'replication_status': (
                         None,
@@ -852,7 +853,7 @@ class API(base.Base):
         # on this volume, e.g. attach, detach, retype, migrate, etc.
         if lock_volume:
             updates['status'] = db.Case(
-                [(volume.model.status.in_(('available', 'reserved')),
+                [(volume.model.status.in_(states),
                   'maintenance')],
                 else_=volume.model.status)
 

--- a/cinder/volume/drivers/vmware/remote.py
+++ b/cinder/volume/drivers/vmware/remote.py
@@ -51,10 +51,12 @@ class VmdkDriverRemoteApi(rpc.RPCAPI):
         return cctxt.call(ctxt, 'move_volume_backing_to_folder', volume=volume,
                           folder=folder)
 
-    def create_backing(self, ctxt, host, volume, create_params=None):
+    def create_backing(self, ctxt, host, volume, create_params=None,
+                       cinder_host=None):
         cctxt = self._get_cctxt(host)
         return cctxt.call(ctxt, 'create_backing', volume=volume,
-                          create_params=create_params)
+                          create_params=create_params,
+                          cinder_host=cinder_host or host)
 
 
 class VmdkDriverRemoteService(object):
@@ -94,6 +96,8 @@ class VmdkDriverRemoteService(object):
         folder_ref = vim_util.get_moref(folder, 'Folder')
         self._driver.volumeops.move_backing_to_folder(backing, folder_ref)
 
-    def create_backing(self, ctxt, volume, create_params=None):
+    def create_backing(self, ctxt, volume, create_params=None,
+                       cinder_host=None):
         return self._driver._create_backing(volume,
-                                            create_params=create_params)
+                                            create_params=create_params,
+                                            cinder_host=cinder_host)

--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -652,7 +652,8 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                 volumeops.BACKING_UUID_KEY: volume['id']}
 
     @utils.trace
-    def _create_backing(self, volume, host=None, create_params=None):
+    def _create_backing(self, volume, host=None, create_params=None,
+                        cinder_host=None):
         """Create volume backing under the given host.
 
         If host is unspecified, any suitable host is selected.
@@ -661,13 +662,15 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         :param host: Reference of the host
         :param create_params: Dictionary specifying optional parameters for
                               backing VM creation
+        :param cinder_host: String of the format host@backend_name#pool.
         :return: Reference to the created backing
         """
+        create_params = create_params or {}
 
         (host_ref, resource_pool, folder,
-            summary) = self._select_ds_for_volume(volume, host)
-
-        create_params = create_params or {}
+            summary) = self._select_ds_for_volume(volume, host,
+                                                  create_params=create_params,
+                                                  cinder_host=cinder_host)
 
         # check if a storage profile needs to be associated with the backing VM
         profile_id = self._get_storage_profile_id(volume)

--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -2939,7 +2939,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                      {'volume_name': volume.name, 'dest_host': dest_host})
             return (True, None)
 
-        if volume['status'] == 'in-use':
+        if volume['attach_status'] == 'attached':
             if self._vcenter_instance_uuid != vcenter:
                 return self._migrate_attached_cross_vc(context, dest_host,
                                                        volume, backing)


### PR DESCRIPTION
The fix consists of two changes, each in their commit.
- We lock now the volumes before migrating them, so we have to handle the changed status
- We parse the current volume (cinder-)host to determine the datastore, which needs to be overridden with the target cinder-host.
