### PR TITLE
[vmware] Allow pulling images from Swift

### DIFF
--- a/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
@@ -108,6 +108,7 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
         self._config.vmware_select_random_best_datastore = False
         self._config.vmware_random_datastore_range = None
         self._config.vmware_datastores_as_pools = False
+        self._config.allow_pulling_images_from_url = False
 
         self._db = mock.Mock()
         self._driver = vmdk.VMwareVcVmdkDriver(configuration=self._config,
@@ -1253,7 +1254,8 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
             vm_folder=folder,
             vm_import_spec=import_spec,
             image_size=image_size,
-            http_method='POST')
+            http_method='POST',
+            allow_pull_from_url=False)
         if download_error:
             self.assertFalse(vops.update_backing_disk_uuid.called)
             vops.delete_backing.assert_called_once_with(backing)

--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -196,7 +196,15 @@ vmdk_opts = [
                 'This allows the cinder scheduler to pick which datastore '
                 'a volume lives on.  This also enables managing capacity '
                 'for each datastore by cinder.  '
-                )
+                ),
+    cfg.StrOpt('allow_pulling_images_from_url',
+               default=True,
+               help='Allow VMware to pull images directly from Swift. '
+               'By enabling this, images that are stored in Swift will be '
+               'downloaded by VMWare from the `direct_url`, instead of the '
+               'cinder-volume container having to proxy the image between '
+               'glance and VMware.'
+               ),
 ]
 
 CONF = cfg.CONF
@@ -1651,8 +1659,12 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
             timeout = self.configuration.vmware_image_transfer_timeout_secs
             host_ip = self.configuration.vmware_host_ip
             port = self.configuration.vmware_host_port
+            allow_url = self.configuration.allow_pulling_images_from_url
             LOG.debug("Fetching glance image: %(id)s to server: %(host)s.",
                       {'id': image_id, 'host': host_ip})
+            if allow_url:
+                LOG.debug("Downloading images directly from URL was enabled "
+                          "by `allow_pulling_images_from_url`")
             backing = image_transfer.download_stream_optimized_image(
                 context,
                 timeout,
@@ -1665,7 +1677,8 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                 vm_folder=folder,
                 vm_import_spec=vm_import_spec,
                 image_size=image_size,
-                http_method='POST')
+                http_method='POST',
+                allow_pull_from_url=allow_url)
             self.volumeops.update_backing_disk_uuid(backing, volume['id'])
         except (exceptions.VimException,
                 exceptions.VMwareDriverException):


### PR DESCRIPTION
oslo.vmware has a new option to pass the Swift direct_url of an
image to VMware for being downloaded directly from there, instead
of cinder-volume proxying between glance and VMware.

We can feature-toggle this on/off by controlling
`allow_pulling_images_from_url`

Depends on https://github.com/sapcc/oslo.vmware/pull/24