### PR TITLE
[SAP] fix the metadata for affinity/anti-affinity

### DIFF
--- a/cinder/volume/api.py
+++ b/cinder/volume/api.py
@@ -209,10 +209,16 @@ class API(base.Base):
                                                 metadata):
         if scheduler_hints:
             if 'same_host' in scheduler_hints:
-                hint = ','.join(scheduler_hints["same_host"])
+                if isinstance(scheduler_hints['same_host'], str):
+                    hint = scheduler_hints['same_host']
+                else:
+                    hint = ','.join(scheduler_hints["same_host"])
                 metadata["scheduler_hint_same_host"] = hint
             if "different_host" in scheduler_hints:
-                hint = ','.join(scheduler_hints["different_host"])
+                if isinstance(scheduler_hints['different_host'], str):
+                    hint = scheduler_hints["different_host"]
+                else:
+                    hint = ','.join(scheduler_hints["different_host"])
                 metadata["scheduler_hint_different_host"] = hint
         return metadata
 


### PR DESCRIPTION
This fixes a problem of storing the volume uuids in the metadata
{'scheduler_hint_same_host':
   'f,0,5,1,d,d,d,3,-,b,2,b,4,-,4,5,2,2,-,b,0,8,7,-,6,4,c,d,8,f,a,5,c,7,a,3'}