### PR TITLE
[SAP] change storage_profile reporting

### DIFF
--- a/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
@@ -215,7 +215,7 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
             objects = [props()]
 
         datastores = {"datastore-85": {"summary": summary,
-                                       "storage_profile": "Gold"}}
+                                       "storage_profile": {"name": "Gold"}}}
         return result(), datastores
 
     @mock.patch('cinder.volume.drivers.vmware.datastore.'

--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -576,6 +576,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
             for ds_name in datastores:
                 datastore = datastores[ds_name]
                 summary = datastore["summary"]
+                storage_profile = datastore["storage_profile"].get("name")
 
                 pool_state = 'down'
                 pool_down_reason = 'Datastore not usable'
@@ -626,7 +627,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                         'datastore_type': summary.type,
                         'location_url': summary.url,
                         'location_info': location_info,
-                        'storage_profile': datastore["storage_profile"],
+                        'storage_profile': storage_profile,
                         'connection_capabilities': connection_capabilities,
                         'backend_state': backend_state,
                         'pool_state': pool_state,


### PR DESCRIPTION
This patch changes the way the storage_profile attribute is reported in the pool stats.  Previously the value was a dictionary that
included the name and the storage profile id.   The storage_profile
needs to only be the name so we can match against it in the
volume type extra spec.

This is related to the cinder-issue:
https://github.wdf.sap.corp/cc/cinder-issues/issues/14