### PR TITLE
SAP: VMware FCD volume encryption

### DIFF
--- a/cinder/common/sap.py
+++ b/cinder/common/sap.py
@@ -25,5 +25,9 @@ sap_custom_opts = [
                 default=False,
                 help='Allow cinder to schedule a clone volume on a pool '
                      'other than the source volume pool.'),
+    cfg.StrOpt('sap_barbican_acl_user_id',
+               default=None,
+               help='ID of the technical user for which to add ACL '
+                    'in Barbican when an encryption key is created.')
 ]
 CONF.register_opts(sap_custom_opts)

--- a/cinder/keymgr/kmip.py
+++ b/cinder/keymgr/kmip.py
@@ -1,0 +1,64 @@
+# Copyright (C) 2025 SAP SE
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from oslo_log import log as logging
+import requests
+
+from cinder import utils
+
+LOG = logging.getLogger(__name__)
+
+
+class KMIPRestApiClient:
+
+    def __init__(self, kmip_url, barbican_url):
+        self._kmip_url = kmip_url
+        self._barbican_url = barbican_url
+
+    @utils.retry(requests.RequestException)
+    def kmip_register(self, key_uuid: str,
+                      owner: str, policy: str) -> str:
+        """Registers a new KMIP object in the managed_objects.
+
+        :returns: the ID of the object created in KMIP
+        """
+        key_url = f"{self._barbican_url}/v1/secrets/{key_uuid}"
+        payload = {
+            "url": key_url,
+            "owner": owner,
+            "policy": policy
+        }
+        LOG.debug("Registering barbican key to KMIP. Request=%s",
+                  payload)
+        response = requests.post(
+            f"{self._kmip_url}/kmip/kmip_register",
+            json=payload)
+        data = response.json()
+        LOG.debug("Registered barbican key to KMIP. Result=%s",
+                  data)
+        return str(data.get("uid"))
+
+    @utils.retry(requests.RequestException)
+    def get_kmip_id(self, barbican_uuid: str) -> str:
+        """Retrieves the KMIP ID of a Barbican key
+
+        :returns: the ID of the key in KMIP
+        """
+        LOG.debug("Retrieving KMIP id for barbican_uuid=%s",
+                  barbican_uuid)
+        response = requests.get(
+            f"{self._kmip_url}/kmip/get_kmip_id_from_barbican"
+            f"?barbican_id={barbican_uuid}")
+        data = response.json()
+        return str(data.get("kmip_id"))

--- a/cinder/tests/unit/volume/drivers/vmware/test_fcd.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_fcd.py
@@ -70,6 +70,8 @@ class VMwareVStorageObjectDriverTestCase(test.TestCase):
         self._config.vmware_storage_profile = None
         self._config.reserved_percentage = self.RESERVED_PERCENTAGE
         self._config.vmware_datastores_as_pools = False
+        self._config.kmip_api_url = mock.sentinel.kmip_api_url
+        self._config.barbican_url = mock.sentinel.barbican_url
         self._config.vmware_snapshot_format = "COW"
         self._config.sap_netapp_credentials = {}
         self._driver = fcd.VMwareVStorageObjectDriver(
@@ -231,7 +233,8 @@ class VMwareVStorageObjectDriverTestCase(test.TestCase):
             vops.create_fcd.assert_called_once_with(
                 volume.id, volume.name, volume.size * units.Ki,
                 ds_ref, disk_type,
-                profile_id=profile_id)
+                profile_id=profile_id,
+                key_id=None)
         else:
             self.assertIsNone(ret)
             select_ds_fcd.assert_not_called()
@@ -438,7 +441,9 @@ class VMwareVStorageObjectDriverTestCase(test.TestCase):
             str(ds_url),
             volume.name,
             datastore)
-        vops.update_fcd_policy.assert_called_once_with(fcd_loc, profile_id)
+        vops.update_fcd_policy.assert_called_once_with(fcd_loc, profile_id,
+                                                       key_id=None,
+                                                       is_new=True)
         volume_update.assert_called_once_with(
             {'provider_location': provider_location}
         )
