### PR TITLE
SAP: clean up sensitive info from the connection_info

### DIFF
--- a/cinder/objects/volume_attachment.py
+++ b/cinder/objects/volume_attachment.py
@@ -147,6 +147,11 @@ class VolumeAttachment(base.CinderPersistentObject, base.CinderObject,
     def _convert_connection_info_to_db_format(updates):
         properties = updates.pop('connection_info', None)
         if properties is not None:
+            # SAP: Remove sensitive data from the connection_info
+            # before storing it in the database
+            if properties.get('config', {}).get('vmware_host_ip'):
+                del properties['config']
+
             updates['connection_info'] = jsonutils.dumps(properties)
 
     @staticmethod


### PR DESCRIPTION
connection_info['config'] may contain sensitive information about the vCenter and we don't want it to end up in the attachments database, therefore we must drop it before saving VolumeAttachment.

Note: there was no real elegant way of fixing this, as all of these properties are needed during the operation runtime, except when the attachment is saved to the DB.

Change-Id: I73f873c04a8c66a4bc368aa7773999241a7858d8