### PR TITLE
SAP: sensitive connection_info to only be sent for os_brick

### DIFF
--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -1101,7 +1101,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         }
 
         # vmdk connector in os-brick needs additional connection info.
-        if 'platform' in connector and 'os_type' in connector:
+        if self._is_os_brick_connector(connector):
             connection_info['data']['vmdk_size'] = volume['size'] * units.Gi
 
             vmdk_path = self.volumeops.get_vmdk_path(backing)
@@ -1130,6 +1130,11 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                    'connector': connector})
 
         return connection_info
+
+    @staticmethod
+    def _is_os_brick_connector(connector):
+        return ('platform' in connector and 'os_type' in connector
+                and connector['os_type'] != 'baremetal')
 
     def _is_volume_subject_to_import_vapp(self, volume):
         return (volume['status'] == 'restoring-backup' or
@@ -1266,7 +1271,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         # that case, the VMDK connector in os-brick created a new backing
         # which will replace the initial one. Here we set the proper name
         # and backing uuid for the new backing, because os-brick doesn't do it.
-        if (connector and 'platform' in connector and 'os_type' in connector
+        if (connector and self._is_os_brick_connector(connector)
                 and self._is_volume_subject_to_import_vapp(volume)):
             backing = self.volumeops.get_backing_by_uuid(volume['id'])
 


### PR DESCRIPTION
An attempt to attach a volume to a baremetal instance would generate a connector with os_type='platform', thus we need to be more specific when checking if the connector is os_brick.

This prevents any sensitive information that's passed to os_brick from being saved in the attachments database.

Change-Id: I58f9c8e3f57bd632ae8abd74f9afc9acd070363c