### PR TITLE
Migrate the volume if resize can't happen on current host

### DIFF
--- a/cinder/scheduler/manager.py
+++ b/cinder/scheduler/manager.py
@@ -48,6 +48,7 @@ from cinder import rpc
 from cinder.scheduler.flows import create_volume
 from cinder.scheduler import rpcapi as scheduler_rpcapi
 from cinder.volume import rpcapi as volume_rpcapi
+from cinder.volume import volume_utils
 
 
 scheduler_manager_opts = [
@@ -471,15 +472,56 @@ class SchedulerManager(manager.CleanableManager, manager.Manager):
                 {'size': new_size - volume.size})
             volume_rpcapi.VolumeAPI().extend_volume(context, volume, new_size,
                                                     reservations)
-        except exception.NoValidBackend as ex:
-            QUOTAS.rollback(context, reservations,
-                            project_id=volume.project_id)
-            _extend_volume_set_error(self, context, ex, request_spec)
-            self.message_api.create(
-                context,
-                message_field.Action.EXTEND_VOLUME,
-                resource_uuid=volume.id,
-                exception=ex)
+        except exception.NoValidBackend:
+            try:
+                self._extend_migrate(context, volume, new_size, request_spec,
+                                     filter_properties, reservations)
+            except exception.NoValidBackend as ex:
+                QUOTAS.rollback(context, reservations,
+                                project_id=volume.project_id)
+                _extend_volume_set_error(self, context, ex, request_spec)
+                self.message_api.create(
+                    context,
+                    message_field.Action.EXTEND_VOLUME,
+                    resource_uuid=volume.id,
+                    exception=ex)
+
+    def _extend_migrate(self, context, volume, new_size, request_spec,
+                        filter_properties, reservations):
+
+        if volume.consistencygroup_id or volume.group_id:
+            raise exception.NoValidBackend(
+                reason='The volume is in a group and cannot be migrated.')
+
+        scheduler_hints = \
+            volume_utils.get_scheduler_hints_from_volume(volume)
+        filter_properties.update(scheduler_hints)
+        filter_properties.pop('new_size')
+
+        if not request_spec:
+            request_spec = {'volume_properties': {'size': new_size}}
+        else:
+            request_spec['volume_properties']['size'] = new_size
+
+        if volume['availability_zone']:
+            request_spec['resource_properties'] = {
+                'availability_zone': volume['availability_zone']}
+
+        # SAP
+        # We have to force the destination host to be on
+        # the same backend, or it might get migrated
+        # to another vcenter.
+        backend = volume_utils.extract_host(volume['host'])
+
+        backend_state = self.driver.backend_passes_filters(
+            context, backend, request_spec, filter_properties)
+
+        backend_state.consume_from_volume(volume)
+
+        volume_rpcapi.VolumeAPI().migrate_volume(
+            context, volume, backend_state,
+            force_host_copy=False, wait_for_completion=False,
+            extend_spec={'new_size': new_size, 'reservations': reservations})
 
     def _set_volume_state_and_notify(self, method, updates, context, ex,
                                      request_spec, msg=None):

--- a/cinder/tests/unit/scheduler/test_scheduler.py
+++ b/cinder/tests/unit/scheduler/test_scheduler.py
@@ -211,9 +211,11 @@ class SchedulerManagerTestCase(test.TestCase):
                                          mock_backend_passes):
         volume = fake_volume.fake_volume_obj(self.context,
                                              **{'size': 1,
+                                                'host': 'fake_host',
                                                 'previous_status': status})
         no_valid_backend = exception.NoValidBackend(reason='')
-        mock_backend_passes.side_effect = [no_valid_backend]
+        mock_backend_passes.side_effect = [no_valid_backend,
+                                           no_valid_backend]
 
         with mock.patch.object(self.manager,
                                '_set_volume_state_and_notify') as mock_notify:
@@ -232,6 +234,28 @@ class SchedulerManagerTestCase(test.TestCase):
                 message_field.Action.EXTEND_VOLUME,
                 resource_uuid=volume.id,
                 exception=no_valid_backend)
+
+    @ddt.data('available', 'in-use')
+    @mock.patch('cinder.volume.rpcapi.VolumeAPI.migrate_volume')
+    @mock.patch('cinder.scheduler.driver.Scheduler.backend_passes_filters')
+    def test_extend_volume_migrate_in_group(self,
+                                            status,
+                                            mock_backend_passes,
+                                            mock_migrate):
+        volume = fake_volume.fake_volume_obj(self.context,
+                                             **{'size': 1,
+                                                'group_id': fake.GROUP_ID,
+                                                'previous_status': status})
+        no_valid_backend = exception.NoValidBackend(reason='')
+        mock_backend_passes.side_effect = [no_valid_backend]
+
+        with mock.patch.object(self.manager,
+                               '_set_volume_state_and_notify') as mock_notify:
+            self.manager.extend_volume(self.context, volume, 2,
+                                       'fake_reservation')
+            posargs = mock_notify.call_args[0]
+            self.assertIsInstance(posargs[3], exception.NoValidBackend)
+            mock_migrate.assert_not_called()
 
     @mock.patch('cinder.quota.QuotaEngine.expire')
     def test_clean_expired_reservation(self, mock_clean):

