### PR TITLE
[SAP] Add action_track to format specific logs for easier debugging

### DIFF
--- a/cinder/action_track.py
+++ b/cinder/action_track.py
@@ -1,0 +1,200 @@
+# Copyright 2023 Openstack Foundation.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import abc
+import inspect
+import traceback
+
+import decorator
+from oslo_config import cfg
+from oslo_log import log as logging
+from oslo_utils import excutils
+
+from cinder import context as cinder_context
+
+
+CONF = cfg.CONF
+LOG = logging.getLogger(__name__)
+
+ACTION_VOLUME_CREATE = "volume_create"
+ACTION_VOLUME_DELETE = "volume_delete"
+ACTION_VOLUME_RESERVE = "volume_reserve"
+ACTION_VOLUME_ATTACH = "volume_attach"
+ACTION_VOLUME_EXTEND = "volume_extend"
+ACTION_VOLUME_DETACH = "volume_detach"
+ACTION_VOLUME_MIGRATE = "volume_migrate"
+ACTION_VOLUME_RETYPE = "volume_retype"
+ACTION_VOLUME_BACKUP = "volume_backup"
+ACTION_BACKUP_RESTORE = "volume_restore"
+ACTION_VOLUME_BACKUP_DELETE = "volume_backup_delete"
+ACTION_VOLUME_COPY_TO_IMAGE = "volume_copy_to_image"
+ACTION_VOLUME_BACKUP_RESET_STATUS = "volume_backup_reset_status"
+ACTION_SNAPSHOT_CREATE = "snapshot_create"
+ACTION_SNAPSHOT_DELETE = "snapshot_delete"
+
+
+VALID_RESOURCE_NAMES = [
+    'volume', 'backup', 'snapshot'
+]
+VALID_CONTEXT_NAMES = [
+    'context', 'ctxt'
+]
+
+log_level_map = {
+    logging.CRITICAL: LOG.error,
+    logging.ERROR: LOG.error,
+    logging.WARNING: LOG.warning,
+    logging.INFO: LOG.info,
+    logging.DEBUG: LOG.debug,
+}
+
+
+class ActionTrack(object, metaclass=abc.ABCMeta):
+    """Base class for the 'trace' api.
+
+    The purpose of this trace facility is to be able to
+    keep track of critical parts of operations against resources.
+    This will create a standardized object/log entry for troubleshooting
+    actions against resources.
+
+    This is not for performance tracing, but for action/operation tracking.
+    by default it will simply format a log entry such that the entries are
+    easy to find with a standard format and information.
+    """
+
+    @staticmethod
+    @abc.abstractmethod
+    def track(context, action, resource, message, loglevel=logging.INFO):
+        pass
+
+    @staticmethod
+    @abc.abstractmethod
+    def track_with_file_info(context, action, resource, message,
+                             filename, line_number, function,
+                             loglevel=logging.INFO):
+        pass
+
+
+class LogActionTrack(ActionTrack):
+    @staticmethod
+    def _track_with_info(context, action, resource, message,
+                         filename, line_number, function,
+                         loglevel=logging.INFO):
+        entry = f"ACTION:'{action}' "
+        if loglevel == logging.ERROR or loglevel == logging.CRITICAL:
+            # The action failed and this trace is the reason
+            entry += "FAILED "
+
+        msg = message.replace("\n", "")
+
+        entry += (
+            f"MSG:'{msg}' "
+            f"FILE:{filename}:{line_number}:{function} "
+            f"RSC:{resource} "
+        )
+        log_func = log_level_map[loglevel]
+        log_func(entry, resource=resource)
+
+    @staticmethod
+    def track(context, action, resource, message, loglevel=logging.INFO):
+        # Do not call this directly.   Call action_track.track() instead.
+
+        # We only want the frame of the caller
+        # we should always be called from the trace() method in this module
+        # not called directly in this static method
+        info = list(traceback.walk_stack(None))[1][0]
+        LogActionTrack._track_with_info(context, action, resource, message,
+                                        info.f_code.co_filename,
+                                        info.f_lineno,
+                                        info.f_code.co_name,
+                                        loglevel=loglevel)
+
+    @staticmethod
+    def track_with_file_info(context, action, resource, message,
+                             filename, line_number, function,
+                             loglevel=logging.INFO):
+        # Do not call this directly.
+        # Call action_track.track_with_file_info() instead.
+        LogActionTrack._track_with_info(
+            context, action, resource, message,
+            filename, line_number, function, loglevel=loglevel
+        )
+
+
+def track(context, action, resource, message, loglevel=logging.INFO):
+    """For now we only implement LogActionTrack.
+
+    TODO(waboring): add rabbitmq trace? to send entries to a msg queue
+    or add: DBtrace to send traces to the DB instead?
+    """
+    LogActionTrack.track(context, action, resource, message,
+                         loglevel=loglevel)
+
+
+def track_with_info(context, action, resource, message, file, line_number,
+                    function, loglevel=logging.INFO):
+    """For now we only implement LogActionTrack.
+
+    TODO(waboring): add rabbitmq trace? to send entries to a msg queue
+    or add: DBtrace to send traces to the DB instead?
+    """
+    LogActionTrack.track_with_file_info(context, action, resource, message,
+                                        file, line_number, function,
+                                        loglevel=loglevel)
+
+
+def track_decorator(action):
+    """Decorator to automatically handle exceptions raised as failures.
+
+       Place this decorator on a function that you want to mark as an
+       action failure and the action_track tracing will get called
+       for the action.
+
+       @track_decorator(action_track.ACTION_VOLUME_ATTACH)
+       def initialize_connection(....)
+       If initialize_connection raises an exception then you will get a
+       action_track.track called with action of ACTION_VOLUME_ATTACH
+       and a failure.
+
+    """
+    @decorator.decorator
+    def inner(func, *args, **kwargs):
+        # Find the context and the volume/backup object
+        resource = None
+        context = None
+        call_args = inspect.getcallargs(func, *args, **kwargs)
+        for key in call_args:
+            if key in VALID_RESOURCE_NAMES:
+                resource = call_args[key]
+            elif (key in VALID_CONTEXT_NAMES and
+                    isinstance(call_args[key], cinder_context.RequestContext)):
+                context = call_args[key]
+
+        track(context, action, resource, "called")
+
+        try:
+            return func(*args, **kwargs)
+        except Exception:
+            with excutils.save_and_reraise_exception() as exc:
+                # We only want the frame of the caller
+                tl = traceback.extract_tb(exc.tb)
+                i = tl[1]
+                message = str(exc.value)
+                track_with_info(
+                    context, action, resource, message,
+                    i.filename, i.lineno, i.name,
+                    loglevel=logging.ERROR
+                )
+    return inner

