### PR TITLE
[SAP] fix default max_oversubscription_ratio to float

### DIFF
--- a/cinder/volume/manager.py
+++ b/cinder/volume/manager.py
@@ -2727,7 +2727,7 @@ class VolumeManager(manager.CleanableManager,
         if thin:
             max_over_subscription_ratio = pool.get(
                 'max_over_subscription_ratio',
-                self.configuration.max_over_subscription_ratio
+                float(self.configuration.max_over_subscription_ratio)
             )
             thin_factors = utils.calculate_capacity_factors(
                 pool['total_capacity_gb'],


### PR DESCRIPTION
When the pool stats are pulled from the volume driver and the max oversubscription ratio isn't set yet, the max oversubscription ratio comes from the default config setting, which is a string.  Have to force that to a float when using it for calculations.