### PR TITLE
[SAP] Fix vmware fcd driver delete_volume on failure

### DIFF
--- a/cinder/volume/drivers/vmware/fcd.py
+++ b/cinder/volume/drivers/vmware/fcd.py
@@ -23,6 +23,7 @@ driver requires a minimum vCenter version of 6.5.
 from oslo_log import log as logging
 from oslo_utils import units
 from oslo_utils import versionutils
+from oslo_vmware import exceptions as vexc
 from oslo_vmware import image_transfer
 from oslo_vmware.objects import datastore
 from oslo_vmware import vim_util
@@ -147,7 +148,15 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
             LOG.warning("FCD provider location is empty for volume %s",
                         volume.id)
         else:
-            self._delete_fcd(volume.provider_location)
+            try:
+                self._delete_fcd(volume.provider_location)
+            except vexc.VimException as ex:
+                if "could not be found" in str(ex):
+                    LOG.warning("FCD deletion failed for %s not found. "
+                                "delete_volume is considered successful.",
+                                volume.id)
+                else:
+                    raise ex
 
     def initialize_connection(self, volume, connector, initiator_data=None):
         """Allow connection to connector and return connection info.


### PR DESCRIPTION
This patch catches the VIMException when an fcd volume isn't found during a delete_volume.  This is considerd a success.