### PR TITLE
ShardFilter: allow existing K8S clusters with more than 1 shard

### DIFF
--- a/cinder/db/api.py
+++ b/cinder/db/api.py
@@ -281,10 +281,10 @@ def volume_get_all(context, marker=None, limit=None, sort_keys=None,
                                offset=offset)
 
 
-def get_host_by_volume_metadata(key, value, filters=None):
+def get_hosts_by_volume_metadata(key, value, filters=None):
     """Returns the host with the most volumes matching volume metadata."""
-    return IMPL.get_host_by_volume_metadata(key, value,
-                                            filters=filters)
+    return IMPL.get_hosts_by_volume_metadata(key, value,
+                                             filters=filters)
 
 
 def calculate_resource_count(context, resource_type, filters):

--- a/cinder/db/sqlalchemy/api.py
+++ b/cinder/db/sqlalchemy/api.py
@@ -2176,7 +2176,7 @@ def volume_get_all(context, marker=None, limit=None, sort_keys=None,
         return query.all()
 
 
-def get_host_by_volume_metadata(meta_key, meta_value, filters=None):
+def get_hosts_by_volume_metadata(meta_key, meta_value, filters=None):
     session = get_session()
     count_label = func.count().label("n")
     query = session.query(
@@ -2199,13 +2199,10 @@ def get_host_by_volume_metadata(meta_key, meta_value, filters=None):
                 models.Volume.availability_zone == az)
 
     query = query.group_by("h")\
-        .order_by(desc(count_label)).limit(1)
+        .order_by(desc(count_label))
 
     with session.begin():
-        result = query.first()
-        if result:
-            return result[0]
-    return None
+        return query.all()
 
 
 @require_context

--- a/cinder/tests/unit/scheduler/test_shard_filter.py
+++ b/cinder/tests/unit/scheduler/test_shard_filter.py
@@ -228,7 +228,7 @@ class ShardFilterTestCase(BackendFiltersTestCase):
         self.backend_passes(host, self.props)
 
     @mock.patch('cinder.context.get_admin_context')
-    @mock.patch('cinder.db.get_host_by_volume_metadata')
+    @mock.patch('cinder.db.get_hosts_by_volume_metadata')
     def test_same_shard_for_k8s_volumes(self, mock_get_hosts,
                                         mock_get_context):
         CSI_KEY = 'cinder.csi.openstack.org/cluster'
@@ -246,7 +246,8 @@ class ShardFilterTestCase(BackendFiltersTestCase):
         fake_meta = {
             CSI_KEY: 'cluster-1',
         }
-        mock_get_hosts.return_value = 'volume-vc-a-1'
+        mock_get_hosts.return_value = [('volume-vc-x-1', 2),
+                                       ('volume-vc-a-1', 1)]
         self.filt_cls._PROJECT_SHARD_CACHE['baz'] = ['sharding_enabled',
                                                      'vc-a-1']
         filter_props = dict(self.props)
@@ -254,9 +255,7 @@ class ShardFilterTestCase(BackendFiltersTestCase):
             'project_id': 'baz',
             'metadata': fake_meta
         })
-        filter_props['request_spec']['resource_properties'] = {
-            'availability_zone': 'az-1'
-        }
+        filter_props['availability_zone'] = 'az-1'
 
         filtered = self.filt_cls.filter_all(all_backends, filter_props)
 


### PR DESCRIPTION
Extend the SQL query to return all matching hosts, ordered desc. For new volume creations we allow it in the dominant shard only, however for existing volumes we allow the operation in all the shards of the K8S cluster. This is a backward-compatibility with existing K8S cluster spanning multiple shards in the same AZ.

Additionally, this commit fixes the availability_zone value to be taken from filter_properties, which is always seeded by populate_filter_properties()

For better debugging, adding a debug log when a backend is filtered out by the K8S logic.

Change-Id: I42d526e8b1335e9025543a424f9203858a44663e