### PR TITLE
[SAP] Fix misnamed StorageMigrationFailed call

### DIFF
--- a/cinder/volume/drivers/vmware/volumeops.py
+++ b/cinder/volume/drivers/vmware/volumeops.py
@@ -1148,7 +1148,7 @@ class VMwareVolumeOps(object):
                       'ds': ds_val, 'rp': rp_val})
         except Exception as e:
             LOG.error("Relocation of main vmdk: %s failed.", vmdk_path)
-            raise vmdk_exceptions.StorageMigratonFailed(e)
+            raise vmdk_exceptions.StorageMigrationFailed(e)
         finally:
             rename_vm(ownervm, original_name)
 


### PR DESCRIPTION
This patch fixes a misspelled name of a vmware exception
from
StorageMigratonFailed to
StorageMigrationFailed