### PR TITLE
[SAP] Fix the shard filter for group creation

### DIFF
--- a/cinder/group/api.py
+++ b/cinder/group/api.py
@@ -245,7 +245,10 @@ class API(base.Base):
         # 'volume_properties' as scheduler's filter logic are all designed
         # based on this attribute.
         kwargs = {'group_id': group.id,
-                  'volume_properties': objects.VolumeProperties(size=size)}
+                  'volume_properties': objects.VolumeProperties(
+                      size=size,
+                      project_id=group.project_id
+                  )}
 
         if not group.host or not self.scheduler_rpcapi.validate_host_capacity(
                 context, group.host, objects.RequestSpec(**kwargs)):


### PR DESCRIPTION
Temptest tests found a bug in the shard filter where creating a cinder group from an existing group or group snapshot always failed with not finding any hosts.  This is due to the shard filter not getting much of any information about the request.

This patch adds the project_id of the group being created to ensure that the shard filter can work properly.