### PR TITLE
Allow independent cloning of volumes

### DIFF
--- a/cinder/scheduler/manager.py
+++ b/cinder/scheduler/manager.py
@@ -66,6 +66,10 @@ scheduler_manager_opts = [
                 default=False,
                 help='Allow cinder to schedule snapshot creations on pools '
                      'other than the source volume pool.'),
+    cfg.BoolOpt('sap_allow_independent_clone',
+                default=False,
+                help='Allow cinder to schedule a clone volume on a pool '
+                     'other than the source volume pool.'),
 ]
 
 CONF = cfg.CONF

--- a/cinder/volume/flows/api/create_volume.py
+++ b/cinder/volume/flows/api/create_volume.py
@@ -773,8 +773,13 @@ class VolumeCastTask(flow_utils.CinderTask):
                 request_spec['resource_backend'] = backend
         elif source_volid:
             source_volume_ref = objects.Volume.get_by_id(context, source_volid)
-            request_spec['resource_backend'] = (
-                source_volume_ref.resource_backend)
+            if CONF.sap_allow_independent_clone:
+                backend = volume_utils.extract_host(
+                    source_volume_ref.resource_backend
+                )
+            else:
+                backend = source_volume_ref.resource_backend
+            request_spec['resource_backend'] = backend
 
         self.scheduler_rpcapi.create_volume(
             context,


### PR DESCRIPTION
This patch adds a new custom sap config option
SAP_allow_independent_clone

This patch allows a clone of a volume to be scheduled on a different pool than the source volume.