### PR TITLE
Change FCD driver to use volume.name attribute for directory naming, …

### DIFF
--- a/cinder/tests/unit/volume/drivers/vmware/test_fcd.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_fcd.py
@@ -168,7 +168,9 @@ class VMwareVStorageObjectDriverTestCase(test.TestCase):
         vops.get_dc.return_value = dc_ref
 
         size_bytes = units.Gi
-        ret = self._driver._get_temp_image_folder(volume.name, size_bytes, preallocated)
+        ret = self._driver._get_temp_image_folder(volume.name,
+                                                  size_bytes,
+                                                  preallocated)
         self.assertEqual(
             (dc_ref, summary, volume.name + '/'), ret)
         exp_req = {hub.DatastoreSelector.SIZE_BYTES: size_bytes}
@@ -358,7 +360,8 @@ class VMwareVStorageObjectDriverTestCase(test.TestCase):
             self._context, volume, image_service, image_id)
 
         self.assertEqual({'provider_location': provider_location}, ret)
-        get_temp_image_folder.assert_called_once_with(volume.name, volume.size * units.Gi)
+        get_temp_image_folder.assert_called_once_with(volume.name,
+                                                      volume.size * units.Gi)
         if disk_type == vmdk.ImageDiskType.PREALLOCATED:
             create_disk_from_preallocated_image.assert_called_once_with(
                 self._context, image_service, image_id, image_meta['size'],

--- a/cinder/tests/unit/volume/drivers/vmware/test_vmware_volumeops.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_vmware_volumeops.py
@@ -2331,7 +2331,7 @@ class VolumeOpsTestCase(test.TestCase):
             snapshotId=fcd_snap_id,
             name=name,
             profile=[profile_spec],
-            path=name+'/')
+            path=name + '/')
         self.session.wait_for_task.assert_called_once_with(task)
 
     @mock.patch('cinder.volume.drivers.vmware.volumeops.VMwareVolumeOps.'

--- a/cinder/tests/unit/volume/drivers/vmware/test_vmware_volumeops.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_vmware_volumeops.py
@@ -2080,7 +2080,9 @@ class VolumeOpsTestCase(test.TestCase):
         self.assertEqual(dest_ds_ref_val, ret.ds_ref_val)
         self.session.vim.client.factory.create.assert_called_once_with(
             'ns0:VslmCloneSpec')
-        create_fcd_backing_spec.assert_called_once_with(disk_type, dest_ds_ref, name)
+        create_fcd_backing_spec.assert_called_once_with(disk_type,
+                                                        dest_ds_ref,
+                                                        name)
         self.assertEqual(name, spec.name)
         self.assertEqual(backing_spec, spec.backingSpec)
         self.assertEqual([profile_spec], spec.profile)

--- a/cinder/tests/unit/volume/drivers/vmware/test_vmware_volumeops.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_vmware_volumeops.py
@@ -32,6 +32,7 @@ class VolumeOpsTestCase(test.TestCase):
     """Unit tests for volumeops module."""
 
     MAX_OBJECTS = 100
+
     def setUp(self):
         super(VolumeOpsTestCase, self).setUp()
         self.session = mock.MagicMock()
@@ -1978,9 +1979,9 @@ class VolumeOpsTestCase(test.TestCase):
         disk_type = mock.sentinel.disk_type
         profile_id = mock.sentinel.profile_id
 
-        def mock_invoke_api(vim_util, method, vim, 
-                            the_object=None, arg=None, 
-                            name=None, datacenter=None, 
+        def mock_invoke_api(vim_util, method, vim,
+                            the_object=None, arg=None,
+                            name=None, datacenter=None,
                             spec=None):
             if arg == "parent":
                 return the_object.parent
@@ -1997,7 +1998,9 @@ class VolumeOpsTestCase(test.TestCase):
         self.assertEqual(ds_ref_val, ret.ds_ref_val)
         self.session.vim.client.factory.create.assert_called_once_with(
             'ns0:VslmCreateSpec')
-        create_fcd_backing_spec.assert_called_once_with(disk_type, ds_ref, name)
+        create_fcd_backing_spec.assert_called_once_with(disk_type,
+                                                        ds_ref,
+                                                        name)
         self.assertEqual(1024, spec.capacityInMB)
         self.assertEqual(name, spec.name)
         self.assertEqual(backing_spec, spec.backingSpec)

--- a/cinder/volume/drivers/vmware/fcd.py
+++ b/cinder/volume/drivers/vmware/fcd.py
@@ -91,7 +91,7 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
         (_host_ref, _resource_pool, summary) = self._select_datastore(req)
         return summary.datastore
 
-    def _get_temp_image_folder(self, size_bytes, preallocated=False):
+    def _get_temp_image_folder(self, name, size_bytes, preallocated=False):
         req = {}
         req[hub.DatastoreSelector.SIZE_BYTES] = size_bytes
 
@@ -102,7 +102,7 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
 
         (host_ref, _resource_pool, summary) = self._select_datastore(req)
 
-        folder_path = vmdk.TMP_IMAGES_DATASTORE_FOLDER_PATH
+        folder_path = name + '/'
         dc_ref = self.volumeops.get_dc(host_ref)
         self.volumeops.create_datastore_folder(
             summary.name, folder_path, dc_ref)
@@ -201,7 +201,7 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
 
         size_bytes = metadata['size']
         dc_ref, summary, folder_path = self._get_temp_image_folder(
-            volume.size * units.Gi)
+            volume.name, volume.size * units.Gi)
         disk_name = volume.id
         if disk_type in [vmdk.ImageDiskType.SPARSE,
                          vmdk.ImageDiskType.STREAM_OPTIMIZED]:

--- a/cinder/volume/drivers/vmware/volumeops.py
+++ b/cinder/volume/drivers/vmware/volumeops.py
@@ -2131,7 +2131,7 @@ class VMwareVolumeOps(object):
         backing_spec.provisioningType = disk_type
         backing_spec.datastore = ds_ref
         if path:
-            backing_spec.path = path + '/'
+                backing_spec.path = path + '/'
         return backing_spec
 
     def _create_profile_spec(self, cf, profile_id):
@@ -2144,16 +2144,11 @@ class VMwareVolumeOps(object):
         spec = cf.create('ns0:VslmCreateSpec')
         spec.capacityInMB = size_mb
         spec.name = name
-        spec.backingSpec = self._create_fcd_backing_spec(disk_type,
-                                                         ds_ref,
-                                                         name)
-        hosts = self.get_connected_hosts(ds_ref)
-        host_ref = vim_util.get_moref(hosts[0], 'HostSystem')
-        dc_ref = self.get_dc(host_ref)
+        spec.backingSpec = self._create_fcd_backing_spec(disk_type, ds_ref, name)
+        dc_ref = self.get_dc(ds_ref)
         ds_name = self._session.invoke_api(vim_util, 'get_object_property',
-                                           self._session.vim, ds_ref,
-                                           'name')
-
+                                        self._session.vim, ds_ref,
+                                        'name')
         self.create_datastore_folder(ds_name, name, dc_ref)
 
         if profile_id:

