### PR TITLE
Use openstack branch name for dnspython dependency

### DIFF
--- a/custom-requirements.txt
+++ b/custom-requirements.txt
@@ -11,4 +11,4 @@ jaeger-client
 -e git+https://github.com/sapcc/openstack-rate-limit-middleware.git#egg=rate-limit-middleware
 -e git+https://github.com/sapcc/os-brick.git@stable/wallaby-m3#egg=os-brick
 -e git+https://github.com/sapcc/oslo.vmware.git@stable/wallaby-m3#egg=oslo.vmware
--e git+https://github.com/sapcc/dnspython.git@ccloud#egg=dnspython
+-e git+https://github.com/sapcc/dnspython.git@stable/wallaby-m3#egg=dnspython


### PR DESCRIPTION
There is no code change, it just refers to the same code by a different branch name.

Change-Id: Ic11af672d790791442d7dc988215bc4cc43f1d27