### PR TITLE
[SAP] Mark a pool as down if overcommited

### DIFF
--- a/cinder/scheduler/filters/sap_pool_down_filter.py
+++ b/cinder/scheduler/filters/sap_pool_down_filter.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2020 SAP SE
+#
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from oslo_log import log as logging
+
+from cinder.scheduler import filters
+
+
+LOG = logging.getLogger(__name__)
+
+
+class SAPPoolDownFilter(filters.BaseBackendFilter):
+    """Filter out pools that are not marked 'up'."""
+
+    def backend_passes(self, backend_state, filter_properties):
+
+        if backend_state.pool_state == 'up':
+            return True
+        else:
+            LOG.debug("%(id)s pool state is not 'up'. state='%(state)s'",
+                      {'id': backend_state.backend_id,
+                       'state': backend_state.pool_state})
+            return False

--- a/cinder/scheduler/host_manager.py
+++ b/cinder/scheduler/host_manager.py
@@ -389,6 +389,7 @@ class PoolState(BackendState):
                     capability, CONF.max_over_subscription_ratio))
 
             self.multiattach = capability.get('multiattach', False)
+            self.pool_state = capability.get('pool_state', 'up')
 
     def update_pools(self, capability):
         # Do nothing, since we don't have pools within pool, yet

--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -39,6 +39,7 @@ from oslo_vmware import image_transfer
 from oslo_vmware import pbm
 from oslo_vmware import vim_util
 
+from cinder import context
 from cinder import exception
 from cinder.i18n import _
 from cinder.image import image_utils
@@ -328,7 +329,9 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
     # 3.4.2.99.2 - Added soft sharding volume migration, fixed a small issue
     #          in check_for_setup_error where storage_profile not set.
     # 3.4.2.99.3 - Add support for reporting each datastore as a pool.
-    VERSION = '3.4.2.99.3'
+    # 3.4.2.99.4 - Default to thick provisioning and report provisioning type
+    #              based on the volume type extra specs if possible.
+    VERSION = '3.4.2.99.4'
 
     # ThirdPartySystems wiki page
     CI_WIKI_NAME = "VMware_CI"
@@ -358,6 +361,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         ])
         self._remote_api = remote_api.VmdkDriverRemoteApi()
         self._storage_profiles = []
+        self._volume_type_by_backend = None
 
     @staticmethod
     def get_driver_options():
@@ -460,10 +464,40 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
 
         return (result, {})
 
+    def _get_volume_type_by_backend_name(self, backend_name):
+        if not self._volume_type_by_backend:
+            self._volume_type_by_backend = {}
+            ctxt = context.get_admin_context()
+            all_types = volume_types.get_all_types(ctxt)
+            for v_type_name, v_type in all_types.items():
+                specs = v_type['extra_specs']
+                if 'volume_backend_name' in specs:
+                    self._volume_type_by_backend[backend_name] = v_type
+
+        return self._volume_type_by_backend.get(backend_name, None)
+
     def _get_volume_stats(self):
         backend_name = self.configuration.safe_get('volume_backend_name')
         if not backend_name:
             backend_name = self.__class__.__name__
+
+        # Force the reporting of provisioning support based
+        # on the volume type setting
+        v_type_provisioning_type = 'thick'
+
+        # Volume type matches for this backend
+        v_type = self._get_volume_type_by_backend_name(backend_name)
+        if v_type and v_type.get('extra_specs', None):
+            extra_specs = v_type.get('extra_specs')
+            v_type_provisioning_type = extra_specs.get('provisioning:type',
+                                                       'thin')
+
+        if v_type_provisioning_type == 'thin':
+            thin_provisioning_on = True
+            thick_provisioning_on = False
+        else:
+            thin_provisioning_on = False
+            thick_provisioning_on = True
 
         location_info = '%(driver_name)s:%(vcenter)s' % {
             'driver_name': LOCATION_DRIVER_NAME,
@@ -501,8 +535,8 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                             summary.capacity / units.Gi),
                         'free_capacity_gb': round(
                             summary.freeSpace / units.Gi),
-                        'thin_provisioning_support': True,
-                        'thick_provisioning_support': True,
+                        'thin_provisioning_support': thin_provisioning_on,
+                        'thick_provisioning_support': thick_provisioning_on,
                         'max_over_subscription_ratio': (
                             max_over_subscription_ratio),
                         'reserved_percentage': reserved_percentage,

