### PR TITLE
[SAP] Add any custom attributes to pool stats

### DIFF
--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -474,6 +474,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
             for ds_name in datastores:
                 datastore = datastores[ds_name]
                 summary = datastore["summary"]
+
                 pool_state = "up" if summary.accessible is True else "down"
                 pool = {'pool_name': summary.name,
                         'total_capacity_gb': round(
@@ -493,6 +494,11 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                         'storage_profile': datastore["storage_profile"],
                         'connection_capabilities': connection_capabilities,
                         }
+
+                # Add any custom attributes associated with the datastore
+                if "custom_attributes" in datastore:
+                    pool['custom_attributes'] = datastore['custom_attributes']
+
                 pools.append(pool)
             data['pools'] = pools
             return data
@@ -2421,10 +2427,25 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                     # Reconstruct a managed object reference to that
                     # datastore
                     ds = vim_util.get_moref(h.hubId, "Datastore")
-                    summary = self.volumeops.get_summary(ds)
+                    objects = self.volumeops.get_datastore_properties(ds)
+                    summary = objects['summary']
                     datastores[summary.name] = {'summary': summary,
-                                                'storage_profile': profile}
+                                                'storage_profile': profile,
+                                                'datastore_object': ds}
+                    if ('availableField' in objects and
+                            'customValue' in objects):
+                        custom_fields = {}
+                        for junk, field in objects['availableField']:
+                            for v in field:
+                                custom_fields[v.key] = v.name
 
+                        custom_attributes = {}
+                        for junk, attr in objects['customValue']:
+                            for v in attr:
+                                field = custom_fields[v.key]
+                                custom_attributes[field] = v.value
+                        datastores[summary.name][
+                            "custom_attributes"] = custom_attributes
         return datastores
 
     def _new_host_for_volume(self, volume):

--- a/cinder/volume/drivers/vmware/volumeops.py
+++ b/cinder/volume/drivers/vmware/volumeops.py
@@ -984,6 +984,20 @@ class VMwareVolumeOps(object):
                                         self._session.vim, datastore,
                                         'summary')
 
+    def get_datastore_properties(self, datastore):
+        """Get datastore summary.
+
+        :param datastore: Reference to the datastore
+        :return: 'summary' property of the datastore
+        """
+        return self._session.invoke_api(vim_util, 'get_object_properties_dict',
+                                        self._session.vim, datastore,
+                                        properties_to_collect=[
+                                            "summary",
+                                            "availableField",
+                                            "customValue"
+                                        ])
+
     def _create_relocate_spec_disk_locator(self, datastore, disk_type,
                                            disk_device, profile_id=None):
         """Creates spec for disk type conversion during relocate."""


### PR DESCRIPTION
This patch tries to read any custom attributes associated with
each datastore and shove those attributes in the pool stats.
This will allow us to filter by custom attributes.

The end goal is to add a netapp backend fqdn custom attribute
so we know where each datastore lives.  This will allow cinder
to have affinity/anti-affinity to netapps.