### PR TITLE
[SAP] update independent snapshot code

### DIFF
--- a/cinder/common/sap.py
+++ b/cinder/common/sap.py
@@ -1,0 +1,29 @@
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from oslo_config import cfg
+
+CONF = cfg.CONF
+
+sap_custom_opts = [
+    cfg.BoolOpt('sap_allow_independent_snapshots',
+                default=False,
+                help='Allow cinder to schedule snapshot creations on pools '
+                     'other than the source volume pool.'),
+    cfg.BoolOpt('sap_allow_independent_clone',
+                default=False,
+                help='Allow cinder to schedule a clone volume on a pool '
+                     'other than the source volume pool.'),
+]
+CONF.register_opts(sap_custom_opts)

--- a/cinder/opts.py
+++ b/cinder/opts.py
@@ -44,6 +44,7 @@ from cinder.backup import manager as cinder_backup_manager
 from cinder.cmd import backup as cinder_cmd_backup
 from cinder.cmd import volume as cinder_cmd_volume
 from cinder.common import config as cinder_common_config
+from cinder.common import sap as cinder_common_sap
 import cinder.compute
 from cinder.compute import nova as cinder_compute_nova
 from cinder import context as cinder_context
@@ -241,6 +242,7 @@ def list_opts():
                 cinder_common_config.image_opts,
                 cinder_common_config.global_opts,
                 cinder_common_config.compression_opts,
+                cinder_common_sap.sap_custom_opts,
                 cinder.compute.compute_opts,
                 cinder_context.context_opts,
                 cinder_db_api.db_opts,

--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -41,6 +41,8 @@ from oslo_vmware import vim_util
 
 from cinder import context
 from cinder import exception
+# This is needed to register the SAP config options
+from cinder.common import sap # noqa
 from cinder.i18n import _
 from cinder.image import image_utils
 from cinder import interface
@@ -557,13 +559,17 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
             snapshot_type = 'clone'
 
         backend_state = 'up'
+        if CONF.sap_allow_independent_snapshots:
+            independent_snapshot = 'true'
+        else:
+            independent_snapshot = 'false'
         data = {'volume_backend_name': backend_name,
                 'vendor_name': 'VMware',
                 'driver_version': self.VERSION,
                 'storage_protocol': 'vmdk',
                 'location_info': location_info,
                 'backend_state': backend_state,
-                'snapshot_type': snapshot_type
+                'snapshot_type': snapshot_type,
                 }
 
         result, datastores = self._collect_backend_stats()
@@ -632,6 +638,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                         'pool_state': pool_state,
                         'pool_down_reason': pool_down_reason,
                         'custom_attributes': custom_attributes,
+                        'independent_snapshots': independent_snapshot,
                         }
 
                 pools.append(pool)


### PR DESCRIPTION
This patch adds the additional check for the volume type containing the key/value of
independent_snapshot = True as well as the
CONF.sap_allow_independent_snapshot.

Previously, the only driver enabled anywhere was the vmdk.py driver which needs independent snapshots created as they are full clones.  FCD driver doesn't need/have independent snaps.

This prevents the FCD volume snapshots from getting placed on a vmware (vmdk.py) datastore.