--- a/cinder/volume/drivers/vmware/volumeops.py
+++ b/cinder/volume/drivers/vmware/volumeops.py
@@ -2144,7 +2144,7 @@ class VMwareVolumeOps(object):
         spec = cf.create('ns0:VslmCreateSpec')
         spec.capacityInMB = size_mb
         spec.name = name
-        spec.backingSpec = self._create_fcd_backing_spec(disk_type, 
+        spec.backingSpec = self._create_fcd_backing_spec(disk_type,
                                                          ds_ref, name)
         dc_ref = self.get_dc(ds_ref)
         ds_name = self._session.invoke_api(vim_util, 'get_object_property',

--- a/cinder/volume/drivers/vmware/volumeops.py
+++ b/cinder/volume/drivers/vmware/volumeops.py
@@ -2300,6 +2300,13 @@ class VMwareVolumeOps(object):
 
         vstorage_mgr = self._session.vim.service_content.vStorageObjectManager
         cf = self._session.vim.client.factory
+        ds_ref = fcd_snap_loc.fcd_loc.ds_ref()
+        dc_ref = self.get_dc(ds_ref)
+        ds_name = self._session.invoke_api(vim_util, 'get_object_property',
+                                           self._session.vim, ds_ref,
+                                           'name')
+        self.create_datastore_folder(ds_name, name, dc_ref)
+
         if profile_id:
             profile = [self._create_profile_spec(cf, profile_id)]
         else:
@@ -2312,7 +2319,8 @@ class VMwareVolumeOps(object):
             datastore=fcd_snap_loc.fcd_loc.ds_ref(),
             snapshotId=fcd_snap_loc.id(cf),
             name=name,
-            profile=profile)
+            profile=profile,
+            path=name + '/')
         task_info = self._session.wait_for_task(task)
         fcd_loc = FcdLocation.create(task_info.result.config.id,
                                      fcd_snap_loc.fcd_loc.ds_ref())