@@ -547,8 +552,10 @@ class VMwareVStorageObjectDriverTestCase(test.TestCase):
                                       name, dest_ds_ref, disk_type)
         self.assertEqual(dest_fcd_loc, ret)
         vops.clone_fcd.assert_called_once_with(
-            name, fcd_loc, dest_ds_ref, disk_type, profile_id=None)
+            name, fcd_loc, dest_ds_ref, disk_type,
+            profile_id=None, key_id=None)
 
+    @mock.patch.object(FCD_DRIVER, '_get_storage_profile_id')
     @mock.patch.object(FCD_DRIVER,
                        '_snap_provider_location_to_ds_name_location')
     @mock.patch.object(FCD_DRIVER,
@@ -563,6 +570,7 @@ class VMwareVStorageObjectDriverTestCase(test.TestCase):
             provider_loc_to_moref,
             provider_loc_to_ds_name_loc,
             snap_provider_loc_to_ds_name_loc,
+            _get_storage_profile_id,
             use_fcd_snapshot=False):
         self._driver._use_fcd_snapshot = use_fcd_snapshot
 
@@ -587,6 +595,7 @@ class VMwareVStorageObjectDriverTestCase(test.TestCase):
             provider_loc_to_moref.return_value = None
             from_provider_loc.return_value = dest_fcd_loc
             provider_loc_to_ds_name_loc.return_value = provider_location
+            _get_storage_profile_id.return_value = mock.sentinel.profile_id
 
         volume = self._create_volume_obj()
         snapshot = fake_snapshot.fake_snapshot_obj(
@@ -600,7 +609,8 @@ class VMwareVStorageObjectDriverTestCase(test.TestCase):
         else:
             select_ds_fcd.assert_called_once_with(snapshot.volume)
             clone_fcd.assert_called_once_with(
-                volume.provider_location, snapshot, ds_ref)
+                volume.provider_location, snapshot, ds_ref,
+                profile_id=mock.sentinel.profile_id, key_id=None)
 
     def test_create_snapshot_legacy(self):
         self._test_create_snapshot()
@@ -698,7 +708,8 @@ class VMwareVStorageObjectDriverTestCase(test.TestCase):
         get_disk_type.test_assert_called_once_with(volume)
         clone_fcd.assert_called_once_with(provider_loc, volume,
                                           ds_ref, disk_type=disk_type,
-                                          profile_id=profile_id)
+                                          profile_id=profile_id,
+                                          key_id=None)
         extend_if_needed.assert_called_once_with(
             cloned_fcd_loc, cur_size, volume.size)
 
@@ -744,7 +755,8 @@ class VMwareVStorageObjectDriverTestCase(test.TestCase):
         if use_fcd_snapshot:
             self.assertEqual({'provider_location': provider_loc}, ret)
             vops.create_fcd_from_snapshot.assert_called_once_with(
-                fcd_snap_loc, volume.name, volume.id, profile_id=profile_id)
+                fcd_snap_loc, volume.name, volume.id, profile_id=profile_id,
+                key_id=None)
             extend_if_needed.assert_called_once_with(
                 fcd_loc, snapshot.volume_size, volume.size)
         else:

--- a/cinder/tests/unit/volume/drivers/vmware/test_vmware_volumeops.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_vmware_volumeops.py
@@ -37,9 +37,12 @@ class VolumeOpsTestCase(test.TestCase):
     def setUp(self):
         super(VolumeOpsTestCase, self).setUp()
         self.session = mock.MagicMock()
+        configuration = mock.Mock(
+            vmware_host_ip='vsphere')
+        kmip_api = mock.Mock()
         self.vops = volumeops.VMwareVolumeOps(
             self.session, self.MAX_OBJECTS, mock.sentinel.extension_key,
-            mock.sentinel.extension_type)
+            mock.sentinel.extension_type, configuration, kmip_api)
 
     def test_split_datastore_path(self):
         test1 = '[datastore1] myfolder/mysubfolder/myvm.vmx'
@@ -2334,6 +2337,7 @@ class VolumeOpsTestCase(test.TestCase):
             datastore=ds_ref,
             snapshotId=fcd_snap_id,
             name=name,
