### PR TITLE
[SAP] Fix for allocated_capacity_gb not being updated

### DIFF
--- a/cinder/scheduler/manager.py
+++ b/cinder/scheduler/manager.py
@@ -357,13 +357,13 @@ class SchedulerManager(manager.CleanableManager, manager.Manager):
 
     @append_operation_type()
     def find_backend_for_connector(self, context, connector, request_spec,
-                                   filter_properties=None):
+                                   volume_size, filter_properties=None):
         self._wait_for_scheduler()
-
         backend = self.driver.find_backend_for_connector(context,
                                                          connector,
                                                          request_spec,
                                                          filter_properties)
+        backend.consume_from_volume({'size': volume_size})
         return {'host': backend.host,
                 'cluster_name': backend.cluster_name,
                 'capabilities': backend.capabilities}

--- a/cinder/scheduler/rpcapi.py
+++ b/cinder/scheduler/rpcapi.py
@@ -262,8 +262,9 @@ class SchedulerAPI(rpc.RPCAPI):
         return cctxt.call(context, 'get_log_levels', log_request=log_request)
 
     def find_backend_for_connector(self, context, connector, request_spec,
-                                   filter_properties=None):
+                                   volume_size, filter_properties=None):
         cctxt = self._get_cctxt()
         return cctxt.call(context, 'find_backend_for_connector',
                           connector=connector, request_spec=request_spec,
+                          volume_size=volume_size,
                           filter_properties=filter_properties)

--- a/cinder/tests/unit/scheduler/test_scheduler.py
+++ b/cinder/tests/unit/scheduler/test_scheduler.py
@@ -587,11 +587,13 @@ class SchedulerManagerTestCase(test.TestCase):
     def test_find_backend_for_connector(self, _mock_find_backend_for_conector):
         connector = mock.Mock()
         request_spec = mock.Mock()
