### PR TITLE
[SAP] Update allocated_capacity on potentially remote host

### DIFF
--- a/cinder/volume/rpcapi.py
+++ b/cinder/volume/rpcapi.py
@@ -307,6 +307,10 @@ class VolumeAPI(rpc.RPCAPI):
                    new_volume=new_volume,
                    volume_status=original_volume_status)
 
+    def update_migrated_volume_capacity(self, ctxt, volume):
+        cctxt = self._get_cctxt(volume.service_topic_queue)
+        cctxt.cast(ctxt, 'update_migrated_volume_capacity', volume=volume)
+
     def freeze_host(self, ctxt, service):
         """Set backend host to frozen."""
         cctxt = self._get_cctxt(service.service_topic_queue)


### PR DESCRIPTION
This patch calls a new RPCAPI to tell the new remote host
that it needs to update it's allocated_capacity_gb after a
volume migration is successful.

This ensures that migrating between 2 different cinder volume
services can update the allocated_capacity_gb after a migration
from one host to another.   This happens when a volume is moved
from one shard to another.