### PR TITLE
[SAP] use BackupRestoreHandle only for restoring to VMware

### DIFF
--- a/cinder/backup/chunkeddriver.py
+++ b/cinder/backup/chunkeddriver.py
@@ -107,7 +107,8 @@ class ChunkedBackupDriver(driver.BackupDriver, metaclass=abc.ABCMeta):
     """
 
     DRIVER_VERSION = '1.0.0'
-    DRIVER_VERSION_MAPPING = {
+    DRIVER_VERSION_MAPPING = {'1.0.0': '_restore_v1'}
+    SAP_DRIVER_VERSION_MAPPING = {
         '1.0.0': 'cinder.backup.chunkeddriver.BackupRestoreHandleV1'
     }
 
@@ -796,13 +797,19 @@ class ChunkedBackupDriver(driver.BackupDriver, metaclass=abc.ABCMeta):
         metadata = self._read_metadata(backup)
         metadata_version = metadata['version']
         LOG.debug('Restoring backup version %s', metadata_version)
+        sap_restore = use_sap_restore(volume_file)
         try:
-            restore_handle = importutils.import_object(
-                self.DRIVER_VERSION_MAPPING[metadata_version],
-                self,
-                volume_id,
-                volume_file)
-        except (KeyError, ImportError):
+            if sap_restore:
+                restore_handle = importutils.import_object(
+                    self.SAP_DRIVER_VERSION_MAPPING[metadata_version],
+                    self,
+                    volume_id,
+                    volume_file)
+            else:
+                restore_handle = getattr(
+                    self, self.DRIVER_VERSION_MAPPING.get(
+                        metadata_version))
+        except (TypeError, KeyError, ImportError):
             err = (_('No support to restore backup version %s')
                    % metadata_version)
             raise exception.InvalidBackup(reason=err)
@@ -824,8 +831,11 @@ class ChunkedBackupDriver(driver.BackupDriver, metaclass=abc.ABCMeta):
             backup1 = backup_list[index]
             index = index - 1
             metadata = self._read_metadata(backup1)
-            restore_handle.add_backup(backup1, metadata, backup, volume_id)
-
+            if sap_restore:
+                restore_handle.add_backup(backup1, metadata, backup, volume_id)
+            else:
+                restore_handle(backup1, volume_id, metadata, volume_file,
+                               volume_is_new, backup)
             volume_meta = metadata.get('volume_meta', None)
             try:
                 if volume_meta:
@@ -837,7 +847,8 @@ class ChunkedBackupDriver(driver.BackupDriver, metaclass=abc.ABCMeta):
                 LOG.error(msg)
                 raise exception.BackupOperationError(msg)
 
-        restore_handle.finish_restore()
+        if sap_restore:
+            restore_handle.finish_restore()
 
         LOG.debug('restore %(backup_id)s to %(volume_id)s finished.',
                   {'backup_id': backup_id, 'volume_id': volume_id})
@@ -873,6 +884,11 @@ class ChunkedBackupDriver(driver.BackupDriver, metaclass=abc.ABCMeta):
                 eventlet.sleep(0)
 
         LOG.debug('delete %s finished.', backup['id'])
+
+
+def use_sap_restore(volume_file):
+    class_name = volume_file.__class__.__name__
+    return class_name and "VmdkReadHandle" in class_name
 
 
 class BackupRestoreHandle(object, metaclass=abc.ABCMeta):

--- a/cinder/tests/unit/backup/test_chunkeddriver.py
+++ b/cinder/tests/unit/backup/test_chunkeddriver.py
@@ -455,9 +455,7 @@ class ChunkedDriverTestCase(test.TestCase):
                           self.backup,
                           mock.Mock())
 
-    @mock.patch('cinder.backup.chunkeddriver.BackupRestoreHandleV1.add_backup')
-    def test_restore(self, mock_add_backup):
-        volume_file = mock.Mock()
+    def _test_restore(self, volume_file):
         restore_test = mock.Mock()
         self.driver._restore_v1 = restore_test
 
@@ -469,7 +467,24 @@ class ChunkedDriverTestCase(test.TestCase):
             self.driver.restore(backup, self.volume, volume_file, False)
             self.assertEqual(2, mock_put.call_count)
 
+    @mock.patch('cinder.backup.chunkeddriver.BackupRestoreHandleV1.add_backup')
+    @mock.patch(
+        'cinder.backup.chunkeddriver.BackupRestoreHandleV1.finish_restore')
+    def test_restore(self, mock_finish_restore,
+                     mock_add_backup):
+        self._test_restore(mock.Mock())
+        mock_add_backup.assert_not_called()
+        mock_finish_restore.assert_not_called()
+
+    @mock.patch('cinder.backup.chunkeddriver.BackupRestoreHandleV1.add_backup')
+    @mock.patch(
+        'cinder.backup.chunkeddriver.BackupRestoreHandleV1.finish_restore')
+    def test_sap_restore(self, mock_finish_restore, mock_add_backup):
+        volume_file = mock.Mock(
+            __class__=mock.Mock(__name__='VmdkReadHandle'))
+        self._test_restore(volume_file)
         mock_add_backup.assert_called()
+        mock_finish_restore.assert_called_once_with()
 
     def test_delete_backup(self):
         with mock.patch.object(self.driver, 'delete_object') as mock_delete:

--- a/cinder/tests/unit/policies/test_volume_actions.py
+++ b/cinder/tests/unit/policies/test_volume_actions.py
@@ -406,8 +406,10 @@ class VolumeActionsPolicyTest(base.BasePolicyTest):
                                  id=volume.id, body=body)
 
     @ddt.data(*base.all_users)
+    @mock.patch.object(volume_api.volume_rpcapi.VolumeAPI, 'get_capabilities')
     @mock.patch('cinder.objects.Service.get_by_id')
-    def test_migrate_policy(self, user_id, mock_get_service_by_id):
+    def test_migrate_policy(self, user_id, mock_get_service_by_id,
+                            mock_get_capabilities):
         volume = self._create_volume()
         rule_name = policy.MIGRATE_POLICY
         url = '%s/%s/action' % (self.api_path, volume.id)

--- a/cinder/tests/unit/volume/drivers/test_datera.py
+++ b/cinder/tests/unit/volume/drivers/test_datera.py
@@ -20,7 +20,6 @@ import uuid
 from cinder import context
 from cinder import exception
 from cinder.tests.unit import test
-from cinder import version
 from cinder.volume import configuration as conf
 from cinder.volume import volume_types
 
@@ -430,21 +429,13 @@ class DateraVolumeTestCasev22(test.TestCase):
         offset = mock.MagicMock()
         sort_keys = mock.MagicMock()
         sort_dirs = mock.MagicMock()
-        if (version.version_string() >= '15.0.0'):
-            with mock.patch(
-                    'cinder.volume.volume_utils.paginate_entries_list') \
-                    as mpage:
-                self.driver.get_manageable_volumes(
-                    [testvol], marker, limit, offset, sort_keys, sort_dirs)
-                mpage.assert_called_once_with(
-                    [v1, v2], marker, limit, offset, sort_keys, sort_dirs)
-        else:
-            with mock.patch(
-                    'cinder.volume.utils.paginate_entries_list') as mpage:
-                self.driver.get_manageable_volumes(
-                    [testvol], marker, limit, offset, sort_keys, sort_dirs)
-                mpage.assert_called_once_with(
-                    [v1, v2], marker, limit, offset, sort_keys, sort_dirs)
+        with mock.patch(
+                'cinder.volume.volume_utils.paginate_entries_list') \
+                as mpage:
+            self.driver.get_manageable_volumes(
+                [testvol], marker, limit, offset, sort_keys, sort_dirs)
+            mpage.assert_called_once_with(
+                [v1, v2], marker, limit, offset, sort_keys, sort_dirs)
 
     def test_unmanage(self):
         testvol = _stub_volume()

--- a/custom-requirements.txt
+++ b/custom-requirements.txt
@@ -9,6 +9,6 @@ jaeger-client
 -e git+https://github.com/sapcc/openstack-watcher-middleware.git#egg=watcher-middleware
 -e git+https://github.com/sapcc/openstack-audit-middleware.git#egg=audit-middleware
 -e git+https://github.com/sapcc/openstack-rate-limit-middleware.git#egg=rate-limit-middleware
--e git+https://github.com/sapcc/os-brick.git@stable/wallaby-m3#egg=os-brick
--e git+https://github.com/sapcc/oslo.vmware.git@stable/wallaby-m3#egg=oslo.vmware
--e git+https://github.com/sapcc/dnspython.git@stable/wallaby-m3#egg=dnspython
+-e git+https://github.com/sapcc/os-brick.git@stable/2023.1-m3#egg=os-brick
+-e git+https://github.com/sapcc/oslo.vmware.git@stable/2023.1-m3#egg=oslo.vmware
+-e git+https://github.com/sapcc/dnspython.git@stable/2023.1-m3#egg=dnspython


### PR DESCRIPTION
Otherwise, use upstream's _restore_v1 function.
This allows using the new _write_nonzero upstream function for the other kind of backups, which can't work when restoring a backup to VMware (as it's done via HTTP).

Change-Id: I425b4ca4161f28eb6a50b4fc18737561932133f0

---

This also includes 2 other commits for the 2023.1 upgrade