--- a/cinder/volume/drivers/vmware/volumeops.py
+++ b/cinder/volume/drivers/vmware/volumeops.py
@@ -2131,7 +2131,7 @@ class VMwareVolumeOps(object):
         backing_spec.provisioningType = disk_type
         backing_spec.datastore = ds_ref
         if path:
-                backing_spec.path = path + '/'
+            backing_spec.path = path + '/'
         return backing_spec
 
     def _create_profile_spec(self, cf, profile_id):
@@ -2144,16 +2144,17 @@ class VMwareVolumeOps(object):
         spec = cf.create('ns0:VslmCreateSpec')
         spec.capacityInMB = size_mb
         spec.name = name
-        spec.backingSpec = self._create_fcd_backing_spec(disk_type, ds_ref, name)
+        spec.backingSpec = self._create_fcd_backing_spec(disk_type, 
+                                                         ds_ref, 
+                                                         name)
         hosts = self.get_connected_hosts(ds_ref)
         host_ref = vim_util.get_moref(hosts[0], 'HostSystem')
         dc_ref = self.get_dc(host_ref)
         ds_name = self._session.invoke_api(vim_util, 'get_object_property',
-                                        self._session.vim, ds_ref,
-                                        'name')
- 
-        self.create_datastore_folder(ds_name, name, dc_ref)
+                                           self._session.vim, ds_ref,
+                                           'name')
 
+        self.create_datastore_folder(ds_name, name, dc_ref)
 
         if profile_id:
             profile_spec = self._create_profile_spec(cf, profile_id)

--- a/cinder/volume/drivers/vmware/volumeops.py
+++ b/cinder/volume/drivers/vmware/volumeops.py
@@ -2131,7 +2131,7 @@ class VMwareVolumeOps(object):
         backing_spec.provisioningType = disk_type
         backing_spec.datastore = ds_ref
         if path:
-                backing_spec.path = path + '/'
+            backing_spec.path = path + '/'
         return backing_spec
 
     def _create_profile_spec(self, cf, profile_id):
@@ -2144,11 +2144,12 @@ class VMwareVolumeOps(object):
         spec = cf.create('ns0:VslmCreateSpec')
         spec.capacityInMB = size_mb
         spec.name = name
-        spec.backingSpec = self._create_fcd_backing_spec(disk_type, ds_ref, name)
+        spec.backingSpec = self._create_fcd_backing_spec(disk_type, 
+                                                         ds_ref, name)
         dc_ref = self.get_dc(ds_ref)
         ds_name = self._session.invoke_api(vim_util, 'get_object_property',
-                                        self._session.vim, ds_ref,
-                                        'name')
+                                           self._session.vim, ds_ref,
+                                           'name')
         self.create_datastore_folder(ds_name, name, dc_ref)
 
         if profile_id:

--- a/cinder/volume/drivers/vmware/volumeops.py
+++ b/cinder/volume/drivers/vmware/volumeops.py
@@ -2144,8 +2144,8 @@ class VMwareVolumeOps(object):
         spec = cf.create('ns0:VslmCreateSpec')
         spec.capacityInMB = size_mb
         spec.name = name
-        spec.backingSpec = self._create_fcd_backing_spec(disk_type, 
-                                                         ds_ref, 
+        spec.backingSpec = self._create_fcd_backing_spec(disk_type,
+                                                         ds_ref,
                                                          name)
         hosts = self.get_connected_hosts(ds_ref)
         host_ref = vim_util.get_moref(hosts[0], 'HostSystem')

--- a/cinder/volume/drivers/vmware/volumeops.py
+++ b/cinder/volume/drivers/vmware/volumeops.py
@@ -2148,7 +2148,7 @@ class VMwareVolumeOps(object):
     def update_fcd_vmdk_uuid(self, ds_ref, vmdk_path, cinder_uuid):
         def cinder_uuid_to_vmwhex(cinder_uuid):
             t = iter(cinder_uuid.replace('-', ''))
-            hextext = ' '.join(a+b for a, b in zip(t, t))
+            hextext = ' '.join(a + b for a, b in zip(t, t))
             return hextext[:23] + '-' + hextext[24:]
 
         virtual_dmgr = self._session.vim.service_content.virtualDiskManager


### PR DESCRIPTION
…also use it for temp directory.

This change will help ops to find fcd objects on the datastore, as there is no longer any searchable object in vcenter....
Naming can be adjusted with the volume_name_template = volume-%s parameter ...
