### PR TITLE
ShardFilter: allow new K8S volumes in any shard

### DIFF
--- a/cinder/scheduler/filters/shard_filter.py
+++ b/cinder/scheduler/filters/shard_filter.py
@@ -197,10 +197,6 @@ class ShardFilter(filters.BaseBackendFilter):
         if not results:
             return backends
 
-        # Allowing new volumes to be created only in the dominant shard
-        if spec.get('operation') == 'create_volume':
-            results = results[:1]
-
         k8s_hosts = dict(results)
 
         def _is_k8s_host(b):


### PR DESCRIPTION
If a cluster already spans across multiple shards, allow new volumes to be created in any of the existing shards. They will later be migrated by Nova, and since they are new volumes the operation will be quite fast.

Change-Id: I148a6432a9ed7f003dc2d171b2d035095c8cce10