--- a/cinder/tests/unit/attachments/test_attachments_manager.py
+++ b/cinder/tests/unit/attachments/test_attachments_manager.py
@@ -243,12 +243,13 @@ class AttachmentManagerTestCase(test.TestCase):
         # does not have a connector will not call the driver and return None
         # if the force flag is False.
         attachment = mock.MagicMock(connector={})
+        volume = mock.MagicMock()
         with mock.patch.object(self.manager.driver, '_initialized',
                                create=True, new=True):
             with mock.patch.object(self.manager.driver,
                                    'terminate_connection') as term_conn:
                 has_shared_connection = self.manager._connection_terminate(
-                    self.context, mock.sentinel.volume, attachment)
+                    self.context, volume, attachment)
                 self.assertIsNone(has_shared_connection)
                 term_conn.assert_not_called()
 

--- a/cinder/tests/unit/volume/test_connection.py
+++ b/cinder/tests/unit/volume/test_connection.py
@@ -500,8 +500,9 @@ class VolumeAttachDetachTestCase(base.BaseVolumeTestCase):
                           self.context,
                           volume_id)
 
-    @mock.patch('cinder.volume.manager.LOG', mock.Mock())
-    def test_initialize_connection(self):
+    @mock.patch.object(cinder.action_track.LOG, "log")
+    @mock.patch.object(cinder.volume.manager.LOG, "log")
+    def test_initialize_connection(self, _mock_manager, _mock_track):
         volume = mock.Mock(save=mock.Mock(side_effect=Exception))
         with mock.patch.object(self.volume, 'driver') as driver_mock:
             self.assertRaises(exception.ExportFailure,

--- a/cinder/volume/api.py
+++ b/cinder/volume/api.py
@@ -28,6 +28,7 @@ from oslo_utils import strutils
 from oslo_utils import timeutils
 from oslo_utils import versionutils
 
+from cinder import action_track
 from cinder.api import common
 from cinder.common import constants
 from cinder import context
@@ -203,6 +204,7 @@ class API(base.Base):
             return False
         return specs.get('encryption', {}) is not {}
 
+    @action_track.track_decorator(action_track.ACTION_VOLUME_CREATE)
     def create(self, context, size, name, description, snapshot=None,
                image_id=None, volume_type=None, metadata=None,
                availability_zone=None, source_volume=None,
@@ -344,6 +346,10 @@ class API(base.Base):
                                                  create_what,
                                                  sched_rpcapi,
                                                  volume_rpcapi)
+            action_track.track(
+                context, action_track.ACTION_VOLUME_CREATE,
+                None, "taskflow get_flow() created"
+            )
         except Exception:
             msg = _('Failed to create api volume flow.')
             LOG.exception(msg)
@@ -361,8 +367,10 @@ class API(base.Base):
                 if flow_engine.storage.fetch('refresh_az'):
                     self.list_availability_zones(enable_cache=True,
                                                  refresh_cache=True)
-                LOG.info("Create volume request issued successfully.",
-                         resource=vref)
+                action_track.track(
+                    context, action_track.ACTION_VOLUME_CREATE,
+                    vref, "create volume request issued successfully"
+                )
                 return vref
             except exception.InvalidAvailabilityZone:
                 with excutils.save_and_reraise_exception():
@@ -696,6 +704,7 @@ class API(base.Base):
         LOG.info("Get all snapshots completed successfully.")
         return snapshots
 
+    @action_track.track_decorator(action_track.ACTION_VOLUME_RESERVE)
     def reserve_volume(self, context, volume):
         context.authorize(vol_action_policy.RESERVE_POLICY, target_obj=volume)
         expected = {'multiattach': volume.multiattach,
@@ -709,11 +718,12 @@ class API(base.Base):
             msg = _('Volume status must be %(expected)s to reserve, but the '
                     'status is %(current)s.') % {'expected': expected_status,
                                                  'current': volume.status}
-            LOG.error(msg)
             raise exception.InvalidVolume(reason=msg)
 
-        LOG.info("Reserve volume completed successfully.",
-                 resource=volume)
+        action_track.track(
+            context, action_track.ACTION_VOLUME_ATTACH,
+            volume, "Reserve volume completed successfully."
+        )
 
     def unreserve_volume(self, context, volume):
         context.authorize(vol_action_policy.UNRESERVE_POLICY,
@@ -763,6 +773,7 @@ class API(base.Base):
         LOG.info("Roll detaching of volume completed successfully.",
                  resource=volume)
 
+    @action_track.track_decorator(action_track.ACTION_VOLUME_ATTACH)
     def attach(self, context, volume, instance_uuid, host_name,
                mountpoint, mode):
         context.authorize(vol_action_policy.ATTACH_POLICY,
@@ -782,16 +793,23 @@ class API(base.Base):
             raise exception.InvalidVolumeAttachMode(mode=mode,
                                                     volume_id=volume.id)
 
+        action_track.track(
+            context, action_track.ACTION_VOLUME_ATTACH,
+            volume, "calling volume_rpc_api.attach_volume"
+        )
         attach_results = self.volume_rpcapi.attach_volume(context,
                                                           volume,
                                                           instance_uuid,
                                                           host_name,
                                                           mountpoint,
                                                           mode)
-        LOG.info("Attach volume completed successfully.",
-                 resource=volume)
+        action_track.track(
+            context, action_track.ACTION_VOLUME_ATTACH,
+            volume, "Attach volume completed successfully."
+        )
         return attach_results
 
+    @action_track.track_decorator(action_track.ACTION_VOLUME_DETACH)
     def detach(self, context, volume, attachment_id):
         context.authorize(vol_action_policy.DETACH_POLICY,
                           target_obj=volume)
@@ -806,6 +824,7 @@ class API(base.Base):
                  resource=volume)
         return detach_results
 
+    @action_track.track_decorator(action_track.ACTION_VOLUME_MIGRATE)
     def migrate_volume_by_connector(self, ctxt, volume, connector,
                                     lock_volume):
         if not connector:
@@ -829,9 +848,11 @@ class API(base.Base):
                 ctxt, connector, request_spec, volume.size,
                 filter_properties=filter_properties)
         except exception.NoValidBackend:
-            LOG.error("The connector was rejected by the backend. Could not "
-                      "find another backend compatible with the connector %s.",
-                      connector)
+            msg = ("The connector was rejected by the backend. Could not "
+                   "find another backend compatible with the connector %s.",
+                   connector)
+            action_track.track(ctxt, action_track.ACTION_VOLUME_MIGRATE,
+                               volume, msg, loglevel=logging.ERROR)
             return None
         backend = host_manager.BackendState(host=dest['host'],
                                             cluster_name=dest['cluster_name'],
@@ -866,6 +887,10 @@ class API(base.Base):
                   'maintenance')],
                 else_=volume.model.status)
 
