### PR TITLE
[SAP] Allow migration for vmdk -> fcd

### DIFF
--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -3134,9 +3134,10 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         except ValueError:
             return false_ret
 
-        if ((volume['status'] == 'retyping') and
-           (driver_name == 'VMwareVcFcdDriver')):
-            LOG.info("Retyping volume %s to FCD driver.", volume['id'])
+        # This covers retype and migration
+        if (driver_name == 'VMwareVcFcdDriver'):
+            LOG.info("Retyping/Migrating volume %s to FCD driver.",
+                     volume['id'])
             return self._migrate_to_fcd(context, volume, host)
 
         if driver_name != self._driver_name():


### PR DESCRIPTION
This patch updates the vmdk.py driver to allow migration of a vmdk based volume to fcd.

Change-Id: I1b79d54398cda6aa8e47bbd0c001da214320d487