### PR TITLE
[SAP] Don't create shadow vm on initialize_connection

### DIFF
--- a/cinder/tests/unit/volume/drivers/vmware/test_fcd.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_fcd.py
@@ -278,7 +278,11 @@ class VMwareVStorageObjectDriverTestCase(test.TestCase):
         extract_host.return_value = mock.sentinel.host
 
         volume = self._create_volume_obj()
-        connector = {}
+        connector = {'platform': 'x86_64', 'os_type': 'linux',
+                     'ip': '10.0.0.1',
+                     'host': 'cinder-volume-backup-vmware-vc-a-0',
+                     'multipath': False,
+                     'initiator': 'iqn.1993-08.org.debian:01:c4f3207eed25'}
         profile_id = mock.sentinel.profile_id
         get_storage_profile_id.return_value = profile_id
         ret = self._driver.initialize_connection(volume, connector)

--- a/cinder/volume/drivers/vmware/fcd.py
+++ b/cinder/volume/drivers/vmware/fcd.py
@@ -274,13 +274,22 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
                 volume.provider_location
             )
         )
-        backing = self.volumeops.get_backing(volume.name, volume.id)
-        if not backing:
-            backing = self._create_backing(volume)
-        self.volumeops.attach_fcd(backing, fcd_loc)
-        backing_moref = backing.value
-        vmdk_path = self.volumeops.get_vmdk_path(backing)
-        datacenter = self.volumeops.get_dc(backing)
+        # We don't need this parameters unless backup is created/restored
+        backup = False
+        backing_moref = ""
+        vmdk_path = ""
+        datacenter = ""
+        if 'cinder-volume-backup' in connector['host']:
+            backup = True
+
+        if backup:
+            backing = self.volumeops.get_backing(volume.name, volume.id)
+            if not backing:
+                backing = self._create_backing(volume)
+                self.volumeops.attach_fcd(backing, fcd_loc)
+            backing_moref = backing.value
+            vmdk_path = self.volumeops.get_vmdk_path(backing)
+            datacenter = self.volumeops.get_dc(backing)
 
         connection_info = {
             'driver_volume_type': self.STORAGE_TYPE,


### PR DESCRIPTION
We are not creating a backing shadow vm for fcd object, if the initialize_connection call is not originating from backup pod
This solves the current issue with attachment does not work after the 1st attach