+            crypto=None,
             profile=[profile_spec],
             path=name + '/')
         self.session.wait_for_task.assert_called_once_with(task)

--- a/cinder/volume/drivers/vmware/fcd.py
+++ b/cinder/volume/drivers/vmware/fcd.py
@@ -233,9 +233,10 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
         disk_type = self._get_disk_type(volume)
         ds_ref = self._select_ds_fcd(volume)
         profile_id = self._get_storage_profile_id(volume)
+        key_id = self._register_kmip_key_id(volume)
         fcd_loc = self.volumeops.create_fcd(
             volume.id, volume.name, volume.size * units.Ki, ds_ref,
-            disk_type, profile_id=profile_id)
+            disk_type, profile_id=profile_id, key_id=key_id)
 
         # Convert the provider_location from the moref format to the
         # datastore name format to store in the cinder DB.
@@ -340,6 +341,10 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
                 'datacenter': datacenter,
             }
         }
+
+        kmip_key_id = self._get_kmip_key_id(volume)
+        if kmip_key_id:
+            connection_info['data']['kmip_key_id'] = kmip_key_id
 
         # This is needed by the backup process (os-brick)
         if self._is_os_brick_connector(connector):
@@ -498,7 +503,16 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
 
         profile_id = self._get_storage_profile_id(volume)
         if profile_id:
-            self.volumeops.update_fcd_policy(fcd_loc, profile_id)
+            key_id = self._register_kmip_key_id(volume)
+            self.volumeops.update_fcd_policy(
+                fcd_loc, profile_id, key_id=key_id, is_new=True)
+            if key_id:
+                # VMware moves the disk to another path after encryption
+                vmdk_path = self._volumeops.get_vmdk_path_for_fcd(
+                    fcd_loc=fcd_loc)
+
+        self.volumeops.update_fcd_vmdk_uuid(ds_ref,
+                                            vmdk_path, volume.id)
 
         # Extend the volume if needed
         # break this up to 2 lines to pass pep8
@@ -509,14 +523,27 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
                 fcd_loc=fcd_loc) / units.Gi)
         image_size = 1 if image_gib == 0 else image_gib
         self._extend_if_needed(fcd_loc, image_size, volume.size)
-        self.volumeops.update_fcd_vmdk_uuid(ds_ref,
-                                            vmdk_path, volume.id)
 
         provider_location = self._provider_location_to_ds_name_location(
             fcd_loc.provider_location()
         )
         volume.update({'provider_location': provider_location})
         volume.save()
+
+    def _register_kmip_key_id(self, obj):
+        if getattr(obj, 'encryption_key_id', None):
+            owner = self.configuration.vmware_host_ip
+            return self._kmip_api.kmip_register(
+                obj.encryption_key_id,
+                owner,
+                "default")
+        return None
+
+    def _get_kmip_key_id(self, obj):
+        barbican_id = getattr(obj, 'encryption_key_id', None)
+        if barbican_id:
+            return self._kmip_api.get_kmip_id(barbican_id)
+        return None
 
     @volume_utils.trace
     def copy_volume_to_image(self, context, volume, image_service, image_meta):
@@ -595,7 +622,7 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
 
     def _clone_fcd(self, provider_loc, volume, dest_ds_ref,
                    disk_type=vops.VirtualDiskType.THIN,
-                   profile_id=None):
+                   profile_id=None, key_id=None):
         # Must pass in the moref format for the provider location
         fcd_loc = vops.FcdLocation.from_provider_location(provider_loc)
         cf = self._session.vim.client.factory
@@ -612,7 +639,7 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
         else:
             return self.volumeops.clone_fcd(
                 volume, fcd_loc, dest_ds_ref,
-                disk_type, profile_id=profile_id
+                disk_type, profile_id=profile_id, key_id=key_id
             )
 
     @volume_utils.trace
@@ -642,7 +669,11 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
         provider_location = self._provider_location_to_moref_location(
             snapshot.volume.provider_location
         )
