### PR TITLE
[SAP] Add new recount_host_stats API

### DIFF
--- a/cinder/api/contrib/services.py
+++ b/cinder/api/contrib/services.py
@@ -154,6 +154,15 @@ class ServiceController(wsgi.Controller):
                                cluster_name, body.get('backend_id'))
         return webob.Response(status_int=http_client.ACCEPTED)
 
+    @validation.schema(os_services.recount_host_stats)
+    def _recount_host_stats(self, req, context, body):
+        """Ask the volume manager to recount allocated capacity for host."""
+        cluster_name, host = common.get_cluster_host(req, body,
+                                                     mv.REPLICATION_CLUSTER)
+        self._volume_api_proxy(self.volume_api.recount_host_stats, context,
+                               host)
+        return webob.Response(status_int=http_client.ACCEPTED)
+
     def _log_params_binaries_services(self, context, body):
         """Get binaries and services referred by given log set/get request."""
         query_filters = {'is_up': True}
@@ -274,6 +283,8 @@ class ServiceController(wsgi.Controller):
             return self._set_log(req, context, body=body)
         elif support_dynamic_log and id == 'get-log':
             return self._get_log(req, context, body=body)
+        elif id == "recount_host_stats":
+            return self._recount_host_stats(req, context, body=body)
         else:
             raise exception.InvalidInput(reason=_("Unknown action"))
 

--- a/cinder/api/schemas/services.py
+++ b/cinder/api/schemas/services.py
@@ -82,3 +82,12 @@ failover_host = {
     },
     'additionalProperties': False,
 }
+
+
+recount_host_stats = {
+    'type': 'object',
+    'properties': {
+        'host': parameter_types.hostname,
+    },
+    'additionalProperties': False,
+}

--- a/cinder/policies/services.py
+++ b/cinder/policies/services.py
@@ -23,6 +23,7 @@ UPDATE_POLICY = "volume_extension:services:update"
 FAILOVER_POLICY = "volume:failover_host"
 FREEZE_POLICY = "volume:freeze_host"
 THAW_POLICY = "volume:thaw_host"
+RECOUNT_STATS_POLICY = "volume:recount_host_stats"
 
 services_policies = [
     policy.DocumentedRuleDefault(
@@ -74,6 +75,16 @@ services_policies = [
             {
                 'method': 'PUT',
                 'path': '/os-services/failover_host'
+            }
+        ]),
+    policy.DocumentedRuleDefault(
+        name=RECOUNT_STATS_POLICY,
+        check_str=base.RULE_ADMIN_API,
+        description="Recount host stats allocated capacity",
+        operations=[
+            {
+                'method': 'PUT',
+                'path': '/os-services/recount_host_stats'
             }
         ]),
 ]

--- a/cinder/tests/unit/volume/test_volume.py
+++ b/cinder/tests/unit/volume/test_volume.py
@@ -1460,7 +1460,8 @@ class VolumeTestCase(base.BaseVolumeTestCase):
 
         # locked
         self.volume.delete_volume(self.context, dst_vol)
-        mock_lock.assert_called_with('%s-delete_volume' % dst_vol.id)
+        mock_lock.assert_any_call('%s-delete_volume' % dst_vol.id)
+        mock_lock.assert_any_call('volume-stats')
 
         # locked
         self.volume.delete_snapshot(self.context, snapshot_obj)
@@ -1468,7 +1469,8 @@ class VolumeTestCase(base.BaseVolumeTestCase):
 
         # locked
         self.volume.delete_volume(self.context, src_vol)
-        mock_lock.assert_called_with('%s-delete_volume' % src_vol.id)
+        mock_lock.assert_any_call('%s-delete_volume' % src_vol.id)
+        mock_lock.assert_any_call('volume-stats')
 
         self.assertTrue(mock_lvm_create.called)
 
@@ -1513,11 +1515,12 @@ class VolumeTestCase(base.BaseVolumeTestCase):
 
         # locked
         self.volume.delete_volume(self.context, dst_vol)
-        mock_lock.assert_called_with('%s-delete_volume' % dst_vol_id)
+        mock_lock.assert_any_call('%s-delete_volume' % dst_vol_id)
+        mock_lock.assert_any_call('volume-stats')
 
         # locked
         self.volume.delete_volume(self.context, src_vol)
-        mock_lock.assert_called_with('%s-delete_volume' % src_vol_id)
+        mock_lock.assert_any_call('%s-delete_volume' % src_vol_id)
 
     def _raise_metadata_copy_failure(self, method, dst_vol):
         # MetadataCopyFailure exception will be raised if DB service is Down

--- a/cinder/volume/api.py
+++ b/cinder/volume/api.py
@@ -2143,6 +2143,11 @@ class API(base.Base):
         if not self.volume_rpcapi.thaw_host(ctxt, services[0]):
             return "Backend reported error during thaw_host operation."
 
+    def recount_host_stats(self, ctxt, host):
+        ctxt.authorize(svr_policy.RECOUNT_STATS_POLICY)
+        ctxt = ctxt if ctxt.is_admin else ctxt.elevated()
+        self.volume_rpcapi.recount_host_stats(ctxt, host)
+
     def check_volume_filters(self, filters, strict=False):
         """Sets the user filter value to accepted format"""
         booleans = self.db.get_booleans_for_table('volume')

--- a/cinder/volume/rpcapi.py
+++ b/cinder/volume/rpcapi.py
@@ -135,6 +135,7 @@ class VolumeAPI(rpc.RPCAPI):
         3.15 - Add revert_to_snapshot method
         3.16 - Add no_snapshots to accept_transfer method
         3.17 - Make get_backup_device a cast (async)
+        3.17 - SAP - Added recount_host_stats (async)
     """
 
     RPC_API_VERSION = '3.17'
@@ -158,6 +159,11 @@ class VolumeAPI(rpc.RPCAPI):
             kwargs['server'] = server
 
         return super(VolumeAPI, self)._get_cctxt(version=version, **kwargs)
+
+    @rpc.assert_min_rpc_version('3.17')
+    def recount_host_stats(self, ctxt, host):
+        cctxt = self._get_cctxt(host=host)
+        cctxt.cast(ctxt, 'recount_host_stats')
 
     def create_volume(self, ctxt, volume, request_spec, filter_properties,
                       allow_reschedule=True):


### PR DESCRIPTION
This patch adds a custom API to force
the volume manager to recount all of it's volumes.
This enables us to update the allocated capacity for a running
cinder service.

This patch has a shared lock with the _report_driver_status call as well
so if the recount_host_volumes is working, then the driver stats won't
get reported until it is complete.