### PR TITLE
[WIP] [SAP] set the correct vmdk_size when restoring backups

### DIFF
--- a/cinder/backup/chunkeddriver.py
+++ b/cinder/backup/chunkeddriver.py
@@ -781,6 +781,16 @@ class BackupRestoreHandle(object):
         return
 
     def finish_restore(self):
+        # SAP
+        # hacking into VmdkWriteHandle to set the correct file size.
+        # VMDKs are stream optimized, being smaller than the actual
+        # volume. Setting the correct vmdk_size in VmdkWriteHandle
+        # allows it to properly validate the upload progress,
+        # otherwise the restore would fail with 'incomplete transfer'.
+        if hasattr(self._volume_file, '_vmdk_size'):
+            file_size = sum([s.length for s in self._segments])
+            self._volume_file._vmdk_size = file_size
+
         for segment in self._segments:
             LOG.debug('restoring object. backup: %(backup_id)s, '
                       'container: %(container)s, object name: '


### PR DESCRIPTION
VMDKs are stream optimized, having different size than the actual volume. We have to set the correct vmdk_size to VmdkWriteHandle so that it can validate the upload progress correctly.