-        cloned_fcd_loc = self._clone_fcd(provider_location, snapshot, ds_ref)
+        profile_id = self._get_storage_profile_id(snapshot.volume)
+        key_id = self._register_kmip_key_id(snapshot)
+        cloned_fcd_loc = self._clone_fcd(provider_location, snapshot, ds_ref,
+                                         profile_id=profile_id,
+                                         key_id=key_id)
         # Now convert the fcd snapshot provider location to the
         # datastore format
         provider_location = self._provider_location_to_ds_name_location(
@@ -688,9 +719,10 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
         provider_loc = self._provider_location_to_moref_location(
             provider_location
         )
+        key_id = self._register_kmip_key_id(volume)
         cloned_fcd_loc = self._clone_fcd(
             provider_loc, volume, ds_ref, disk_type=disk_type,
-            profile_id=profile_id)
+            profile_id=profile_id, key_id=key_id)
         self._extend_if_needed(cloned_fcd_loc, cur_size, volume.size)
         # Convert the provider location from the moref format to the
         # datastore name format to store in the cinder DB.
@@ -715,8 +747,10 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
             fcd_snap_loc = vops.FcdSnapshotLocation.from_provider_location(
                 snap_location)
             profile_id = self._get_storage_profile_id(volume)
+            key_id = self._register_kmip_key_id(volume)
             fcd_loc = self.volumeops.create_fcd_from_snapshot(
-                fcd_snap_loc, volume.name, volume.id, profile_id=profile_id)
+                fcd_snap_loc, volume.name, volume.id, profile_id=profile_id,
+                key_id=key_id)
             self._extend_if_needed(fcd_loc, snapshot.volume_size, volume.size)
             # Convert the provider location from the moref format to the
             # datastore name format to store in the cinder DB.
@@ -872,7 +906,7 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
 
         if ds_info['datastore_url'] != src_ds_info['url']:
             self.volumeops.relocate_fcd(fcd_loc, ds_ref, volume.name,
-                                        service_locator)
+                                        service_locator, new_profile_id)
 
         # if we are migrating to a different DS on the same host
         # there is no reason to call the remote_api to get the
@@ -892,13 +926,15 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
 
         volume.update({'provider_location': prov_loc})
         volume.save()
+        key_id = self._get_kmip_key_id(volume)
         if cross_vc:
             if self._use_fcd_cross_vc_migration:
                 # Use the native FCD cross vc migration from 8.0U3 and >
                 fcd_loc_moid = vops.FcdLocation(fcd_loc.fcd_id, ds_ref.value)
                 prov_loc_moid = fcd_loc_moid.provider_location()
                 self._remote_api.update_fcd_policy(
-                    context, dest_host, prov_loc_moid, new_profile_id)
+                    context, dest_host, prov_loc_moid, new_profile_id,
+                    key_id=key_id)
             else:
                 # TODO(hemna): Add the temporary shadow migration
                 LOG.error("TODO: Need to add shadow migration for cross vc.")
@@ -906,7 +942,8 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
         # todo-update policy-onremote vc and move it to folder
         else:
             fcd_loc_moid = vops.FcdLocation(fcd_loc.fcd_id, ds_ref.value)
-            self.volumeops.update_fcd_policy(fcd_loc_moid, new_profile_id)
+            self.volumeops.update_fcd_policy(fcd_loc_moid, new_profile_id,
+                                             key_id=key_id)
 
         return (True, None)
 

--- a/cinder/volume/drivers/vmware/remote.py
+++ b/cinder/volume/drivers/vmware/remote.py
@@ -67,11 +67,13 @@ class VmdkDriverRemoteApi(rpc.RPCAPI):
         return cctxt.call(ctxt, 'destory_backing', volume=volume)
 
     @volume_utils.trace
-    def update_fcd_policy(self, ctxt, cinder_host, prov_loc, profile_id):
+    def update_fcd_policy(self, ctxt, cinder_host, prov_loc, profile_id,
+                          key_id=None):
         cctxt = self._get_cctxt(cinder_host)
         return cctxt.call(ctxt, 'update_fcd_policy',
                           prov_loc=prov_loc,
-                          profile_id=profile_id)
+                          profile_id=profile_id,
+                          key_id=key_id)
 
     def get_fcd_provider_location(self, ctxt, host, fcd_id, datastore_ref):
         cctxt = self._get_cctxt(host)
