### PR TITLE
[SAP] Add new aggregate Pools feature

### DIFF
--- a/cinder/scheduler/filter_scheduler.py
+++ b/cinder/scheduler/filter_scheduler.py
@@ -107,6 +107,12 @@ class FilterScheduler(driver.Scheduler):
         # context is not serializable
         filter_properties.pop('context', None)
 
+        # SAP
+        # Update all the aggregate allocated_capacity_gb accounting
+        # for the new volume size.
+        self.host_manager.consume_from_volume_aggregate(
+            backend, request_spec['volume_properties']['size'])
+
         self.volume_rpcapi.create_volume(context, updated_volume, request_spec,
                                          filter_properties,
                                          allow_reschedule=True)


### PR DESCRIPTION
This patch adds the aggregate pools feature to the cinder scheduler. Aggregate pools are made up of pools that exist in multiple backends. For example:
Pool A lives in backend A and backend B.

The stats reporting for the pools normally are completely separate for pools in different backends, but when a backend has the same pool as another backend, the stats reporting up to the scheduler can be wrong.  Since the pool has volumes from both backend A and backend B, but the scheduler sees those stats as completely different.  We need the scheduler to see the pool from the 2 different backends as the same, otherwise the pool can get overcommited by a factor of 2.

When a backend has a pool that is shared with another backend, the stats reporting for that backend will do 2 things. 1) provide a new has_aggregate_pools = True in the backend level stats. 2) provide a unique aggregate_id for each of the pools.  This
   aggregate_id is what identifies the same pool for each backend.

So for pool A as described above the aggregate_id would be say "foo_a" being reported by both backend A and backend B.

When the scheduler sees a backend that has the setting of has_aggregate_pools, it will then sum up the allocated_capacity_gb for all the other stats from the other backends.  This ensures that the entire allocated capacity from all the backends is accurate.

For example, if backend A has create 10 volumes of 100Gib and backend B has created 5 volumes of 500Gib, the scheduler updates the stats it keeps for Pool A to 600Gib allocated_capacity_gb for both the pool stats for BackendA:PoolA and BackendB:PoolA