### PR TITLE
[SAP] fix default max_oversubscription_ratio to float

### DIFF
--- a/cinder/volume/manager.py
+++ b/cinder/volume/manager.py
@@ -2734,7 +2734,7 @@ class VolumeManager(manager.CleanableManager,
                 pool['free_capacity_gb'],
                 pool['allocated_capacity_gb'],
                 True,
-                max_over_subscription_ratio,
+                float(max_over_subscription_ratio),
                 pool['reserved_percentage'],
                 True
             )


### PR DESCRIPTION
When the pool stats are pulled from the volume driver and the max oversubscription ratio is a string, the volume manager has to force the value to a float.