### PR TITLE
[SAP] Allow snapshots to be independent

### DIFF
--- a/cinder/api/common.py
+++ b/cinder/api/common.py
@@ -55,6 +55,8 @@ ATTRIBUTE_CONVERTERS = {'name~': 'display_name~',
 
 METADATA_TYPES = enum.Enum('METADATA_TYPES', 'user image')
 
+SAP_HIDDEN_METADATA_KEY = "__cinder_internal"
+
 
 def get_pagination_params(params, max_limit=None):
     """Return marker, limit, offset tuple from request.

--- a/cinder/api/views/snapshots.py
+++ b/cinder/api/views/snapshots.py
@@ -39,6 +39,12 @@ class ViewBuilder(common.ViewBuilder):
         """Generic, non-detailed view of a snapshot."""
         if isinstance(snapshot.metadata, dict):
             metadata = snapshot.metadata
+            # SAP we don't show the backend here because it's
+            # custom for our deployment with independent snaps
+            # for the vmware vmdk driver
+            for key in metadata:
+                if key.startswith(common.SAP_HIDDEN_METADATA_KEY):
+                    del metadata[key]
         else:
             metadata = {}
 

--- a/cinder/objects/snapshot.py
+++ b/cinder/objects/snapshot.py
@@ -16,6 +16,7 @@ from oslo_config import cfg
 from oslo_utils import versionutils
 from oslo_versionedobjects import fields
 
+from cinder.api import common
 from cinder import db
 from cinder import exception
 from cinder.i18n import _
@@ -27,6 +28,8 @@ from cinder.volume import volume_types
 
 
 CONF = cfg.CONF
+
+SAP_HIDDEN_BACKEND_KEY = common.SAP_HIDDEN_METADATA_KEY + "_backend"
 
 
 @base.CinderObjectRegistry.register

--- a/cinder/scheduler/manager.py
+++ b/cinder/scheduler/manager.py
@@ -43,6 +43,7 @@ from cinder.message import api as mess_api
 from cinder.message import message_field
 from cinder import objects
 from cinder.objects import fields
+from cinder.objects import snapshot as snapshot_obj
 from cinder import quota
 from cinder import rpc
 from cinder.scheduler.flows import create_volume
@@ -61,6 +62,10 @@ scheduler_manager_opts = [
                min=1,
                help='Maximum time in seconds to wait for the driver to '
                     'report as ready'),
+    cfg.BoolOpt('sap_allow_independent_snapshots',
+                default=False,
+                help='Allow cinder to schedule snapshot creations on pools '
+                     'other than the source volume pool.'),
 ]
 
 CONF = cfg.CONF
@@ -237,19 +242,33 @@ class SchedulerManager(manager.CleanableManager, manager.Manager):
         """
         self._wait_for_scheduler()
 
+        if CONF.sap_allow_independent_snapshots:
+            # We allow snapshots to be created on a pool
+            # separate from the volume's pool.
+            backend = volume_utils.extract_host(volume['host'])
+
         try:
             tgt_backend = self.driver.backend_passes_filters(
                 ctxt, backend, request_spec, filter_properties)
             tgt_backend.consume_from_volume(
                 {'size': request_spec['volume_properties']['size']})
+            LOG.info("Snapshot picked backend_id is '%s'",
+                     tgt_backend.backend_id)
         except exception.NoValidBackend as ex:
             self._set_snapshot_state_and_notify('create_snapshot',
                                                 snapshot,
                                                 fields.SnapshotStatus.ERROR,
                                                 ctxt, ex, request_spec)
         else:
-            volume_rpcapi.VolumeAPI().create_snapshot(ctxt, volume,
-                                                      snapshot)
+            if CONF.sap_allow_independent_snapshots:
+                # Set this in the metadata of the snap
+                key = snapshot_obj.SAP_HIDDEN_BACKEND_KEY
+                if snapshot.metadata:
+                    snapshot.metadata[key] = tgt_backend.backend_id
+                else:
+                    snapshot.metadata = {key: tgt_backend.backend_id}
+                snapshot.save()
+            volume_rpcapi.VolumeAPI().create_snapshot(ctxt, volume, snapshot)
 
     def _do_cleanup(self, ctxt, vo_resource):
         # We can only receive cleanup requests for volumes, but we check anyway

--- a/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
@@ -389,7 +389,8 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
                 'name': name,
                 'display_description': description,
                 'volume_size': volume['size'],
-                'provider_location': provider_location
+                'provider_location': provider_location,
+                'metadata': {},
                 }
 
     @mock.patch.object(VMDK_DRIVER, 'volumeops')
