### PR TITLE
[SAP] update the new remote host allocated_capacity_gb

### DIFF
--- a/cinder/volume/manager.py
+++ b/cinder/volume/manager.py
@@ -2505,9 +2505,10 @@ class VolumeManager(manager.CleanableManager,
                 # needs to account for the space consumed.
                 LOG.debug("Update remote allocated_capacity_gb for "
                           "host %(host)s",
-                          {'host': volume.host},
+                          {'host': host},
                           resource=volume)
-                rpcapi.update_migrated_volume_capacity(ctxt, volume)
+                rpcapi.update_migrated_volume_capacity(ctxt, volume,
+                                                       host=host['host'])
                 moved, model_update = self.driver.migrate_volume(ctxt,
                                                                  volume,
                                                                  host)
@@ -2532,9 +2533,10 @@ class VolumeManager(manager.CleanableManager,
             except Exception:
                 LOG.debug("Decrement remote allocated_capacity_gb for "
                           "host %(host)s",
-                          {'host': volume.host},
+                          {'host': host['host']},
                           resource=volume)
                 rpcapi.update_migrated_volume_capacity(ctxt, volume,
+                                                       host=host['host'],
                                                        decrement=True)
                 with excutils.save_and_reraise_exception():
                     updates = {'migration_status': 'error'}
@@ -2549,16 +2551,18 @@ class VolumeManager(manager.CleanableManager,
                           "host %(host)s",
                           {'host': volume.host},
                           resource=volume)
-                rpcapi.update_migrated_volume_capacity(ctxt, volume)
+                rpcapi.update_migrated_volume_capacity(ctxt, volume,
+                                                       host=host['host'])
                 self._migrate_volume_generic(ctxt, volume, host, new_type_id)
                 self._update_allocated_capacity(volume, decrement=True,
                                                 host=original_host)
             except Exception:
                 LOG.debug("Decrement remote allocated_capacity_gb for "
                           "host %(host)s",
-                          {'host': volume.host},
+                          {'host': host['host']},
                           resource=volume)
                 rpcapi.update_migrated_volume_capacity(ctxt, volume,
+                                                       host=host['host'],
                                                        decrement=True)
                 with excutils.save_and_reraise_exception():
                     updates = {'migration_status': 'error'}
@@ -4147,9 +4151,10 @@ class VolumeManager(manager.CleanableManager,
                                                 snapshots)
 
     @utils.trace
-    def update_migrated_volume_capacity(self, ctxt, volume, decrement=False):
+    def update_migrated_volume_capacity(self, ctxt, volume, host=None,
+                                        decrement=False):
         """Update allocated_capacity_gb for the migrated volume host."""
-        self._update_allocated_capacity(volume, decrement=decrement)
+        self._update_allocated_capacity(volume, host=host, decrement=decrement)
 
     def update_migrated_volume(self, ctxt, volume, new_volume, volume_status):
         """Finalize migration process on backend device."""

--- a/cinder/volume/rpcapi.py
+++ b/cinder/volume/rpcapi.py
@@ -307,10 +307,12 @@ class VolumeAPI(rpc.RPCAPI):
                    new_volume=new_volume,
                    volume_status=original_volume_status)
 
-    def update_migrated_volume_capacity(self, ctxt, volume, decrement=False):
+    def update_migrated_volume_capacity(self, ctxt, volume, host=None,
+                                        decrement=False):
         cctxt = self._get_cctxt(volume.service_topic_queue)
         cctxt.cast(ctxt, 'update_migrated_volume_capacity',
                    volume=volume,
+                   host=host,
                    decrement=decrement)
 
     def freeze_host(self, ctxt, service):


### PR DESCRIPTION
This patch fixes a problem updated the allocated_capacity_gb
for the destination cinder host during volume migration.

We recently made a change to when we update the allocated_capacity_gb
during volume migration, which allowed an over allocation.  The
remove rpc call to update the destination host was moved to before
the call to migrate the volume to ensure that the scheduler had updated
stats for the destination, since the migration can take a long time.

The problem with this move is that the volume host entry wasn't updated
at the time of the call to update the remote destination host.  The
update was being called on the source host, so there was effectively
no change since the src and destination host was the same during both
calls to update_allocated_capacity_gb.  This patch fixes that.

Added a host entry to the rpc call to force the update on that
particular host value.