+        action_track.track(
+            ctxt, action_track.ACTION_VOLUME_MIGRATE,
+            volume, "updating volume migration_status to 'starting'"
+        )
         result = volume.conditional_update(updates, expected, filters)
 
         if not result:
@@ -876,7 +901,10 @@ class API(base.Base):
             LOG.error(msg)
             raise exception.InvalidVolume(reason=msg)
 
-        LOG.debug("Invoking migrate_volume to host=%s", dest['host'])
+        action_track.track(
+            ctxt, action_track.ACTION_VOLUME_MIGRATE,
+            volume, f"calling volume_rpcapi.migrate_volume to {dest['host']}"
+        )
         self.volume_rpcapi.migrate_volume(ctxt, volume, backend,
                                           force_host_copy=False,
                                           wait_for_completion=False)
@@ -1149,8 +1177,10 @@ class API(base.Base):
         result = self._create_snapshot(context, volume, name, description,
                                        False, metadata, cgsnapshot_id,
                                        group_snapshot_id)
-        LOG.info("Snapshot create request issued successfully.",
-                 resource=result)
+        action_track.track(
+            context, action_track.ACTION_SNAPSHOT_CREATE,
+            result, "Snapshot create request issued successfully."
+        )
         return result
 
     def create_snapshot_force(self, context,
@@ -1158,8 +1188,10 @@ class API(base.Base):
                               description, metadata=None):
         result = self._create_snapshot(context, volume, name, description,
                                        True, metadata)
