### PR TITLE
SAP: ShardFilter don't k8s filter on migration

### DIFF
--- a/cinder/scheduler/filters/shard_filter.py
+++ b/cinder/scheduler/filters/shard_filter.py
@@ -164,6 +164,10 @@ class ShardFilter(filters.BaseBackendFilter):
         project_id = vol_props.get('project_id', None)
         metadata = vol_props.get('metadata', {})
 
+        # We don't filter on the cluster if we're migrating a volume
+        if spec.get('action', None) == 'volume_migrate':
+            return backends
+
         is_vmware = any(self._is_vmware(b) for b in backends)
         if (not metadata or not project_id
                 or spec.get('snapshot_id')

--- a/cinder/scheduler/filters/shard_filter.py
+++ b/cinder/scheduler/filters/shard_filter.py
@@ -165,7 +165,7 @@ class ShardFilter(filters.BaseBackendFilter):
         metadata = vol_props.get('metadata', {})
 
         # We don't filter on the cluster if we're migrating a volume
-        if spec.get('action', None) == 'volume_migrate':
+        if spec.get('operation', None) == 'volume_migrate':
             return backends
 
         is_vmware = any(self._is_vmware(b) for b in backends)

--- a/cinder/scheduler/manager.py
+++ b/cinder/scheduler/manager.py
@@ -533,13 +533,15 @@ class SchedulerManager(manager.CleanableManager, manager.Manager):
         filter_properties.pop('new_size')
 
         if not request_spec:
-            request_spec = {'volume_properties': {'size': new_size}}
+            request_spec = {'volume_properties': {'size': new_size},
+                            'operation': 'volume_migrate'}
         else:
             request_spec['volume_properties']['size'] = new_size
 
         if volume['availability_zone']:
             request_spec['resource_properties'] = {
                 'availability_zone': volume['availability_zone']}
+        request_spec['operation'] = 'volume_migrate'
 
         # SAP
         # We have to force the destination host to be on

--- a/cinder/volume/api.py
+++ b/cinder/volume/api.py
@@ -838,7 +838,7 @@ class API(base.Base):
             'volume_properties': volume,
             'volume_type': volume_type,
             'volume_id': volume.id,
-            'action': 'migrate_volume'
+            'operation': 'migrate_volume'
         }
 
         # Check if there is an affinity/antiaffinity against the volume
@@ -1727,7 +1727,7 @@ class API(base.Base):
         request_spec = {'volume_properties': volume,
                         'volume_type': volume_type,
                         'volume_id': volume.id,
-                        'action': 'migrate_volume'}
+                        'operation': 'migrate_volume'}
         self.scheduler_rpcapi.migrate_volume(context,
                                              volume,
                                              cluster_name or host,

--- a/cinder/volume/api.py
+++ b/cinder/volume/api.py
@@ -837,7 +837,9 @@ class API(base.Base):
         request_spec = {
             'volume_properties': volume,
             'volume_type': volume_type,
-            'volume_id': volume.id}
+            'volume_id': volume.id,
+            'action': 'migrate_volume'
+        }
 
         # Check if there is an affinity/antiaffinity against the volume
         filter_properties = \
@@ -1724,7 +1726,8 @@ class API(base.Base):
                                                        volume.volume_type_id)
         request_spec = {'volume_properties': volume,
                         'volume_type': volume_type,
-                        'volume_id': volume.id}
+                        'volume_id': volume.id,
+                        'action': 'migrate_volume'}
         self.scheduler_rpcapi.migrate_volume(context,
                                              volume,
                                              cluster_name or host,


### PR DESCRIPTION
This patch adds a check in the ShardFilter to not do any k8s filtering on a volume migration.  For volumes in place prior to the k8s filtering feature of the ShardFilter, the shard that a volume currently lives on can get filtered out due to the k8s filtering and the sql query odering.  This could prevent a volume from being moved to another datastore in the same shard.

This patch adds an 'action' to the volume migration request spec with the value of 'volume_migrate' and the ShardFilter looks for it to tell it to not filter k8s volume hosts out.