### PR TITLE
[SAP] Fix vmdk stats reporting

### DIFF
--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -585,7 +585,8 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                     # in which case we want to mark it down.
                     if 'cinder_state' in custom_attributes:
                         cinder_pool_state = custom_attributes['cinder_state']
-                        if cinder_pool_state.lower() == 'drain':
+                        if (cinder_pool_state and
+                                cinder_pool_state.lower() == 'drain'):
                             pool_state = 'down'
                             pool_down_reason = 'Datastore marked as draining'
 


### PR DESCRIPTION
There is a failure for looking at the cinder_pool_state for a datastore when the state is None (not set).  This patch ensures that the custom attribute is set to something before trying to call .lower() on the string.