@@ -132,11 +134,12 @@ class VmdkDriverRemoteService(object):
         self._driver.volumeops.delete_backing(backing)
 
     @volume_utils.trace
-    def update_fcd_policy(self, ctxt, prov_loc, profile_id):
+    def update_fcd_policy(self, ctxt, prov_loc, profile_id, key_id=None):
         vops = self._driver.volumeops
         fcd_location = vops._get_fcd_loc(prov_loc)
         return self._driver.volumeops.update_fcd_policy(fcd_location,
-                                                        profile_id)
+                                                        profile_id,
+                                                        key_id=key_id)
 
     def get_fcd_provider_location(self, ctxt, fcd_id, datastore_ref):
         fcd_loc_new = self._driver._get_fcd_location(fcd_id, datastore_ref)

--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -48,6 +48,7 @@ from cinder.common import sap # noqa
 from cinder.i18n import _
 from cinder.image import image_utils
 from cinder import interface
+from cinder.keymgr import kmip
 from cinder.objects import snapshot as snapshot_obj
 from cinder.volume import configuration
 from cinder.volume import driver
@@ -232,6 +233,13 @@ vmdk_opts = [
         'sap_netapp_credentials = netapp_1: {user: foo, password: bar},'
         'netapp_2: {user: baz, password: qux}'
     ),
+    cfg.StrOpt('kmip_api_url',
+               default="http://kmip-barbican:5006",
+               help='KMIP rest API base URL'),
+    cfg.StrOpt('barbican_url',
+               default="http://barbican-api:9311",
+               help='Barbican base URL passed to the KMIP API to register a '
+                    'key. The URL must be accessible by the KMIP API.'),
 ]
 
 CONF = cfg.CONF
@@ -400,6 +408,9 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
             # only one item, so we need to get the first one.
             _conf = self.configuration
             self._sap_netapp_credentials = _conf.sap_netapp_credentials[0]
+        self._kmip_api = kmip.KMIPRestApiClient(
+            kmip_url=self.configuration.kmip_api_url,
+            barbican_url=self.configuration.barbican_url)
 
     @staticmethod
     def get_driver_options():
@@ -2030,6 +2041,11 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                                  VMwareVcVmdkDriver._get_disk_type(volume))
         # TODO(vbala): handle volume_size < disk_size case.
 
