### PR TITLE
[SAP] fix FCD bootable adapater_type

### DIFF
--- a/cinder/volume/drivers/vmware/fcd.py
+++ b/cinder/volume/drivers/vmware/fcd.py
@@ -196,6 +196,29 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
         return fcd_snap_loc.provider_location()
 
     @volume_utils.trace
+    def _get_adapter_type(self, volume):
+        """Get the adapter type for the volume.
+
+        :param volume: Volume object
+        :returns: Adapter type
+        """
+        if volume.bootable:
+            # Fetch the adapter type from the image metadata
+            image_metadata = volume.glance_metadata
+            if image_metadata:
+                return image_metadata.get(
+                    'vmware_adaptertype',
+                    super(VMwareVStorageObjectDriver,
+                          self)._get_adapter_type(volume)
+                )
+            else:
+                return super(VMwareVStorageObjectDriver,
+                             self)._get_adapter_type(volume)
+        else:
+            return super(VMwareVStorageObjectDriver,
+                         self)._get_adapter_type(volume)
+
+    @volume_utils.trace
     def create_volume(self, volume):
         """Create a new volume on the backend.
 


### PR DESCRIPTION
This patch changes how we return the adapter_type for bootable volumes for FCD.  We need to return the adapter type that exists in the volume glance metadata if it's there.  The fallback is the same mechanism as before (first extra specs, default fallback to vmware_adapter_type in config)

Change-Id: I8faa731e476619721b6f1f8b63e29b3d4c1cd8f0