### PR TITLE
[SAP] catch TemplateNotFoundException during delete

### DIFF
--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -1290,7 +1290,13 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
             raise exception.InvalidSnapshot(reason=msg)
         else:
             if is_template:
-                self._delete_snapshot_template_format(snapshot)
+                try:
+                    self._delete_snapshot_template_format(snapshot)
+                except vmdk_exceptions.TemplateNotFoundException:
+                    # Just raise a warning and move on like the snap
+                    # was deleted.  If it's not there, it's already gone.
+                    LOG.warning("Failed to find template for snapshot %s",
+                                snapshot.id)
             else:
                 self.volumeops.delete_snapshot(backing, snapshot.name)
 


### PR DESCRIPTION
This patch adds an exception catch around the call to delete a snapshot template.  If the template isn't found, then most likely it was never created, so 'delete' can be successful.