-        LOG.info("Snapshot force create request issued successfully.",
-                 resource=result)
+        action_track.track(
+            context, action_track.ACTION_SNAPSHOT_CREATE,
+            result, "Snapshot force create request issued successfully."
+        )
         return result
 
     def delete_snapshot(self, context, snapshot, force=False,
@@ -1190,8 +1222,10 @@ class API(base.Base):
             raise exception.InvalidSnapshot(reason=msg)
 
         self.volume_rpcapi.delete_snapshot(context, snapshot, unmanage_only)
-        LOG.info("Snapshot delete request issued successfully.",
-                 resource=snapshot)
+        action_track.track(
+            context, action_track.ACTION_SNAPSHOT_DELETE,
+            snapshot, "Snapshot delete request issued successfully."
+        )
 
     def update_snapshot(self, context, snapshot, fields):
         context.authorize(snapshot_policy.UPDATE_POLICY,
@@ -2220,6 +2254,10 @@ class API(base.Base):
         # NOTE(jdg): Reserved is a special case, we're avoiding allowing
         # creation of other new reserves/attachments while in this state
         # so we avoid contention issues with shared connections
+        action_track.track(
+            ctxt, action_track.ACTION_VOLUME_ATTACH,
+            vref, "called",
+        )
 
         # Multiattach of bootable volumes is a special case with it's own
         # policy, check that here right off the bat
@@ -2266,6 +2304,10 @@ class API(base.Base):
                        {'vol_id': vref.id,
                         'statuses': utils.build_or_str(expected['status']),
                         'current': vref.status})
+                action_track.track(
+                    ctxt, action_track.ACTION_VOLUME_ATTACH,
+                    vref, msg, loglevel=logging.ERROR
+                )
                 raise exception.InvalidVolume(reason=msg)
 
         values = {'volume_id': vref.id,
@@ -2273,6 +2315,10 @@ class API(base.Base):
                   'attach_status': 'reserved',
                   'instance_uuid': instance_uuid}
         db_ref = self.db.volume_attach(ctxt.elevated(), values)
+        action_track.track(
+            ctxt, action_track.ACTION_VOLUME_ATTACH,
+            vref, "attach_status changed to reserved",
+        )
         return objects.VolumeAttachment.get_by_id(ctxt, db_ref['id'])
 
     def attachment_create(self,
@@ -2284,6 +2330,10 @@ class API(base.Base):
         """Create an attachment record for the specified volume."""
         ctxt.authorize(attachment_policy.CREATE_POLICY, target_obj=volume_ref)
         connection_info = {}
+        action_track.track(
+            ctxt, action_track.ACTION_VOLUME_ATTACH,
+            volume_ref, "attachment_create called"
+        )
         if "error" in volume_ref.status:
             msg = ('Volume attachments can not be created if the volume '
                    'is in an error state. '
@@ -2291,13 +2341,20 @@ class API(base.Base):
                    '%(volume_status)s ') % {
                        'volume_id': volume_ref.id,
                        'volume_status': volume_ref.status}
-            LOG.error(msg)
+            action_track.track(
+                ctxt, action_track.ACTION_VOLUME_ATTACH,
+                volume_ref, msg, loglevel=logging.ERROR
+            )
             raise exception.InvalidVolume(reason=msg)
         attachment_ref = self._attachment_reserve(ctxt,
                                                   volume_ref,
                                                   instance_uuid)
         if connector:
             try:
+                action_track.track(
+                    ctxt, action_track.ACTION_VOLUME_ATTACH,
+                    volume_ref, "calling volume_rpc_api.attachment_update"
+                )
                 connection_info = (
                     self.volume_rpcapi.attachment_update(ctxt,
                                                          volume_ref,
@@ -2305,6 +2362,12 @@ class API(base.Base):
                                                          attachment_ref.id))
             except Exception:
                 with excutils.save_and_reraise_exception():
+                    action_track.track(
+                        ctxt, action_track.ACTION_VOLUME_ATTACH,
+                        volume_ref,
+                        "attachment_update failed, deleting attachment record",
+                        loglevel=logging.ERROR
+                    )
                     self.attachment_delete(ctxt, attachment_ref)
 
         attachment_ref.connection_info = connection_info
@@ -2326,6 +2389,10 @@ class API(base.Base):
             attachment_ref.attach_mode = attach_mode
 
         attachment_ref.save()
+        action_track.track(
+            ctxt, action_track.ACTION_VOLUME_ATTACH,
+            volume_ref, "attachment_create done"
+        )
         return attachment_ref
 
     @coordination.synchronized(
@@ -2348,6 +2415,10 @@ class API(base.Base):
         ctxt.authorize(attachment_policy.UPDATE_POLICY,
                        target_obj=attachment_ref)
         volume_ref = objects.Volume.get_by_id(ctxt, attachment_ref.volume_id)
+        action_track.track(
+            ctxt, action_track.ACTION_VOLUME_ATTACH,
+            volume_ref, "called"
+        )
         if "error" in volume_ref.status:
             msg = ('Volume attachments can not be updated if the volume '
                    'is in an error state. The Volume %(volume_id)s '
@@ -2355,6 +2426,10 @@ class API(base.Base):
                        'volume_id': volume_ref.id,
                        'volume_status': volume_ref.status}
             LOG.error(msg)
+            action_track.track(
+                ctxt, action_track.ACTION_VOLUME_ATTACH,
+                volume_ref, msg, loglevel=logging.ERROR
+            )
             raise exception.InvalidVolume(reason=msg)
 
         if (len(volume_ref.volume_attachment) > 1 and
@@ -2376,8 +2451,16 @@ class API(base.Base):
 
                 msg = _('duplicate connectors detected on volume '
                         '%(vol)s') % {'vol': volume_ref.id}
-
+                action_track.track(
+                    ctxt, action_track.ACTION_VOLUME_ATTACH,
+                    volume_ref, msg, loglevel=logging.ERROR
+                )
                 raise exception.InvalidVolume(reason=msg)
+
+        action_track.track(
+            ctxt, action_track.ACTION_VOLUME_ATTACH,
+            volume_ref, "calling volume_rpcapi.attachment_update"
+        )
         connection_info = (
             self.volume_rpcapi.attachment_update(ctxt,
                                                  volume_ref,
@@ -2385,12 +2468,20 @@ class API(base.Base):
                                                  attachment_ref.id))
         attachment_ref.connection_info = connection_info
         attachment_ref.save()
+        action_track.track(
+            ctxt, action_track.ACTION_VOLUME_ATTACH,
+            volume_ref, "Complete"
+        )
         return attachment_ref
 
     def attachment_delete(self, ctxt, attachment):
         ctxt.authorize(attachment_policy.DELETE_POLICY,
                        target_obj=attachment)
         volume = objects.Volume.get_by_id(ctxt, attachment.volume_id)
+        action_track.track(
+            ctxt, action_track.ACTION_VOLUME_DETACH,
+            volume, "called"
+        )
 
         if attachment.attach_status == fields.VolumeAttachStatus.RESERVED:
             volume_utils.notify_about_volume_usage(ctxt,
@@ -2398,6 +2489,10 @@ class API(base.Base):
         else:
             # Generate the detach.start notification on the volume service to
             # include the host doing the operation.
+            action_track.track(
+                ctxt, action_track.ACTION_VOLUME_DETACH,
+                volume, "call volume_rpcapi.attachment_delete"
+            )
             self.volume_rpcapi.attachment_delete(ctxt, attachment.id, volume)
 
         # Trigger attachments lazy load (missing since volume was loaded in the
@@ -2412,6 +2507,10 @@ class API(base.Base):
         # #1937084, and doing the notification there with the finish here leads
         # to bug #1916980.
         volume_utils.notify_about_volume_usage(ctxt, volume, "detach.end")
+        action_track.track(
+            ctxt, action_track.ACTION_VOLUME_DETACH,
+            volume, "Completed"
+        )
         return volume.volume_attachment
 
 


### PR DESCRIPTION
[SAP] Add action_track to format specific logs for easier debugging

This patch adds the new action_track for cinder.  The purpose of this
module is to add a track() method which can be used to log business
logic actions being taken on resources (volumes, snaps, etc) so we can
then use this action logs to discover our most common failures and help
debug/fix them.

For now the only supported output is sending the actions into the
standard cinder logfile.  But we could add another adapter in the
trace() method for sending the action logs to a rabbitmq queue, and/or
a db table directly.

This patch also adds calls throughout cinder code to track specific
actions against volumes, such as create, delete, attach, migrate