+    def copy_image_to_encrypted_volume(
+            self, context, volume, image_service, image_id):
+        # We don't do anything special as encryption is handled by the vCenter
+        self.copy_image_to_volume(context, volume, image_service, image_id)
+
     def copy_volume_to_image(self, context, volume, image_service, image_meta):
         """Creates glance image from volume.
 
@@ -2563,7 +2579,8 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
 
         max_objects = self.configuration.vmware_max_objects_retrieval
         self._volumeops = volumeops.VMwareVolumeOps(
-            self.session, max_objects, EXTENSION_KEY, EXTENSION_TYPE)
+            self.session, max_objects, EXTENSION_KEY, EXTENSION_TYPE,
+            self.configuration, self._kmip_api)
         random_ds = self.configuration.vmware_select_random_best_datastore
         random_ds_range = self.configuration.vmware_random_datastore_range
         self._ds_sel = hub.DatastoreSelector(
@@ -3398,11 +3415,13 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         prov_loc = fcd_loc.provider_location()
         self.volumeops.delete_backing(backing)
         ds_ref = vim_util.get_moref(tgt_ds['datastore'], 'Datastore')
+        profile_id = tgt_ds.get('profile_id')
         if (ds_ref.value != summary.datastore.value):
             # Migration required
             if vol_status == 'available':
-                self.volumeops.relocate_fcd(fcd_loc, ds_ref,
-                                            volume.name)
+                self.volumeops.relocate_fcd(fcd_loc, ds_ref, volume.name,
+                                            service=None,
+                                            profile_id=profile_id)
                 old_mref = summary.datastore.value
                 new_prov_loc = prov_loc.replace(old_mref, ds_ref.value)
                 prov_loc = self._provider_location_to_ds_name_location(
@@ -3416,7 +3435,6 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                 instance_uuid = attachments[0]['instance_uuid']
                 get_vm_by_uuid = self.volumeops.get_backing_by_uuid
                 attachedvm = get_vm_by_uuid(instance_uuid)
-                profile_id = tgt_ds.get('profile_id')
                 rp_ref = vim_util.get_moref(tgt_ds['resource_pool'],
                                             'ResourcePool')
                 self.volumeops.relocate_one_disk(attachedvm,

--- a/cinder/volume/drivers/vmware/volumeops.py
+++ b/cinder/volume/drivers/vmware/volumeops.py
@@ -43,6 +43,7 @@ VM_NUM_CPUS = 1
 VM_MEMORY_MB = 128
 VMX_VERSION = 'vmx-17'
 CONTROLLER_DEVICE_BUS_NUMBER = 0
+KEY_PROVIDER_ID = "kmip"
 
 
 def split_datastore_path(datastore_path):
@@ -288,7 +289,8 @@ class ControllerType(object):
 class VMwareVolumeOps(object):
     """Manages volume operations."""
 
-    def __init__(self, session, max_objects, extension_key, extension_type):
+    def __init__(self, session, max_objects, extension_key, extension_type,
+                 configuration, kmip_api):
         self._session = session
         self._max_objects = max_objects
         self._extension_key = extension_key
@@ -296,6 +298,8 @@ class VMwareVolumeOps(object):
         self._folder_cache = {}
         self._backing_ref_cache = {}
         self._vmx_version = None
+        self._configuration = configuration
+        self._kmip_api = kmip_api
 
     def set_vmx_version(self, vmx_version):
         self._vmx_version = vmx_version
@@ -1084,6 +1088,10 @@ class VMwareVolumeOps(object):
         relocate_spec.pool = resource_pool
         relocate_spec.host = host
         relocate_spec.diskMoveType = disk_move_type
+
+        if profile_id:
+            profile_spec = self._create_profile_spec(cf, profile_id)
+            relocate_spec.profile = [profile_spec]
 
         # Either we want to convert the disk by specifing the disk_type
         # or we need to determine the profile-id in the disk-locator
@@ -2210,7 +2218,8 @@ class VMwareVolumeOps(object):
         return profile_spec
 
     def create_fcd(self, cinder_uuid, name, size_mb,
-                   ds_ref, disk_type, profile_id=None):
+                   ds_ref, disk_type, profile_id=None,
+                   key_id=None):
         cf = self._session.vim.client.factory
         spec = cf.create('ns0:VslmCreateSpec')
         spec.capacityInMB = size_mb
@@ -2223,7 +2232,10 @@ class VMwareVolumeOps(object):
                                            'name')
         self.create_datastore_folder(ds_name, name, dc_ref)
 
-        if profile_id:
+        # Encrypted volumes must have the profile set later in the
+        # update_fcd_policy along with the key_id, otherwise VMware
+        # will create a new key in the KMIP provider.
+        if profile_id and not key_id:
             profile_spec = self._create_profile_spec(cf, profile_id)
             spec.profile = [profile_spec]
 
@@ -2240,6 +2252,11 @@ class VMwareVolumeOps(object):
         vmdk_path = fcd_obj.config.backing.filePath
         self.update_fcd_vmdk_uuid(ds_ref, vmdk_path, cinder_uuid)
         LOG.debug("Created fcd: %s.", fcd_loc)
+
+        if profile_id and key_id:
+            self.update_fcd_policy(fcd_loc, profile_id, key_id=key_id,
+                                   is_new=True)
+
         return fcd_loc
 
     def delete_fcd(self, fcd_location, delete_folder=False):
@@ -2278,7 +2295,7 @@ class VMwareVolumeOps(object):
 
     def clone_fcd(
             self, volume, fcd_location, dest_ds_ref,
-            disk_type, profile_id=None):
+            disk_type, profile_id=None, key_id=None):
         cf = self._session.vim.client.factory
         spec = cf.create('ns0:VslmCloneSpec')
         spec.name = volume.name
@@ -2295,6 +2312,17 @@ class VMwareVolumeOps(object):
         if profile_id:
             profile_spec = self._create_profile_spec(cf, profile_id)
             spec.profile = [profile_spec]
+
+        if key_id:
+            crypto_spec = cf.create('ns0:CryptoSpecShallowRecrypt')
+            crypto_key_id = cf.create('ns0:CryptoKeyId')
+            crypto_key_id.keyId = key_id
+            crypto_key_id.providerId = cf.create('ns0:KeyProviderId')
+            crypto_key_id.providerId.id = KEY_PROVIDER_ID
+            crypto_spec.newKeyId = crypto_key_id
+            disks_crypto = cf.create('ns0:DiskCryptoSpec')
+            disks_crypto.crypto = crypto_spec
+            spec.disksCrypto = disks_crypto
 
         LOG.debug("Copying fcd: %(fcd_loc)s to datastore: %(ds_ref)s with "
                   "spec: %(spec)s.",
@@ -2470,7 +2498,7 @@ class VMwareVolumeOps(object):
         self._session.wait_for_task(task)
 
     def create_fcd_from_snapshot(self, fcd_snap_loc, name,
-                                 cinder_uuid, profile_id=None):
+                                 cinder_uuid, profile_id=None, key_id=None):
         LOG.debug("Creating fcd with name: %(name)s from fcd snapshot: "
                   "%(snap)s.", {'name': name, 'snap': fcd_snap_loc.snap_id})
 
@@ -2487,6 +2515,17 @@ class VMwareVolumeOps(object):
             profile = [self._create_profile_spec(cf, profile_id)]
         else:
             profile = None
+
+        if key_id:
+            crypto_spec = cf.create('ns0:CryptoSpecShallowRecrypt')
+            crypto_key_id = cf.create('ns0:CryptoKeyId')
+            crypto_key_id.keyId = key_id
+            crypto_key_id.providerId = cf.create('ns0:KeyProviderId')
+            crypto_key_id.providerId.id = KEY_PROVIDER_ID
+            crypto_spec.newKeyId = crypto_key_id
+        else:
+            crypto_spec = None
+
         task = self._session.invoke_api(
             self._session.vim,
             'CreateDiskFromSnapshot_Task',
@@ -2496,6 +2535,7 @@ class VMwareVolumeOps(object):
             snapshotId=fcd_snap_loc.id(cf),
             name=name,
             profile=profile,
+            crypto=crypto_spec,
             path=name + '/')
         task_info = self._session.wait_for_task(task)
         self.update_fcd_vmdk_uuid(fcd_snap_loc.fcd_loc.ds_ref(),
@@ -2508,7 +2548,8 @@ class VMwareVolumeOps(object):
         return fcd_loc
 
     @volume_utils.trace
-    def update_fcd_policy(self, fcd_location, profile_id):
+    def update_fcd_policy(self, fcd_location, profile_id,
+                          key_id=None, is_new=False):
         LOG.debug("Changing fcd: %(fcd_loc)s storage policy to %(policy)s.",
                   {'fcd_loc': fcd_location.fcd_id, 'policy': profile_id})
 
@@ -2518,13 +2559,32 @@ class VMwareVolumeOps(object):
             profile_spec = cf.create('ns0:VirtualMachineEmptyProfileSpec')
         else:
             profile_spec = self._create_profile_spec(cf, profile_id)
+
+        task_name = 'UpdateVStorageObjectPolicy_Task'
+        extra_args = {}
+        if key_id:
+            LOG.debug("Encrypting FCD using keyId %s", key_id)
+            task_name = 'UpdateVStorageObjectCrypto_Task'
+            crypto_key_id = cf.create('ns0:CryptoKeyId')
+            crypto_key_id.keyId = key_id
+            crypto_key_id.providerId = cf.create('ns0:KeyProviderId')
+            crypto_key_id.providerId.id = KEY_PROVIDER_ID
+            crypto_type = ('CryptoSpecEncrypt'
+                           if is_new else 'CryptoSpecRegister')
+            crypto_spec = cf.create('ns0:%s' % crypto_type)
+            crypto_spec.cryptoKeyId = crypto_key_id
+            disks_crypto = cf.create('ns0:DiskCryptoSpec')
+            disks_crypto.crypto = crypto_spec
+            extra_args['disksCrypto'] = disks_crypto
+
         task = self._session.invoke_api(
             self._session.vim,
-            'UpdateVStorageObjectPolicy_Task',
+            task_name,
             vstorage_mgr,
             id=fcd_location.id(cf),
             datastore=fcd_location.ds_ref(),
-            profile=[profile_spec])
+            profile=[profile_spec],
+            **extra_args)
         self._session.wait_for_task(task)
 
         LOG.debug("Updated fcd storage policy to %s.", profile_id)
@@ -2536,19 +2596,25 @@ class VMwareVolumeOps(object):
         backingspec.path = path
         return backingspec
 
-    def _get_VslmRelocateSpec(self, datastore, path, service_locator=None):
+    def _get_VslmRelocateSpec(self, datastore, path, service_locator=None,
+                              profile_id=None):
         cf = self._session.vim.client.factory
         relocate_spec = cf.create("ns0:VslmRelocateSpec")
         relocate_spec.backingSpec = self._VslmCreateSpecDiskFileBackingSpec(
             datastore,
             path)
+        if profile_id:
+            relocate_spec.profile = [
+                self._create_profile_spec(cf, profile_id)]
+
         if service_locator:
             relocate_spec.service = self._get_service_locator_spec(
                 service_locator)
         return relocate_spec
 
     @volume_utils.trace
-    def relocate_fcd(self, fcd_loc, datastore, path, service=None):
+    def relocate_fcd(self, fcd_loc, datastore, path, service=None,
+                     profile_id=None):
         """Relocates fcd to the input datastore.
 
         :param fcd_loc: Reference to the fcd_obj
