### PR TITLE
[SAP] Fix snapshot view filtering

### DIFF
--- a/cinder/api/views/snapshots.py
+++ b/cinder/api/views/snapshots.py
@@ -42,9 +42,10 @@ class ViewBuilder(common.ViewBuilder):
             # SAP we don't show the backend here because it's
             # custom for our deployment with independent snaps
             # for the vmware vmdk driver
-            for key in metadata:
-                if key.startswith(common.SAP_HIDDEN_METADATA_KEY):
-                    del metadata[key]
+            del_key = common.SAP_HIDDEN_METADATA_KEY
+            delete_keys = [key for key in metadata if key.startswith(del_key)]
+            for key in delete_keys:
+                del metadata[key]
         else:
             metadata = {}
 


### PR DESCRIPTION
This patch fixes an issue iterating over the metadata from the snapshot views API.  The code is supposed to filter out and remove the __cinder_internal keys in the metadata.  This patch looks for the keys to remove first and then deletes them instead of iterating over the metadata array and trying to delete them while iterating over the metadata, which causes a python exception.