### PR TITLE
[SAP] Account for snapshot capacity during create

### DIFF
--- a/cinder/volume/manager.py
+++ b/cinder/volume/manager.py
@@ -1345,6 +1345,18 @@ class VolumeManager(manager.CleanableManager,
         snapshot.encryption_key_id = vol_ref.encryption_key_id
         snapshot.save()
 
+        # For snapshots that have a hidden backend key
+        # we update the allocated capacity to account
+        # for the snapshot size on the backend.
+        # The hidden backend key is there for snapshots
+        # that are clones.
+        if snapshot.metadata:
+            key = objects.snapshot.SAP_HIDDEN_BACKEND_KEY
+            host = snapshot.metadata.get(key)
+            self._update_snapshot_allocated_capacity(
+                context, snapshot, host=host
+            )
+
         self._notify_about_snapshot_usage(context, snapshot, "create.end")
         action_track.track(
             context, action_track.ACTION_SNAPSHOT_CREATE,


### PR DESCRIPTION
This patch updates the local accounting for the allocated capacity for a snapshot that has a SAP_HIDDEN_BACKEND_KEY in the metadata. That key is only there if independent snapshots are allowed.  It's assumed that the snapshot is a full clone as well, when the backend allows for independent snaps.