### PR TITLE
[SAP] Ensure pools specify thick_provisioning_support enabled

### DIFF
--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -481,6 +481,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                         'free_capacity_gb': round(
                             summary.freeSpace / units.Gi),
                         'thin_provisioning_support': True,
+                        'thick_provisioning_support': True,
                         'max_over_subscription_ratio': (
                             max_over_subscription_ratio),
                         'reserved_percentage': reserved_percentage,


### PR DESCRIPTION
This patch forces the pool stats to say they support
thick provisioning.