### PR TITLE
[SAP] Add envlist to tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,8 @@ requires = virtualenv>=20.17.1
 # this allows tox to infer the base python from the environment name
 # and override any basepython configured in this file
 ignore_basepython_conflict=true
+# python runtimes: https://governance.openstack.org/tc/reference/project-testing-interface.html#tested-runtimes
+envlist = py3,compliance,pep8
 
 [testenv]
 basepython = python3


### PR DESCRIPTION
The envlist was missing from the tox.ini, which prevented running 'tox' without an -e option correctly.  The upper-constraints were not being applied to the tox environment runtime, which allowed SQLAlchemy 2.0.x to be installed and then the tests would fail instantly.