### PR TITLE
[SAP] Change default provisioning type in vmdk

### DIFF
--- a/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
@@ -370,7 +370,7 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
         self.assertEqual(vmdk_type,
                          self._driver._get_extra_spec_disk_type(type_id))
         get_volume_type_extra_spec.assert_called_once_with(
-            type_id, 'vmdk_type', default_value=vmdk.THIN_VMDK_TYPE)
+            type_id, 'vmdk_type', default_value=vmdk.THICK_VMDK_TYPE)
         validate.assert_called_once_with(vmdk_type)
 
     @mock.patch.object(VMDK_DRIVER, '_get_extra_spec_disk_type')

--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -787,11 +787,11 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
     def _get_extra_spec_disk_type(type_id):
         """Get disk type from the given volume type's extra spec.
 
-        If there is no disk type option, default is THIN_VMDK_TYPE.
+        If there is no disk type option, default is THICK_VMDK_TYPE.
         """
         disk_type = _get_volume_type_extra_spec(type_id,
                                                 'vmdk_type',
-                                                default_value=THIN_VMDK_TYPE)
+                                                default_value=THICK_VMDK_TYPE)
         volumeops.VirtualDiskType.validate(disk_type)
         return disk_type
 


### PR DESCRIPTION
This patch changes the default provisioning type in the vmdk driver to thick, since we use thick everywhere for vmware/fcd based volumes.  This allows us to remove the volume type extra specs setting.