### PR TITLE
[SAP] Remove noisy log for scheduler

### DIFF
--- a/cinder/utils.py
+++ b/cinder/utils.py
@@ -816,8 +816,6 @@ def calculate_max_over_subscription_ratio(capability,
     # If thin provisioning is not supported the capacity filter will not use
     # the value we return, no matter what it is.
     if not thin_provisioning_support:
-        LOG.debug("Trying to retrieve max_over_subscription_ratio from a "
-                  "service that does not support thin provisioning")
         return 1.0
 
     # Again, if total or free capacity is infinite or unknown, the capacity


### PR DESCRIPTION
Since we always have thick provisioning, removing this log entry that complains about looking for max overcommit for thick provisioning just makes noise in the scheduler.