### PR TITLE
[SAP] Add ability to disable updating provider_info

### DIFF
--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -197,6 +197,10 @@ vmdk_opts = [
                 'a volume lives on.  This also enables managing capacity '
                 'for each datastore by cinder.  '
                 ),
+    cfg.BoolOpt('vmware_sap_update_provider_info',
+                default=False,
+                help='This prevents the driver from traversing all volumes '
+                'associated with a backend to ensure the pool is correct'),
     cfg.StrOpt('allow_pulling_images_from_url',
                default=True,
                help='Allow VMware to pull images directly from Swift. '
@@ -2503,6 +2507,10 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         We don't care about snapshots, they just use the volume's provider_id.
         """
         LOG.info("HOST {} : volumes {}".format(self.host, len(volumes)))
+        if not self.configuration.vmware_sap_update_provider_info:
+            LOG.info("Not updating provider information")
+            return [], None
+
         if self.configuration.vmware_datastores_as_pools:
             LOG.info("vmware_datastores_as_pools is enabled. "
                      "Checking host entries for volumes and snapshots.")


### PR DESCRIPTION
This patch defaults to disabling the ability to go through every single volume and ensure the pool is set correctly. This was initially needed in the transition from aggregate info to datastores as pools.  This is not really needed now. It will eventually get moved to a utility.

EU-DE-1 / VC-b-0 takes 5 minutes to go through 4500 volumes at startup and was causing liveliness probe to repeatedly kill the pod because the driver hadn't finished going through all volumes.