@@ -2562,7 +2628,8 @@ class VMwareVolumeOps(object):
         # In case of a cross-vcenter vmotion with a profile-id
         # changing the profile-id happens post relocate
 
-        relocate_spec = self._get_VslmRelocateSpec(datastore, path, service)
+        relocate_spec = self._get_VslmRelocateSpec(datastore, path, service,
+                                                   profile_id)
         vstorage_mgr = self._session.vim.service_content.vStorageObjectManager
         cf = self._session.vim.client.factory
         # For cross vc vmotion we don't create folder

--- a/cinder/volume/volume_utils.py
+++ b/cinder/volume/volume_utils.py
@@ -972,6 +972,8 @@ def create_encryption_key(context: context.RequestContext,
                 context,
                 algorithm=algorithm,
                 length=length)
+            sap_ensure_barbican_key_acl(context, key_manager,
+                                        encryption_key_id)
         except castellan_exception.KeyManagerError:
             # The messaging back to the client here is
             # purposefully terse, so we don't leak any sensitive
@@ -1018,6 +1020,8 @@ def clone_encryption_key(context: context.RequestContext,
         clone_key_id = key_manager.store(
             context,
             key_manager.get(context, encryption_key_id))
+        sap_ensure_barbican_key_acl(context, key_manager,
+                                    clone_key_id)
     return clone_key_id
 
 
@@ -1677,3 +1681,18 @@ def set_scheduler_hints_to_volume_metadata(scheduler_hints,
                 hint = ','.join(scheduler_hints["different_host"])
             metadata["scheduler_hint_different_host"] = hint
     return metadata
+
+
+def sap_ensure_barbican_key_acl(context, key_manager,
+                                encryption_key_id):
+    if (CONF.sap_barbican_acl_user_id
+            and type(key_manager).__name__ == "BarbicanKeyManager"):
+        client = key_manager._get_barbican_client(context)
+        secret_ref = key_manager._create_secret_ref(encryption_key_id)
+        acl_entry = client.acls.create(
+            entity_ref=secret_ref,
+            users=[CONF.sap_barbican_acl_user_id],
+            project_access=True)
+        acl_entry.submit()
+        LOG.debug("Created ACL for Barbican key %s",
+                  secret_ref)


### PR DESCRIPTION
Add support for encrypted volume types with the FCD driver.

Known limitations:
* At the moment cinder backups are not supported for the encrypted volumes.
* Encrypted volumes cannot be attached to non-encrypted VMS. The VM must be created from an encypted root disk.

Change-Id: Id2d189d9ce67599b61449eafa861e30313766e14