### PR TITLE
[SAP] Fix retyping lazy vmdk to fcd volume

### DIFF
--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -3283,6 +3283,16 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                                                        volume=volume)
         vol_status = volume.previous_status
         backing = self.volumeops.get_backing(volume.name, volume.id)
+        if not backing:
+            # we need to create the backing and then migrate it.
+            LOG.debug("Backing does not exist for volume.", resource=volume)
+            backing = self._create_backing(volume)
+            if not backing:
+                msg = ("Failed to create backing for vmdk volume prior to "
+                       "migration to fcd.")
+                LOG.error(msg, resource=volume)
+                raise Exception(msg)
+
         # upgrade shadow vm to support FCD
         vmx = volumeops.VMX_VERSION
         try:


### PR DESCRIPTION
This patch fixes an issue with retyping from a vmdk volume to an fcd volume.  If the vmdk volume is lazy created and hasn't been attached yet, there was no backing, so we have to first create the backing so we can migrate it to an fcd volume.