### PR TITLE
[SAP] Fix rpc call to remote host to update host capacity

### DIFF
--- a/cinder/volume/manager.py
+++ b/cinder/volume/manager.py
@@ -2517,7 +2517,7 @@ class VolumeManager(manager.CleanableManager,
                 # needs to account for the space consumed.
                 LOG.debug("Update remote allocated_capacity_gb for "
                           "host %(host)s",
-                          {'host': host},
+                          {'host': host['host']},
                           resource=volume)
                 rpcapi.update_migrated_volume_capacity(ctxt, volume,
                                                        host=host['host'])
@@ -4166,7 +4166,7 @@ class VolumeManager(manager.CleanableManager,
                                                 snapshots)
 
     @utils.trace
-    def update_migrated_volume_capacity(self, ctxt, volume, host=None,
+    def update_migrated_volume_capacity(self, ctxt, volume, host,
                                         decrement=False):
         """Update allocated_capacity_gb for the migrated volume host."""
         self._update_allocated_capacity(volume, host=host, decrement=decrement)

--- a/cinder/volume/rpcapi.py
+++ b/cinder/volume/rpcapi.py
@@ -314,9 +314,9 @@ class VolumeAPI(rpc.RPCAPI):
                    new_volume=new_volume,
                    volume_status=original_volume_status)
 
-    def update_migrated_volume_capacity(self, ctxt, volume, host=None,
+    def update_migrated_volume_capacity(self, ctxt, volume, host,
                                         decrement=False):
-        cctxt = self._get_cctxt(volume.service_topic_queue)
+        cctxt = self._get_cctxt(host)
         cctxt.cast(ctxt, 'update_migrated_volume_capacity',
                    volume=volume,
                    host=host,


### PR DESCRIPTION
This patch fixes a problem with the volume
rcpapi.update_migrate_volume_capacity()
It was always pulling the remote host to call from the volume.service_topic_queue, which is always the current host entry, not the new host that the volume is migrating to.  This is how we were getting overcommited against remote datastores during volume attachments inducing a migration to another vcenter.  The remote wasn't actually getting called to update it's allocated_capacity_gb.