### PR TITLE
[SAP] ensure snapshot clones accounted for

### DIFF
--- a/cinder/tests/unit/volume/drivers/vmware/test_fcd.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_fcd.py
@@ -70,6 +70,7 @@ class VMwareVStorageObjectDriverTestCase(test.TestCase):
         self._config.vmware_storage_profile = None
         self._config.reserved_percentage = self.RESERVED_PERCENTAGE
         self._config.vmware_datastores_as_pools = False
+        self._config.vmware_snapshot_format = "COW"
         self._driver = fcd.VMwareVStorageObjectDriver(
             configuration=self._config)
         self._driver._vc_version = self.VC_VERSION

--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -417,6 +417,21 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                                   % storage_profile)
                         raise exception.InvalidInput(reason=reason)
 
+    def _init_vendor_properties(self):
+        """Set some vmware specific properties."""
+
+        properties = {}
+        vendor_prefix = "vmware"
+        self._set_property(
+            properties,
+            f"{vendor_prefix}:snapshot_type",
+            "Snapshot type",
+            _("Specifies Type of snapshot"),
+            "string",
+            enum=["snapshot", "clone"])
+
+        return properties, vendor_prefix
+
     def _update_volume_stats(self):
         if self.configuration.safe_get('vmware_enable_volume_stats'):
             self._stats = self._get_volume_stats()
@@ -535,6 +550,12 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         max_over_subscription_ratio = self.configuration.safe_get(
             'max_over_subscription_ratio')
 
+        snapshot_format = self.configuration.vmware_snapshot_format
+        if snapshot_format == 'COW':
+            snapshot_type = 'snapshot'
+        else:
+            snapshot_type = 'clone'
+
         backend_state = 'up'
         data = {'volume_backend_name': backend_name,
                 'vendor_name': 'VMware',
@@ -542,6 +563,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                 'storage_protocol': 'vmdk',
                 'location_info': location_info,
                 'backend_state': backend_state,
+                'snapshot_type': snapshot_type
                 }
 
         result, datastores = self._collect_backend_stats()


### PR DESCRIPTION
This patch adds the ability in the volume manger to check if a backend has clones as snapshots and account for the space consumed on the pool.

All of our snapshots are clones and the volume manager doesn't account for the space consumed on the pool/datastore.  Only the scheduler accounts for that space consumed on the pool currently. With this patch the volume manager will check all snapshots in the DB and properly account for the space used on the pool. This is to help prevent overcommit on a pool.