### PR TITLE
[SAP]Get ready for tox 4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,4 +17,5 @@ import setuptools
 
 setuptools.setup(
     setup_requires=['pbr>=2.0.0'],
+    py_modules=[],
     pbr=True)

--- a/tools/check_exec.py
+++ b/tools/check_exec.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain

--- a/tox.ini
+++ b/tox.ini
@@ -1,26 +1,32 @@
 [tox]
-minversion = 3.18.0
-requires = virtualenv>=20.4.2
-skipsdist = True
-# python runtimes: https://governance.openstack.org/tc/reference/project-testing-interface.html#tested-runtimes
-envlist = py3,compliance,pep8
+minversion = 4.0.0
+# specify virtualenv here to keep local runs consistent with the
+# gate (it sets the versions of pip, setuptools, and wheel)
+requires = virtualenv>=20.17.1
 # this allows tox to infer the base python from the environment name
 # and override any basepython configured in this file
 ignore_basepython_conflict=true
 
 [testenv]
 basepython = python3
-setenv = VIRTUAL_ENV={envdir}
-         PYTHONWARNINGS=default::DeprecationWarning
-         OS_STDOUT_CAPTURE=1
-         OS_STDERR_CAPTURE=1
-         OS_TEST_TIMEOUT=60
-         OS_TEST_PATH=./cinder/tests/unit
-usedevelop = True
-install_command=python -m pip install -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/sapcc/requirements/stable/wallaby-m3/upper-constraints.txt} {opts} {packages}
+usedevelop = true
+setenv =
+  VIRTUAL_ENV={envdir}
+  OS_STDOUT_CAPTURE=1
+  OS_STDERR_CAPTURE=1
+  OS_TEST_TIMEOUT=60
+  OS_TEST_PATH=./cinder/tests/unit
+   PYTHONDONTWRITEBYTECODE=1
+# TODO(stephenfin): Remove once we bump our upper-constraint to SQLAlchemy 2.0
+   SQLALCHEMY_WARN_20=1
 
-deps = -r{toxinidir}/test-requirements.txt
-        -r{toxinidir}/requirements.txt
+# this environment's install command is used if the 'minversion' or 'requires'
+# values declared above in the [tox] section require tox to update itself, so
+# we don't define a non-default install_command here
+
+deps =
+  -r{toxinidir}/test-requirements.txt
+  -r{toxinidir}/requirements.txt
 
 # By default stestr will set concurrency
 # to ncpu, to specify something else use
@@ -33,20 +39,27 @@ commands =
 
 allowlist_externals =
   find
-passenv = *_proxy *_PROXY
+passenv =
+  *_proxy
+  *_PROXY
 
-[testenv:api-ref]
-allowlist_externals = rm
-deps = {[testenv:docs]deps}
-commands =
-  rm -rf api-ref/build
-  sphinx-build -W -b html -d api-ref/build/doctrees api-ref/source api-ref/build/html/
-
-[testenv:releasenotes]
-deps = {[testenv:docs]deps}
-commands = sphinx-build -a -E -W -j auto -d releasenotes/build/doctrees -b html releasenotes/source releasenotes/build/html
+[testenv:py{3,36,38,39,310,311}]
+# NOTE: Do not move the constraints from the install_command into deps, as that
+#       may result in tox using unconstrained/untested dependencies.
+#       We use "usedevelop = True" for tox jobs (except bindep), so tox does 2
+#       install calls, one for the deps and another for the cinder source code
+#       as editable (pip -e).
+#       Without the constraints in the install_command only the first
+#       installation will honor the upper constraints, and the second install
+#       for cinder itself will not know about the constraints which can result
+#       in installing versions we don't want.
+#       With constraints in the install_command tox will always honor our
+#       constraints.
+install_command =
+  python -m pip install -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/sapcc/requirements/stable/wallaby-m3/upper-constraints.txt} {opts} {packages}
 
 [testenv:functional]
+install_command = {[testenv:py3]install_command}
 setenv =
   OS_TEST_PATH = ./cinder/tests/functional
 
@@ -59,6 +72,7 @@ setenv =
   {[testenv:functional]setenv}
 
 [testenv:api-samples]
+install_command = {[testenv:functional]install_command}
 envdir = {toxworkdir}/shared
 setenv =
   GENERATE_SAMPLES=True
@@ -69,10 +83,14 @@ commands =
   stestr slowest
 
 [testenv:compliance]
+install_command = {[testenv:py3]install_command}
 setenv =
   OS_TEST_PATH = ./cinder/tests/compliance
 
 [testenv:pep8]
+allowlist_externals =
+  {toxinidir}/tools/config/check_uptodate.sh
+  {toxinidir}/tools/check_exec.py
 commands =
   flake8 {posargs} .
   doc8