+        volume_size = mock.Mock()
         backend_ret = mock.Mock(host='fake-host',
                                 cluster_name='fake-cluster', capabilities=[])
         _mock_find_backend_for_conector.return_value = backend_ret
         ret = self.manager.find_backend_for_connector(self.context,
-                                                      connector, request_spec)
+                                                      connector, request_spec,
+                                                      volume_size)
         _mock_find_backend_for_conector.assert_called_once_with(
             self.context, connector, request_spec, None)
         self.assertEqual(ret, {

--- a/cinder/volume/api.py
+++ b/cinder/volume/api.py
@@ -863,7 +863,7 @@ class API(base.Base):
 
         try:
             dest = self.scheduler_rpcapi.find_backend_for_connector(
-                ctxt, connector, request_spec,
+                ctxt, connector, request_spec, volume.size,
                 filter_properties=filter_properties)
         except exception.NoValidBackend:
             LOG.error("The connector was rejected by the backend. Could not "

--- a/cinder/volume/manager.py
+++ b/cinder/volume/manager.py
@@ -2500,6 +2500,14 @@ class VolumeManager(manager.CleanableManager,
         if not force_host_copy and new_type_id is None:
             try:
                 LOG.debug("Issue driver.migrate_volume.", resource=volume)
+                # Update the remote host's allocated_capacity_gb first
+                # Because the migration can take a while, and the scheduler
+                # needs to account for the space consumed.
+                LOG.debug("Update remote allocated_capacity_gb for "
+                          "host %(host)s",
+                          {'host': volume.host},
+                          resource=volume)
+                rpcapi.update_migrated_volume_capacity(ctxt, volume)
                 moved, model_update = self.driver.migrate_volume(ctxt,
                                                                  volume,
                                                                  host)
@@ -2521,12 +2529,13 @@ class VolumeManager(manager.CleanableManager,
                     volume.save()
                     self._update_allocated_capacity(volume, decrement=True,
                                                     host=original_host)
-                    LOG.debug("Update remote allocated_capacity_gb for "
-                              "host %(host)s",
-                              {'host': volume.host},
-                              resource=volume)
-                    rpcapi.update_migrated_volume_capacity(ctxt, volume)
             except Exception:
+                LOG.debug("Decrement remote allocated_capacity_gb for "
+                          "host %(host)s",
+                          {'host': volume.host},
+                          resource=volume)
+                rpcapi.update_migrated_volume_capacity(ctxt, volume,
+                                                       decrement=True)
                 with excutils.save_and_reraise_exception():
                     updates = {'migration_status': 'error'}
                     if status_update:
@@ -2536,15 +2545,21 @@ class VolumeManager(manager.CleanableManager,
         if not moved:
             try:
                 original_host = volume.host
-                self._migrate_volume_generic(ctxt, volume, host, new_type_id)
-                self._update_allocated_capacity(volume, decrement=True,
-                                                host=original_host)
                 LOG.debug("Update remote allocated_capacity_gb for "
                           "host %(host)s",
                           {'host': volume.host},
                           resource=volume)
                 rpcapi.update_migrated_volume_capacity(ctxt, volume)
+                self._migrate_volume_generic(ctxt, volume, host, new_type_id)
+                self._update_allocated_capacity(volume, decrement=True,
+                                                host=original_host)
             except Exception:
+                LOG.debug("Decrement remote allocated_capacity_gb for "
+                          "host %(host)s",
+                          {'host': volume.host},
+                          resource=volume)
+                rpcapi.update_migrated_volume_capacity(ctxt, volume,
+                                                       decrement=True)
                 with excutils.save_and_reraise_exception():
                     updates = {'migration_status': 'error'}
                     if status_update:
@@ -4132,9 +4147,9 @@ class VolumeManager(manager.CleanableManager,
                                                 snapshots)
 
     @utils.trace
-    def update_migrated_volume_capacity(self, ctxt, volume):
-        """Update allocated_capacity_gb for the new migrated volume host."""
-        self._update_allocated_capacity(volume)
+    def update_migrated_volume_capacity(self, ctxt, volume, decrement=False):
+        """Update allocated_capacity_gb for the migrated volume host."""
+        self._update_allocated_capacity(volume, decrement=decrement)
 
     def update_migrated_volume(self, ctxt, volume, new_volume, volume_status):
         """Finalize migration process on backend device."""

--- a/cinder/volume/rpcapi.py
+++ b/cinder/volume/rpcapi.py
@@ -307,9 +307,11 @@ class VolumeAPI(rpc.RPCAPI):
                    new_volume=new_volume,
                    volume_status=original_volume_status)
 
-    def update_migrated_volume_capacity(self, ctxt, volume):
+    def update_migrated_volume_capacity(self, ctxt, volume, decrement=False):
         cctxt = self._get_cctxt(volume.service_topic_queue)
-        cctxt.cast(ctxt, 'update_migrated_volume_capacity', volume=volume)
+        cctxt.cast(ctxt, 'update_migrated_volume_capacity',
+                   volume=volume,
+                   decrement=decrement)
 
     def freeze_host(self, ctxt, service):
         """Set backend host to frozen."""


### PR DESCRIPTION
This patch puts a fix in for the scheduler's copy of the
backend/pool's allocated_capacity_gb while doing a migrate
by connected.

This patch also reorders the RPC call to update the
allocated_capacity_gb inside the volume manager's migrate_volume call.

This will ensure:
1) The scheduler's copy of allocated_capacity_gb for a backend/pool is
updated for a migrate_by_connector in between the volume manager's
get_volume_stats() calls.

2) after the volume manager calls get_volume_stats on a driver the
allocated_capacity_gb has been updated from the last migration.

These issues were discovered by an overprovisioning of a few datastores
in eu-de-2, when a customer created 10+ volumes quickly and attached all
of them to a VM.  The volumes were all created on 1 shard, and then due
to the attach call, they were all migrated to the shard where the nova
vm lived, all within a short period of time.