### PR TITLE
[SAP] Use snapshot hidden backend for new volumes

### DIFF
--- a/cinder/volume/flows/api/create_volume.py
+++ b/cinder/volume/flows/api/create_volume.py
@@ -21,6 +21,7 @@ from cinder import flow_utils
 from cinder.i18n import _
 from cinder import objects
 from cinder.objects import fields
+from cinder.objects import snapshot as snapshot_obj
 from cinder.policies import volumes as policy
 from cinder import quota
 from cinder import quota_utils
@@ -765,9 +766,21 @@ class VolumeCastTask(flow_utils.CinderTask):
             # if we are allowing snapshots to live on pools other than
             # the source volume.
             if CONF.sap_allow_independent_snapshots:
-                backend = volume_utils.extract_host(
-                    snapshot.volume.resource_backend
-                )
+                # First see if the host was saved in metadata, because the
+                # source volume is allowed to be migrated off of it's original
+                # shard.
+                # If not, then use the volume's host entry.
+                snap_host_key = snapshot_obj.SAP_HIDDEN_BACKEND_KEY
+                snap_host = snapshot.metadata.get(snap_host_key)
+                if snap_host:
+                    # we need to use the host entry saved in the snapshot
+                    # metadata as the source volume can be migrated to a
+                    # different shard.
+                    backend = volume_utils.extract_host(snap_host)
+                else:
+                    backend = volume_utils.extract_host(
+                        snapshot.volume.resource_backend
+                    )
                 request_spec['resource_backend'] = backend
         elif source_volid:
             source_volume_ref = objects.Volume.get_by_id(context, source_volid)


### PR DESCRIPTION
When creating a volume from a snapshot, the hidden __cinder_internal_backend metadata on the snapshot will be used for the host for the volume creation.  We do this now instead of falling back to the snapshot's source volume host can be different than it was when the snapshot was changed, because the source volume can be migrated now.

This ensures that the new volume from snapshot can copy the bits from the snapshot (clone).