### PR TITLE
[SAP] Fix logging formats

### DIFF
--- a/cinder/volume/manager.py
+++ b/cinder/volume/manager.py
@@ -4881,7 +4881,7 @@ class VolumeManager(manager.CleanableManager,
         if async_call:
             # we have to use an rpc call back to the backup manager to
             # continue the backup
-            LOG.info("Calling backup continue_backup for: {}", backup)
+            LOG.info("Calling backup continue_backup for: %s", backup)
             rpcapi = backup_rpcapi.BackupAPI()
             rpcapi.continue_backup(ctxt, backup, backup_device)
         else:


### PR DESCRIPTION
This patch fixes some formats of strings and calls to LOG.  They were working in train, but started failing in Wallaby.

The old strings were LOG.debug("foo bar {}", something)

They are fixed to
LOG.debug("foo bar %s", something)