### PR TITLE
[SAP] Update nova after a migration for attached

### DIFF
--- a/cinder/volume/drivers/vmware/fcd.py
+++ b/cinder/volume/drivers/vmware/fcd.py
@@ -868,6 +868,18 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
         )
         volume.update({'provider_location': prov_loc})
         volume.save()
+        
+        backing = self.volumeops.get_backing(volume.name, volume.id)
+        chost = self.volumeops.get_host(backing)
+        dc_ref = self.volumeops.get_dc(chost)
+        disk_dev = self.volumeops.get_disk_by_uuid(backing, volume.id)
+        vmdk_path = disk_dev.backing.fileName
+        
+        self._update_fcd_attachment_info_for_nova(
+            context, volume, prov_loc,
+            vmdk_path,
+            dc_ref
+        )
         return (True, None)
 
     @volume_utils.trace

--- a/cinder/volume/drivers/vmware/fcd.py
+++ b/cinder/volume/drivers/vmware/fcd.py
@@ -868,13 +868,10 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
         )
         volume.update({'provider_location': prov_loc})
         volume.save()
-        
-        backing = self.volumeops.get_backing(volume.name, volume.id)
-        chost = self.volumeops.get_host(backing)
-        dc_ref = self.volumeops.get_dc(chost)
-        disk_dev = self.volumeops.get_disk_by_uuid(backing, volume.id)
-        vmdk_path = disk_dev.backing.fileName
-        
+
+        dc_ref = self.volumeops.get_dc(ds_ref)
+        vmdk_path = self.volumeops.get_vmdk_path_for_fcd(fcd_loc=fcd_loc_new)
+
         self._update_fcd_attachment_info_for_nova(
             context, volume, prov_loc,
             vmdk_path,

--- a/cinder/volume/drivers/vmware/volumeops.py
+++ b/cinder/volume/drivers/vmware/volumeops.py
@@ -2157,7 +2157,11 @@ class VMwareVolumeOps(object):
             backing_spec.path = path + '/'
         return backing_spec
 
-    def get_vmdk_path_for_fcd(self, ds_ref, disk_id):
+    def get_vmdk_path_for_fcd(self, ds_ref=None, disk_id=None, fcd_loc=None):
+        cf = self._session.vim.client.factory
+        if fcd_loc:
+            ds_ref = fcd_loc.ds_ref()
+            disk_id = fcd_loc.id(cf)
         vstorage_mgr = self._session.vim.service_content.vStorageObjectManager
         fcd_obj = self._session.invoke_api(
             self._session.vim,


### PR DESCRIPTION
This patch refactors a bit of code to allow both vmdk and fcd drivers to update nova after an attached fcd volume has been migrated.

Change-Id: I80517f79ece2ce24f0457d742e13476ce5cb9ca8