### PR TITLE
Mark pool as down if datastore draining

### DIFF
--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -549,6 +549,19 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                                     alarm_info['info.description']
                                 )
 
+                # Add any custom attributes associated with the datastore
+                custom_attributes = {}
+                if "custom_attributes" in datastore:
+                    custom_attributes = datastore['custom_attributes']
+
+                    # A datastore can be marked as draining in vcenter
+                    # in which case we want to mark it down.
+                    if 'cinder_state' in custom_attributes:
+                        cinder_pool_state = custom_attributes['cinder_state']
+                        if cinder_pool_state.lower() == 'drain':
+                            pool_state = 'down'
+                            pool_down_reason = 'Datastore marked as draining'
+
                 pool = {'pool_name': summary.name,
                         'total_capacity_gb': round(
                             summary.capacity / units.Gi),
@@ -567,12 +580,9 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                         'connection_capabilities': connection_capabilities,
                         'backend_state': backend_state,
                         'pool_state': pool_state,
-                        'pool_down_reason': pool_down_reason
+                        'pool_down_reason': pool_down_reason,
+                        'custom_attributes': custom_attributes,
                         }
-
-                # Add any custom attributes associated with the datastore
-                if "custom_attributes" in datastore:
-                    pool['custom_attributes'] = datastore['custom_attributes']
 
                 pools.append(pool)
             data['pools'] = pools


### PR DESCRIPTION
This patch looks for a custom attribute 'cinder_state' on a datastore at get_volume_stats() time.  If the custom attribute value is 'drain', then the datastore is marked as 'draining' and cinder shouldn't use it for provisioning new requests.  The datastore will be marked as down in the pool stats for that datastore.