### PR TITLE
[SAP] Start work on FCD QOS setting

### DIFF
--- a/cinder/volume/drivers/vmware/fcd.py
+++ b/cinder/volume/drivers/vmware/fcd.py
@@ -208,6 +208,19 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
         fcd_loc = self.volumeops.create_fcd(
             volume.id, volume.name, volume.size * units.Ki, ds_ref,
             disk_type, profile_id=profile_id)
+        
+        # Check if the quality type is 'standard', then we need to apply
+        # the storage policy on the netapp for the vmdk file associated
+        # with this volume.
+        quality_type = self._get_volume_type_extra_spec(volume['volume_type_id'], 'quality_type')
+        if quality_type == 'standard':
+            # apply the netapp storage policy on the vmdk file.
+            # what netapp do we talk to?
+            # get the config options for that specific netapp, so we can
+            # create the correct rest client that is connected to that netapp
+            # so we can apply the qos setting on the vmdk file.a
+            pass
+            
 
         # Convert the provider_location from the moref format to the
         # datastore name format to store in the cinder DB.

--- a/cinder/volume/drivers/vmware/fcd.py
+++ b/cinder/volume/drivers/vmware/fcd.py
@@ -34,6 +34,7 @@ from cinder import exception
 from cinder.i18n import _
 from cinder import interface
 from cinder.volume.drivers.vmware import vmdk
+from cinder.volume.drivers.vmware.vmdk import _get_volume_type_extra_spec
 from cinder.volume.drivers.vmware import volumeops as vops
 from cinder.volume import volume_utils
 
@@ -212,7 +213,10 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
         # Check if the quality type is 'standard', then we need to apply
         # the storage policy on the netapp for the vmdk file associated
         # with this volume.
-        quality_type = self._get_volume_type_extra_spec(volume['volume_type_id'], 'quality_type')
+        quality_type = _get_volume_type_extra_spec(
+                volume['volume_type_id'],
+                'quality_type'
+            )
         if quality_type == 'standard':
             # apply the netapp storage policy on the vmdk file.
             # what netapp do we talk to?
@@ -220,7 +224,6 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
             # create the correct rest client that is connected to that netapp
             # so we can apply the qos setting on the vmdk file.a
             pass
-            
 
         # Convert the provider_location from the moref format to the
         # datastore name format to store in the cinder DB.

--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -220,6 +220,13 @@ vmdk_opts = [
                'cinder-volume container having to proxy the image between '
                'glance and VMware.'
                ),
+    cfg.StrOpt('vmware_netapp_user',
+               default=None,
+               help='Username to use to connect to the netapp servers'),
+    cfg.StrOpt('vmware_netapp_password',
+               default=None,
+               help='Password to use to connect to the netapp servers',
+               secret=True),
 ]
 
 CONF = cfg.CONF
@@ -380,6 +387,9 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         self._remote_api = remote_api.VmdkDriverRemoteApi()
         self._storage_profiles = []
         self._volume_type_by_backend = None
+        # This is a cache of the netapp_fqdn lookup
+        # based on the datastore name.
+        self._netapp_lookup = {}
 
     @staticmethod
     def get_driver_options():
@@ -633,6 +643,9 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                         has_aggregate_pool = True
                         aggregate_id = \
                             custom_attributes['cinder_aggregate_id']
+                    if 'netapp_fqdn' in custom_attributes:
+                        self._netapp_lookup[summary.name] = \
+                            custom_attributes['netapp_fqdn']
 
                 pool = {'pool_name': summary.name,
                         'total_capacity_gb': round(


### PR DESCRIPTION
This patch is the start of the work needed to enable setting qos settings for standard_hdd volume type volumes for netapp .vmdk files.

This patch simply lays out the logic for finding extra spec setting that tells the driver that the volume to be created is for standard hdd. Added todos in comments to actually do the work.

Change-Id: Ie0f59716c9f28076d65dc3c0580c836f6879f90d