### PR TITLE
[SAP] Fix multiattach reporting for vmdk

### DIFF
--- a/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
@@ -233,7 +233,7 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
         self.assertEqual(4657, stats["pools"][0]['free_capacity_gb'])
         self.assertEqual('up', stats["pools"][0]['pool_state'])
         self.assertEqual('up', stats["backend_state"])
-        self.assertFalse(stats["pools"][0]['Multiattach'])
+        self.assertFalse(stats["pools"][0]['multiattach'])
         self.assertEqual(vmdk.LOCATION_DRIVER_NAME + ":fake-service",
                          stats['location_info'])
 

--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -502,7 +502,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                         'max_over_subscription_ratio': (
                             max_over_subscription_ratio),
                         'reserved_percentage': reserved_percentage,
-                        'Multiattach': False,
+                        'multiattach': False,
                         'datastore_type': summary.type,
                         'location_url': summary.url,
                         'location_info': location_info,


### PR DESCRIPTION
This patch fixes the reporting of multiattach capability in the
vmdk driver.   Multiattach -> multiattach