### PR TITLE
[SAP] Allow SAPFCDFilter as valid scheduler filter

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ cinder.scheduler.filters =
     SameBackendFilter = cinder.scheduler.filters.affinity_filter:SameBackendFilter
     InstanceLocalityFilter = cinder.scheduler.filters.instance_locality_filter:InstanceLocalityFilter
     ShardFilter = cinder.scheduler.filters.shard_filter:ShardFilter
+    SAPFCDFilter = cinder.scheduler.filters.sap_fcd_filter:SAPFCDFilter
     SAPLargeVolumeFilter = cinder.scheduler.filters.sap_large_volume_filter:SAPLargeVolumeFilter
     SAPDifferentBackendFilter = cinder.scheduler.filters.sap_affinity_filter:SAPDifferentBackendFilter
     SAPSameBackendFilter = cinder.scheduler.filters.sap_affinity_filter:SAPSameBackendFilter


### PR DESCRIPTION
In order for cinder config to be able to use the SAPFCDFilter, it must first be defined in the setup.cfg.  This simply makes the filter available as a choice in the config file.

Change-Id: Ib65efa32bbae5535c44456da99416734b0919096