### PR TITLE
[SAP] k8s shard filter ignores migrate-by-connector

### DIFF
--- a/cinder/scheduler/filters/shard_filter.py
+++ b/cinder/scheduler/filters/shard_filter.py
@@ -167,6 +167,7 @@ class ShardFilter(filters.BaseBackendFilter):
         is_vmware = any(self._is_vmware(b) for b in backends)
         if (not metadata or not project_id
                 or spec.get('snapshot_id')
+                or spec.get('operation') == 'find_backend_for_connector'
                 or not is_vmware):
             return backends
 


### PR DESCRIPTION
We already ignore the same in the "normal" shard filter code, but also need to do it in the k8s shard part of it - otherwise, VMs being in the wrong shard will not get their volumes attached.

Change-Id: Idf5c8e25916d148bf5cecf5feb1ad2f35e83d7cf