### PR TITLE
Fix cinder connection_info in attachments

### DIFF
--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -3367,7 +3367,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                 'volume': "",
                 'vmdk_size': volume.size * units.Gi,
                 'vmdk_path': vmdk_path,
-                'datacenter': dc_ref.value   
+                'datacenter': dc_ref.value
             }
             attachments = volume.volume_attachment
             for attach in attachments:

--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -3356,20 +3356,18 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         if vol_status == 'in-use':
             new_conn_info = {
                 'driver_volume_type': "vstorageobject",
-                'data': {
-                    'volume_id': volume.id,
-                    'name': volume.name,
-                    'id': fcd_loc.fcd_id,
-                    'ds_ref_val': fcd_loc.ds_ref_val,
-                    'ds_name': volume_utils.extract_host(volume.host,
-                                                         level='pool'),
-                    'adapter_type': self._get_adapter_type(volume),
-                    'profile_id': self._get_storage_profile_id(volume),
-                    'volume': "",
-                    'vmdk_size': volume.size * units.Gi,
-                    'vmdk_path': vmdk_path,
-                    'datacenter': dc_ref.value
-                }
+                'volume_id': volume.id,
+                'name': volume.name,
+                'id': fcd_loc.fcd_id,
+                'ds_ref_val': fcd_loc.ds_ref_val,
+                'ds_name': volume_utils.extract_host(volume.host,
+                                                     level='pool'),
+                'adapter_type': self._get_adapter_type(volume),
+                'profile_id': self._get_storage_profile_id(volume),
+                'volume': "",
+                'vmdk_size': volume.size * units.Gi,
+                'vmdk_path': vmdk_path,
+                'datacenter': dc_ref.value   
             }
             attachments = volume.volume_attachment
             for attach in attachments:


### PR DESCRIPTION
Fix cinder connection_info to be a flat structure, as nova already has a _translate_attachment_ref function in nova/volume/cinder.py to transform the attachments