### PR TITLE
[SAP] Added pool_state tracking. Updated backend_state

### DIFF
--- a/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
@@ -202,15 +202,20 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
                                        "storage_profile": "Gold"}}
         return result(), datastores
 
+    @mock.patch('cinder.volume.drivers.vmware.datastore.'
+                'DatastoreSelector.is_datastore_usable')
     @mock.patch.object(VMDK_DRIVER, '_collect_backend_stats')
     @mock.patch.object(VMDK_DRIVER, 'session')
-    def test_get_volume_stats_pools(self, session, mock_stats):
+    def test_get_volume_stats_pools(self, session, mock_stats,
+                                    datastore_usable):
         fake_result, fake_datastore_profiles = self._fake_stats_result()
         mock_stats.return_value = (fake_result, fake_datastore_profiles)
+        datastore_usable.return_value = True
         self._config.vmware_datastores_as_pools = True
         self._driver = vmdk.VMwareVcVmdkDriver(configuration=self._config,
                                                additional_endpoints=[],
                                                db=self._db)
+        self._driver._ds_sel = mock.MagicMock()
 
         retr_result_mock = mock.Mock(spec=['objects'])
         retr_result_mock.objects = []
@@ -226,7 +231,8 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
         self.assertEqual(0, stats["pools"][0]['reserved_percentage'])
         self.assertEqual(9313, stats["pools"][0]['total_capacity_gb'])
         self.assertEqual(4657, stats["pools"][0]['free_capacity_gb'])
-        self.assertEqual('up', stats["pools"][0]['backend_state'])
+        self.assertEqual('up', stats["pools"][0]['pool_state'])
+        self.assertEqual('up', stats["backend_state"])
         self.assertFalse(stats["pools"][0]['Multiattach'])
         self.assertEqual(vmdk.LOCATION_DRIVER_NAME + ":fake-service",
                          stats['location_info'])

--- a/cinder/volume/drivers/vmware/datastore.py
+++ b/cinder/volume/drivers/vmware/datastore.py
@@ -158,6 +158,10 @@ class DatastoreSelector(object):
 
         return valid_hosts
 
+    def is_datastore_usable(self, summary):
+        return summary.accessible and not self._vops._in_maintenance(
+            summary)
+
     def _filter_datastores(self,
                            datastores,
                            size_bytes,
@@ -174,10 +178,6 @@ class DatastoreSelector(object):
             return (ds_type in DatastoreType.get_all_types() and
                     (hard_affinity_ds_types is None or
                      ds_type in hard_affinity_ds_types))
-
-        def _is_ds_usable(summary):
-            return summary.accessible and not self._vops._in_maintenance(
-                summary)
 
         valid_host_refs = valid_host_refs or []
         valid_hosts = [host_ref.value for host_ref in valid_host_refs]
@@ -207,7 +207,8 @@ class DatastoreSelector(object):
                     not _is_ds_accessible_to_valid_host(host_mounts)):
                 return False
 
-            return _is_valid_ds_type(summary) and _is_ds_usable(summary)
+            return (_is_valid_ds_type(summary) and
+                    self.is_datastore_usable(summary))
 
         datastores = {k: v for k, v in datastores.items()
                       if _is_ds_valid(k, v)}

--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -468,22 +468,30 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         max_over_subscription_ratio = self.configuration.safe_get(
             'max_over_subscription_ratio')
 
+        backend_state = 'up'
         data = {'volume_backend_name': backend_name,
                 'vendor_name': 'VMware',
                 'driver_version': self.VERSION,
                 'storage_protocol': 'vmdk',
                 'location_info': location_info,
+                'backend_state': backend_state,
                 }
 
         result, datastores = self._collect_backend_stats()
         connection_capabilities = self._get_connection_capabilities()
+        if not datastores:
+            backend_state = 'down'
+            data['backend_state'] = backend_state
         if self.configuration.vmware_datastores_as_pools:
             pools = []
             for ds_name in datastores:
                 datastore = datastores[ds_name]
                 summary = datastore["summary"]
 
-                pool_state = "up" if summary.accessible is True else "down"
+                pool_state = 'down'
+                if self.ds_sel.is_datastore_usable(summary):
+                    pool_state = 'up'
+
                 pool = {'pool_name': summary.name,
                         'total_capacity_gb': round(
                             summary.capacity / units.Gi),
@@ -498,9 +506,10 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                         'datastore_type': summary.type,
                         'location_url': summary.url,
                         'location_info': location_info,
-                        'backend_state': pool_state,
                         'storage_profile': datastore["storage_profile"],
                         'connection_capabilities': connection_capabilities,
+                        'backend_state': backend_state,
+                        'pool_state': pool_state
                         }
 
                 # Add any custom attributes associated with the datastore


### PR DESCRIPTION
This patch adds the ability to track if a datastore is available
to be used in get_volume_stats.  If a datastore is in maintenance
mode, then it can't accept volume provisioning requests.  So the
driver now marks the datastore/pool as 'down'.  When the datastore
comes back out of maintenance mode, then the pool_state is changed to
'up'.

Currently, Cinder doesn't have a built in mechanism for dealing with a
pool_state being down, but we can simulate it by adding an extra spec
setting in all volume types of pool_state='up'.  That way the
capability filter will filter out all pools that don't have that
capability coming from the driver.

This patch also changes where the backend_state is set so that
the scheduler can mark the service as down correctly.