--- a/cinder/tests/unit/volume/test_rpcapi.py
+++ b/cinder/tests/unit/volume/test_rpcapi.py
@@ -304,6 +304,7 @@ class VolumeRPCAPITestCase(test.RPCAPITestCase):
                            volume=self.fake_volume_obj,
                            dest_backend=dest_backend,
                            force_host_copy=True,
+                           extend_spec=None,
                            expected_kwargs_diff={
                                'host': {'host': 'fake_host',
                                         'cluster_name': 'cluster_name',

--- a/cinder/tests/unit/volume/test_volume_migration.py
+++ b/cinder/tests/unit/volume/test_volume_migration.py
@@ -85,7 +85,7 @@ class VolumeMigrationTestCase(base.BaseVolumeTestCase):
         super(VolumeMigrationTestCase, self).tearDown()
         self._clear_patch.stop()
 
-    def test_migrate_volume_driver(self):
+    def test_migrate_volume_driver(self, extend_spec=None):
         """Test volume migration done by driver."""
         # Mock driver and rpc functions
         self.mock_object(self.volume.driver, 'migrate_volume',
@@ -96,13 +96,23 @@ class VolumeMigrationTestCase(base.BaseVolumeTestCase):
                                            host=CONF.host,
                                            migration_status='migrating')
         host_obj = {'host': 'newhost', 'capabilities': {}}
-        self.volume.migrate_volume(self.context, volume, host_obj, False)
+        self.volume.migrate_volume(self.context, volume, host_obj, False,
+                                   extend_spec=extend_spec)
 
         # check volume properties
         volume = objects.Volume.get_by_id(context.get_admin_context(),
                                           volume.id)
         self.assertEqual('newhost', volume.host)
         self.assertEqual('success', volume.migration_status)
+
+    @mock.patch.object(volume_rpcapi.VolumeAPI, 'extend_volume')
+    def test_migrate_volume_driver_with_extend(self, fake_extend):
+        extend_spec = {'new_size': 10, 'reservations': 'fake-rsv'}
+        self.test_migrate_volume_driver(extend_spec=extend_spec)
+        self.assertTrue(fake_extend.called)
+        named_args = fake_extend.call_args[1]
+        self.assertEqual(10, named_args['new_size'])
+        self.assertEqual('fake-rsv', named_args['reservations'])
 
     def test_migrate_volume_driver_cross_az(self):
         """Test volume migration done by driver."""

--- a/cinder/volume/api.py
+++ b/cinder/volume/api.py
@@ -205,38 +205,6 @@ class API(base.Base):
             return False
         return specs.get('encryption', {}) is not {}
 
-    def _set_scheduler_hints_to_volume_metadata(self, scheduler_hints,
-                                                metadata):
-        if scheduler_hints:
-            if 'same_host' in scheduler_hints:
-                if isinstance(scheduler_hints['same_host'], str):
-                    hint = scheduler_hints['same_host']
-                else:
-                    hint = ','.join(scheduler_hints["same_host"])
-                metadata["scheduler_hint_same_host"] = hint
-            if "different_host" in scheduler_hints:
-                if isinstance(scheduler_hints['different_host'], str):
-                    hint = scheduler_hints["different_host"]
-                else:
-                    hint = ','.join(scheduler_hints["different_host"])
-                metadata["scheduler_hint_different_host"] = hint
-        return metadata
-
-    def _get_scheduler_hints_from_volume(self, volume):
-        filter_properties = {}
-        if "scheduler_hint_same_host" in volume.metadata:
-            LOG.debug("Found a scheduler_hint_same_host in volume %s",
-                      volume.metadata["scheduler_hint_same_host"])
-            hint = volume.metadata["scheduler_hint_same_host"]
-            filter_properties["same_host"] = hint.split(',')
-
-        if "scheduler_hint_different_host" in volume.metadata:
-            LOG.debug("Found a scheduler_hint_different_host in volume %s",
-                      volume.metadata["scheduler_hint_different_host"])
-            hint = volume.metadata["scheduler_hint_different_host"]
-            filter_properties["different_host"] = hint.split(',')
-        return filter_properties
-
     def create(self, context, size, name, description, snapshot=None,
                image_id=None, volume_type=None, metadata=None,
                availability_zone=None, source_volume=None,
@@ -334,7 +302,7 @@ class API(base.Base):
         if not metadata:
             metadata = {}
 
-        metadata = self._set_scheduler_hints_to_volume_metadata(
+        metadata = volume_utils.set_scheduler_hints_to_volume_metadata(
             scheduler_hints,
             metadata
         )
@@ -859,7 +827,8 @@ class API(base.Base):
             'volume_id': volume.id}
 
         # Check if there is an affinity/antiaffinity against the volume
-        filter_properties = self._get_scheduler_hints_from_volume(volume)
+        filter_properties = \
+            volume_utils.get_scheduler_hints_from_volume(volume)
 
         try:
             dest = self.scheduler_rpcapi.find_backend_for_connector(
@@ -1699,7 +1668,7 @@ class API(base.Base):
             raise exception.InvalidVolume(reason=msg)
 
         # Check if there is an affinity/antiaffinity against the volume
-        filter_props = self._get_scheduler_hints_from_volume(volume)
+        filter_props = volume_utils.get_scheduler_hints_from_volume(volume)
 
         # Call the scheduler to ensure that the host exists and that it can
         # accept the volume

--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -2952,7 +2952,8 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         """
 
         false_ret = (False, None)
-        allowed_statuses = ['available', 'reserved', 'in-use', 'maintenance']
+        allowed_statuses = ['available', 'reserved', 'in-use', 'maintenance',
+                            'extending']
         if volume['status'] not in allowed_statuses:
             LOG.debug('Only %s volumes can be migrated using backend '
                       'assisted migration. Falling back to generic migration.',

--- a/cinder/volume/rpcapi.py
+++ b/cinder/volume/rpcapi.py
@@ -258,7 +258,7 @@ class VolumeAPI(rpc.RPCAPI):
                    reservations=reservations)
 
     def migrate_volume(self, ctxt, volume, dest_backend, force_host_copy,
-                       wait_for_completion=False):
+                       wait_for_completion=False, extend_spec=None):
         backend_p = {'host': dest_backend.host,
                      'cluster_name': dest_backend.cluster_name,
                      'capabilities': dest_backend.capabilities}
@@ -271,7 +271,8 @@ class VolumeAPI(rpc.RPCAPI):
         cctxt = self._get_cctxt(volume.service_topic_queue, version)
         method = 'call' if wait_for_completion else 'cast'
         getattr(cctxt, method)(ctxt, 'migrate_volume', volume=volume,
-                               host=backend_p, force_host_copy=force_host_copy)
+                               host=backend_p, force_host_copy=force_host_copy,
+                               extend_spec=extend_spec)
 
     def migrate_volume_completion(self, ctxt, volume, new_volume, error):
         cctxt = self._get_cctxt(volume.service_topic_queue)

--- a/cinder/volume/volume_utils.py
+++ b/cinder/volume/volume_utils.py
@@ -1248,3 +1248,37 @@ def resolve_hostname(hostname):
     LOG.debug('Asked to resolve hostname %(host)s and got IP %(ip)s.',
               {'host': hostname, 'ip': ip})
     return ip
+
+
+def get_scheduler_hints_from_volume(volume):
+    filter_properties = {}
+    if "scheduler_hint_same_host" in volume.metadata:
+        LOG.debug("Found a scheduler_hint_same_host in volume %s",
+                  volume.metadata["scheduler_hint_same_host"])
+        hint = volume.metadata["scheduler_hint_same_host"]
+        filter_properties["same_host"] = hint.split(',')
+
+    if "scheduler_hint_different_host" in volume.metadata:
+        LOG.debug("Found a scheduler_hint_different_host in volume %s",
+                  volume.metadata["scheduler_hint_different_host"])
+        hint = volume.metadata["scheduler_hint_different_host"]
+        filter_properties["different_host"] = hint.split(',')
+    return filter_properties
+
+
+def set_scheduler_hints_to_volume_metadata(scheduler_hints,
+                                           metadata):
+    if scheduler_hints:
+        if 'same_host' in scheduler_hints:
+            if isinstance(scheduler_hints['same_host'], str):
+                hint = scheduler_hints['same_host']
+            else:
+                hint = ','.join(scheduler_hints["same_host"])
+            metadata["scheduler_hint_same_host"] = hint
+        if "different_host" in scheduler_hints:
+            if isinstance(scheduler_hints['different_host'], str):
+                hint = scheduler_hints["different_host"]
+            else:
+                hint = ','.join(scheduler_hints["different_host"])
+            metadata["scheduler_hint_different_host"] = hint
+    return metadata


### PR DESCRIPTION
If the new size of a volume isn't accepted by the host
it will be rescheduled and migrated to another one.
Volumes that are in a group cannot be rescheduled because
migration to another host is not possible in that case.