### PR TITLE
[SAP] update extend fcd if needed

### DIFF
--- a/cinder/tests/unit/volume/drivers/vmware/test_fcd.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_fcd.py
@@ -318,7 +318,8 @@ class VMwareVStorageObjectDriverTestCase(test.TestCase):
                            container_format='bare',
                            vmware_disktype='streamOptimized',
                            vmware_adaptertype='lsiLogic',
-                           is_public=True):
+                           is_public=True,
+                           virtual_size=1 * units.Gi):
         return {'id': _id,
                 'name': name,
                 'disk_format': disk_format,
@@ -328,6 +329,7 @@ class VMwareVStorageObjectDriverTestCase(test.TestCase):
                                'vmware_adaptertype': vmware_adaptertype,
                                },
                 'is_public': is_public,
+                'virtual_size': virtual_size,
                 }
 
     @mock.patch.object(FCD_DRIVER, '_get_adapter_type')

--- a/cinder/volume/drivers/vmware/fcd.py
+++ b/cinder/volume/drivers/vmware/fcd.py
@@ -492,11 +492,12 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
         profile_id = self._get_storage_profile_id(volume)
         if profile_id:
             self.volumeops.update_fcd_policy(fcd_loc, profile_id)
-        try:
-            LOG.warning("Extending volume %s to %s", volume.id, volume.size)
-            self.volumeops.extend_fcd(fcd_loc, volume['size'] * units.Ki)
-        except Exception as e:
-            LOG.error(e)
+
+        # Extend the volume if needed
+        # break this up to 2 lines to pass pep8
+        image_gib = int(metadata['virtual_size'] / units.Gi)
+        image_size = 1 if image_gib == 0 else image_gib
+        self._extend_if_needed(fcd_loc, image_size, volume.size)
         self.volumeops.update_fcd_vmdk_uuid(ds_ref,
                                             vmdk_path, volume.id)
 


### PR DESCRIPTION
This patch updates the last fix for fcd copy_image_to_volume when the volume needs to be extended.  We now call extend_if_needed if the volume size is > that the image size from the image metadata.

Change-Id: Ib343972451c9c2e0c8c4345a5dc51ce9bbb26c47