### PR TITLE
SAPCC: don't log in method called by eventlet.tpool.execute()

### DIFF
--- a/cinder/backup/chunkeddriver.py
+++ b/cinder/backup/chunkeddriver.py
@@ -876,7 +876,9 @@ class BackupRestoreHandle(object):
                 return
         self._object_readers[obj_name].close()
         del self._object_readers[obj_name]
-        LOG.debug("Cleared reader for object %s", segment.obj['name'])
+        # See hint about https://github.com/eventlet/eventlet/issues/432
+        # at the top why not to log here. May be fixed in oslo.log 5.0.1
+        # LOG.debug("Cleared reader for object %s", segment.obj['name'])
 
     def add_object(self, metadata_object):
         """Merges a backup chunk over the self._segments list.


### PR DESCRIPTION
fixes hanging thread due to
https://github.com/eventlet/eventlet/issues/432
which may get fixed for oslo.log in 5.0.1
with https://github.com/openstack/oslo.log/commit/94b9dc32ec1f52a582adbd97fe2847f7c87d6c17 (at the time of writing master in antelope cycle is constraint to 5.0.0)