### PR TITLE
Vmware: Remove nvp.vm-uuid extraConfig

### DIFF
--- a/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
@@ -2524,7 +2524,8 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
         vops.clone_backing.assert_called_once_with(
             tmp_name, instance, None, volumeops.FULL_CLONE_TYPE, datastore,
             host=host, resource_pool=rp, folder=folder,
-            device_changes=[dev_change_disk_remove])
+            device_changes=[dev_change_disk_remove],
+            extra_config={'nvp.vm-uuid': ''})
 
     @mock.patch.object(VMDK_DRIVER, '_get_disk_type')
     @mock.patch.object(VMDK_DRIVER, 'volumeops')

--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -2792,10 +2792,13 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         device_changes.extend(
             self.volumeops._create_device_change_for_vif_removal(instance))
 
+        # Remove another attribute by which the nova driver identifies VMs
+        extra_config = {'nvp.vm-uuid': ''}
+
         return self.volumeops.clone_backing(
             tmp_name, instance, None, volumeops.FULL_CLONE_TYPE, datastore,
             host=host, resource_pool=rp, folder=folder,
-            device_changes=device_changes)
+            device_changes=device_changes, extra_config=extra_config)
 
     def _extend_if_needed(self, volume, backing):
         volume_size = volume.size * units.Gi


### PR DESCRIPTION
The Nova vmwareapi driver falls back to the extraConfig
option value nvp.vm-uuid to identify vms, if it cannot
find VMs by the config.instanceUuid attribue.
A clone copies the attribute, so when nova retries
to delete a vm after initially succeeding,
it will find the backing with the same value instead
and delete it instead.