@@ -82,11 +100,15 @@ commands =
 [testenv:fast8]
 # Use same environment directory as pep8 env to save space and install time
 envdir = {toxworkdir}/pep8
+install_command = {[testenv:py3]install_command}
+allowlist_externals =
+  {toxinidir}/tools/fast8.sh
 commands =
   {toxinidir}/tools/fast8.sh
 passenv = FAST8_NUM_COMMITS
 
 [testenv:pylint]
+install_command = {[testenv:py3]install_command}
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
        pylint==2.6.0
@@ -96,6 +118,7 @@ commands =
 [testenv:cover]
 # Also do not run test_coverage_ext tests while gathering coverage as those
 # tests conflict with coverage.
+install_command = {[testenv:py3]install_command}
 setenv =
     {[testenv]setenv}
     PYTHON=coverage run --source cinder --parallel-mode
@@ -106,20 +129,27 @@ commands =
     coverage xml -o cover/coverage.xml
 
 [testenv:genconfig]
+install_command = {[testenv:py3]install_command}
 sitepackages = False
 envdir = {toxworkdir}/pep8
 commands = oslo-config-generator --config-file=tools/config/cinder-config-generator.conf
 
 
 [testenv:genpolicy]
+install_command = {[testenv:py3]install_command}
 commands = oslopolicy-sample-generator --config-file=tools/config/cinder-policy-generator.conf
 
 [testenv:genopts]
+install_command = {[testenv:py3]install_command}
 sitepackages = False
 envdir = {toxworkdir}/pep8
 commands = python tools/config/generate_cinder_opts.py
 
 [testenv:venv]
+install_command = {[testenv:py3]install_command}
+deps =
+  {[testenv]deps}
+  reno
 commands = {posargs}
 
 [testenv:docs]
@@ -132,6 +162,7 @@ commands =
 allowlist_externals = rm
 
 [testenv:pdf-docs]
+install_command = {[testenv:docs]install_command}
 deps = {[testenv:docs]deps}
 commands =
   rm -fr doc/source/contributor/api/
@@ -142,12 +173,27 @@ allowlist_externals =
   make
   rm
 
+[testenv:api-ref]
+install_command = {[testenv:docs]install_command}
+allowlist_externals = rm
+deps = {[testenv:docs]deps}
+commands =
+  rm -rf api-ref/build
+  sphinx-build -W -b html -d api-ref/build/doctrees api-ref/source api-ref/build/html/
+
+[testenv:releasenotes]
+install_command = {[testenv:docs]install_command}
+deps = {[testenv:docs]deps}
+commands = sphinx-build -a -E -W -j auto -d releasenotes/build/doctrees -b html releasenotes/source releasenotes/build/html
+
 [testenv:gendriverlist]
+install_command = {[testenv:py3]install_command}
 sitepackages = False
 envdir = {toxworkdir}/venv
 commands = python {toxinidir}/tools/generate_driver_list.py
 
 [testenv:bandit]
+install_command = {[testenv:py3]install_command}
 deps = -r{toxinidir}/test-requirements.txt
 commands = bandit -r cinder -n5 -x cinder/tests/* -ll
 
@@ -160,8 +206,8 @@ commands = bandit-baseline -r cinder -n5 -x cinder/tests/* -ii -ll
 # system dependencies are missing, since it's used to tell you what system
 # dependencies are missing! This also means that bindep must be installed
 # separately, outside of the requirements files, and develop mode disabled
-# explicitly to avoid unnecessarily installing the checked-out repo too (this
-# further relies on "tox.skipsdist = True" above).
+# explicitly to avoid unnecessarily installing the checked-out repo too
+skip_install = True
 deps = bindep
 commands = bindep {posargs}
 usedevelop = False


### PR DESCRIPTION
Changes:
- eliminate whitespace in passenv values
- account for stricter allowlist checking
- removed skipsdist=True, which in tox 4 appears to prevent cinder from being installed in the testenvs
- made 4.0.0 the tox minversion, which means tox will have to update itself until it's available in distros, which in turn means that the default install_command needs to be used in the base testenv, which means a new base pyXX testenv is added to include our install_command that includes upper constraints
- added install_command to most testenvs since they don't inherit the correct one from the base testenv any more

Not strictly necessary for this patch, but I did them anyway:
- moved the api-ref and releasenotes testenvs to be closer to the docs testenv
- added reno as a dep for the 'venv' testenv, which our contributor docs say should be used to generate a new release note from the reno template, and which has apparently been broken for a while

This patch makes tox 4 the default so that we can hopefully catch problems locally before they block the gate.

Change-Id: I75e36fa100925bd486c9d4fdf8a33dd58347ce81