### PR TITLE
[SAP] Add context to the volume-stats tooz lock

### DIFF
--- a/cinder/tests/unit/volume/test_volume.py
+++ b/cinder/tests/unit/volume/test_volume.py
@@ -1461,7 +1461,7 @@ class VolumeTestCase(base.BaseVolumeTestCase):
         # locked
         self.volume.delete_volume(self.context, dst_vol)
         mock_lock.assert_any_call('%s-delete_volume' % dst_vol.id)
-        mock_lock.assert_any_call('volume-stats')
+        mock_lock.assert_any_call('volume-stats-%s' % self.volume.host)
 
         # locked
         self.volume.delete_snapshot(self.context, snapshot_obj)
@@ -1470,7 +1470,7 @@ class VolumeTestCase(base.BaseVolumeTestCase):
         # locked
         self.volume.delete_volume(self.context, src_vol)
         mock_lock.assert_any_call('%s-delete_volume' % src_vol.id)
-        mock_lock.assert_any_call('volume-stats')
+        mock_lock.assert_any_call('volume-stats-%s' % self.volume.host)
 
         self.assertTrue(mock_lvm_create.called)
 
@@ -1516,7 +1516,7 @@ class VolumeTestCase(base.BaseVolumeTestCase):
         # locked
         self.volume.delete_volume(self.context, dst_vol)
         mock_lock.assert_any_call('%s-delete_volume' % dst_vol_id)
-        mock_lock.assert_any_call('volume-stats')
+        mock_lock.assert_any_call('volume-stats-%s' % self.volume.host)
 
         # locked
         self.volume.delete_volume(self.context, src_vol)

--- a/cinder/volume/manager.py
+++ b/cinder/volume/manager.py
@@ -514,7 +514,7 @@ class VolumeManager(manager.CleanableManager,
     def recount_host_stats(self, context):
         self._count_host_stats(context, export_volumes=False)
 
-    @coordination.synchronized('volume-stats')
+    @coordination.synchronized('volume-stats-{self.host}')
     def _count_host_stats(self, context, export_volumes=False):
         """Recount the number of volumes and allocated capacity."""
         ctxt = context.elevated()
@@ -2774,7 +2774,7 @@ class VolumeManager(manager.CleanableManager,
                     ' provisioning'
                 )
 
-    @coordination.synchronized('volume-stats')
+    @coordination.synchronized('volume-stats-{self.host}')
     def _append_volume_stats(self, vol_stats):
         pools = vol_stats.get('pools', None)
         if pools:


### PR DESCRIPTION
This patch adds the cinder host name to the lock for collecting volume-stats to ensure the lock is contextual only inside each host volume process.  This will prevent other hosts for waiting for the same lock when they don't need to.