--- a/cinder/volume/manager.py
+++ b/cinder/volume/manager.py
@@ -2677,6 +2677,69 @@ class VolumeManager(manager.CleanableManager,
                 # queue it to be sent to the Schedulers.
                 self.update_service_capabilities(volume_stats)
 
+    def _set_pool_state(self, pool):
+        """Check the pool stats to decide if the pool should be down.
+
+        When a pool is overcommited already, the pool should not be
+        available to accept new volumes, so we mark the pool down.
+        """
+        # Lets see if we should mark the pool as down
+        # if we are overcommited over the allowed amount
+        thin = pool.get('thin_provisioning_support', None)
+        thick = pool.get('thick_provisioning_support', None)
+        if not thin and not thick:
+            return
+
+        if thin:
+            max_over_subscription_ratio = pool.get(
+                'max_over_subscription_ratio',
+                self.configuration.max_over_subscription_ratio
+            )
+            thin_factors = utils.calculate_capacity_factors(
+                pool['total_capacity_gb'],
+                pool['free_capacity_gb'],
+                pool['allocated_capacity_gb'],
+                True,
+                max_over_subscription_ratio,
+                pool['reserved_percentage'],
+                True
+            )
+            if thin_factors['virtual_free_capacity'] <= 0:
+                # The pool has no free space left or has been
+                # overcommited past what is allowed.
+                LOG.error("Pool(%(pool_name)s is overcommited!!",
+                          {'pool_name': pool['pool_name']})
+                pool['pool_state'] = 'down'
+                pool['pool_state_reason'] = (
+                    'Volume manager marked pool down for being'
+                    ' allocated beyond what is allowed for thin'
+                    ' provisioning.'
+                )
+        else:
+            # Thick provisioning won't allow max oversub
+            # So we force it to 1:1
+            max_oversubscription_ratio = 1
+            thick_factors = utils.calculate_capacity_factors(
+                pool['total_capacity_gb'],
+                pool['free_capacity_gb'],
+                pool['allocated_capacity_gb'],
+                False,
+                max_oversubscription_ratio,
+                pool['reserved_percentage'],
+                False
+            )
+            if thick_factors['virtual_free_capacity'] <= 0:
+                # The pool has no free space left or has been
+                # overcommited past what is allowed.
+                LOG.error("Pool(%(pool_name)s is overcommited!!",
+                          {'pool_name': pool['pool_name']})
+                pool['pool_state'] = 'down'
+                pool['pool_state_reason'] = (
+                    'Volume manager marked pool down for being'
+                    ' allocated beyond what is allowed for thick'
+                    ' provisioning'
+                )
+
     @coordination.synchronized('volume-stats')
     def _append_volume_stats(self, vol_stats):
         pools = vol_stats.get('pools', None)
@@ -2691,6 +2754,8 @@ class VolumeManager(manager.CleanableManager,
                         pool_stats = dict(allocated_capacity_gb=0)
 
                     pool.update(pool_stats)
+                    self._set_pool_state(pool)
+
             else:
                 raise exception.ProgrammingError(
                     reason='Pools stats reported by the driver are not '

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ cinder.scheduler.filters =
     SAPLargeVolumeFilter = cinder.scheduler.filters.sap_large_volume_filter:SAPLargeVolumeFilter
     SAPDifferentBackendFilter = cinder.scheduler.filters.sap_affinity_filter:SAPDifferentBackendFilter
     SAPSameBackendFilter = cinder.scheduler.filters.sap_affinity_filter:SAPSameBackendFilter
+    SAPPoolDownFilter = cinder.scheduler.filters.sap_pool_down_filter:SAPPoolDownFilter
 cinder.scheduler.weights =
     AllocatedCapacityWeigher = cinder.scheduler.weights.capacity:AllocatedCapacityWeigher
     CapacityWeigher = cinder.scheduler.weights.capacity:CapacityWeigher


### PR DESCRIPTION
This patch will check the capacity factors of a pool and check it's virtual_free_capacity left every time the volume manager gets the volume stats from the backend.  If the virtual_free_capacity is <= 0 then the pool is overcommited and will be marked down.

The new SAPPoolDownFilter will check against this pool_state and if it's down, then filter the pool out of results for the scheduler.

This patch also updates the vmware driver to properly report the thin/thick capability depending on the volume type's provisioning:type setting.  This is used to determine the proper capacity factors for the provisioning type.