@@ -536,7 +537,7 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
         vops.get_backing.assert_called_once_with(snapshot['volume_name'],
                                                  snapshot['volume']['id'])
         create_snapshot_template_format.assert_called_once_with(
-            snapshot, backing)
+            snapshot, backing, backend=None)
 
     @mock.patch.object(VMDK_DRIVER, 'volumeops')
     def test_get_template_by_inv_path(self, vops):

--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -44,6 +44,7 @@ from cinder import exception
 from cinder.i18n import _
 from cinder.image import image_utils
 from cinder import interface
+from cinder.objects import snapshot as snapshot_obj
 from cinder import utils
 from cinder.volume import configuration
 from cinder.volume import driver
@@ -1185,10 +1186,21 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         return self._get_volume_group_folder(
             dc, volume.project_id, snapshot=True)
 
-    def _create_snapshot_template_format(self, snapshot, backing):
+    @utils.trace
+    def _create_snapshot_template_format(self, snapshot, backing,
+                                         backend=None):
         volume = snapshot.volume
         folder = self._get_snapshot_group_folder(volume, backing)
-        datastore = self.volumeops.get_datastore(backing)
+        if backend:
+            # Create the snapshot on the datastore described in
+            # backend making this snapshot independent from the volume
+            datastore_name = volume_utils.extract_host(backend, 'pool')
+            (host_ref,
+             resource_pool,
+             summary) = self.ds_sel.select_datastore_by_name(datastore_name)
+            datastore = summary.datastore
+        else:
+            datastore = self.volumeops.get_datastore(backing)
 
         if self._in_use(volume):
             tmp_backing = self._create_temp_backing_from_attached_vmdk(
@@ -1217,6 +1229,11 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
 
         :param snapshot: Snapshot object
         """
+        backend = None
+        key = snapshot_obj.SAP_HIDDEN_BACKEND_KEY
+        if ('metadata' in snapshot and snapshot['metadata'] and
+                key in snapshot['metadata']):
+            backend = snapshot['metadata'][key]
 
         volume = snapshot['volume']
         snapshot_format = self.configuration.vmware_snapshot_format
@@ -1239,7 +1256,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                                            snapshot['display_description'])
         else:
             model_update = self._create_snapshot_template_format(
-                snapshot, backing)
+                snapshot, backing, backend=backend)
 
         LOG.info("Successfully created snapshot: %s.", snapshot['name'])
         return model_update

--- a/cinder/volume/flows/api/create_volume.py
+++ b/cinder/volume/flows/api/create_volume.py
@@ -763,6 +763,14 @@ class VolumeCastTask(flow_utils.CinderTask):
             # service with the desired backend information.
             snapshot = objects.Snapshot.get_by_id(context, snapshot_id)
             request_spec['resource_backend'] = snapshot.volume.resource_backend
+            # SAP only force the same backend, not the same pool
+            # if we are allowing snapshots to live on pools other than
+            # the source volume.
+            if CONF.sap_allow_independent_snapshots:
+                backend = volume_utils.extract_host(
+                    snapshot.volume.resource_backend
+                )
+                request_spec['resource_backend'] = backend
         elif source_volid:
             source_volume_ref = objects.Volume.get_by_id(context, source_volid)
             request_spec['resource_backend'] = (


### PR DESCRIPTION
This patch allows a snapshot creation request go through the
scheduler to pick a pool for the snapshot to live on.
The backend picked by the scheduler is added to the snapshot
metadata.  This metadata field 'backend' is filtered out of
requests fetching the snapshot information, so end users will
never see it.

To enable this ability a new config option is added to the
scheduler and is defaulted to be False or disabled.

sap_allow_independent_snapshots

This allows creating a snapshot from a volume to happen on a
completely different pool than the source volume.

This patch also alters create volume from snapshot, to allow a volume
to be created from a different pool than the source volume that
the snapshot was created from.

All of this is not how upstream works or allows.