### PR TITLE
[SAP] change name for temp backing

### DIFF
--- a/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
@@ -2572,6 +2572,7 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
             [dev_change_disk_remove]
 
         tmp_name = mock.sentinel.tmp_name
+        expected_tmp_name = "TEMP_BACKING-%s" % mock.sentinel.tmp_name
         generate_uuid.return_value = tmp_name
 
         tmp_backing = mock.sentinel.tmp_backing
@@ -2594,8 +2595,8 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
         get_volume_device_uuid.assert_called_once_with(instance,
                                                        src_vref['id'])
         vops.clone_backing.assert_called_once_with(
-            tmp_name, instance, None, volumeops.FULL_CLONE_TYPE, datastore,
-            host=host, resource_pool=rp, folder=folder,
+            expected_tmp_name, instance, None, volumeops.FULL_CLONE_TYPE,
+            datastore, host=host, resource_pool=rp, folder=folder,
             device_changes=[dev_change_disk_remove],
             extra_config={'nvp.vm-uuid': ''})
 

--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -2969,7 +2969,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                   "%(instance)s.", {'dev': vol_dev_uuid,
                                     'instance': instance})
 
-        tmp_name = tmp_name or uuidutils.generate_uuid()
+        tmp_name = tmp_name or "TEMP_BACKING-%s" % uuidutils.generate_uuid()
 
         device_changes = self.volumeops._create_device_change_for_disk_removal(
             instance, disks_to_clone=[vol_dev_uuid])


### PR DESCRIPTION
This patch updates the name of a temporary backing that is created
during the cloning an attached volume.   This prefixes the name
with an obvious string (TEMP_BACKING-<uuid>), so that we can see
orphaned temporary backings easily on vcenter.

This patch also updates the extra_config to remove a few items in the temp backing.