### PR TITLE
[SAP] Fix ShardFilter to query the k8s hosts by project_id

### DIFF
--- a/cinder/db/sqlalchemy/api.py
+++ b/cinder/db/sqlalchemy/api.py
@@ -2197,6 +2197,10 @@ def get_hosts_by_volume_metadata(meta_key, meta_value, filters=None):
         if az:
             query = query.filter(
                 models.Volume.availability_zone == az)
+        project_id = filters.get('project_id')
+        if project_id:
+            query = query.filter(
+                models.Volume.project_id == project_id)
 
     query = query.group_by("h")\
         .order_by(desc(count_label))

--- a/cinder/scheduler/filters/shard_filter.py
+++ b/cinder/scheduler/filters/shard_filter.py
@@ -184,10 +184,10 @@ class ShardFilter(filters.BaseBackendFilter):
         if not cluster_name:
             return backends
 
+        query_filters = {'project_id': project_id}
         availability_zone = filter_properties.get('availability_zone')
-        query_filters = None
         if availability_zone:
-            query_filters = {'availability_zone': availability_zone}
+            query_filters['availability_zone'] = availability_zone
 
         results = db.get_hosts_by_volume_metadata(
             key=CSI_CLUSTER_METADATA_KEY,

--- a/cinder/tests/unit/scheduler/test_shard_filter.py
+++ b/cinder/tests/unit/scheduler/test_shard_filter.py
@@ -261,6 +261,7 @@ class ShardFilterTestCase(BackendFiltersTestCase):
 
         mock_get_hosts.assert_called_once_with(
             key=CSI_KEY, value=fake_meta[CSI_KEY], filters={
+                'project_id': 'baz',
                 'availability_zone': 'az-1'
             })
         self.assertEqual(len(filtered), 1)


### PR DESCRIPTION
The `get_hosts_by_volume_metadata` was returning the hosts without filtering by project_id, resulting in name collision if k8s clusters from different project were using the same cluster name.

We now add the `project_id` in the query filter, making sure the filtering is bound only to that project.

Change-Id: I7d178da2f7ce0926320f326efce2e7c0111bdc47