### PR TITLE
[SAP] Fix SAPFCDFilter

### DIFF
--- a/cinder/scheduler/filters/sap_fcd_filter.py
+++ b/cinder/scheduler/filters/sap_fcd_filter.py
@@ -17,6 +17,7 @@
 from oslo_log import log as logging
 
 from cinder.scheduler import filters
+from cinder.volume.volume_utils import extract_host
 
 
 LOG = logging.getLogger(__name__)
@@ -38,14 +39,12 @@ class SAPFCDFilter(filters.BaseBackendFilter):
     def backend_passes(self, backend_state, filter_properties):
 
         if not self._is_vmware_fcd(backend_state):
-            LOG.info("Backend is not a VMware FCD backend")
             return True
 
         spec = filter_properties.get('request_spec', {})
         vol = spec.get('volume_properties', {})
 
         if spec.get('operation') != 'migrate_volume':
-            LOG.info("Operation is not a migrate_volume")
             return True
 
         # We are migrating a volume.  If we are migrating to a different
@@ -53,20 +52,43 @@ class SAPFCDFilter(filters.BaseBackendFilter):
         # original backend.
 
         #   name@backend#pool
-        orig_host = vol.get('host')
-        orig_backend = orig_host.split('#')[0]
-        orig_pool = orig_host.split('#')[1]
-        destination_host = spec.get('destination_host')
+        # This is the backend passed in to the filter.
+        filter_pool = extract_host(backend_state.host, 'pool')
+        filter_backend = extract_host(backend_state.host, 'backend')
 
-        dest_backend = destination_host.split('#')[0]
-        dest_pool = destination_host.split('#')[1]
+        # This is the original host, backend and pool that the volume
+        # was created on.
+        orig_host = vol.get('host')
+        orig_backend = extract_host(orig_host, 'backend')
+        orig_pool = extract_host(orig_host, 'pool')
+
+        # This is the destination host, backend and pool that the volume
+        # is being migrated to.
+        # If the destination host provides a pool, we will ignore that
+        # pool, because we want it to move to the same pool on the
+        # new backend host first.  This prevents data movement.
+        # You can issue a migrate command with a destination pool
+        # if it's on the same host.
+        destination_host = spec.get('destination_host')
+        dest_backend = extract_host(destination_host, 'backend')
 
         if orig_backend != dest_backend:
-            LOG.info("Destination backend is different from original backend")
             # We only want to pass if the pool is the same as the original pool
-            if dest_pool == orig_pool:
+            # This is to ensure that a cross vcenter migration lands on the
+            # same pool as the source vcenter.  This prevents data movement.
+            if filter_backend == dest_backend and filter_pool == orig_pool:
+                # We will allow a migration to the same pool on a different
+                # backend host.
+                LOG.debug("Allow migration to %s", backend_state.host)
                 return True
             else:
+                LOG.debug("Deny migration to %s", backend_state.host)
                 return False
         else:
+            # The destination backend is the same as the original backend.
+            # We will allow the migration.  This is when the volume is
+            # being migrated on the same vcenter.  Most likely to move
+            # the volume to a different pool on the same vcenter.
+            LOG.debug("Allow migration on same vcenter to %s",
+                      backend_state.host)
             return True


### PR DESCRIPTION
This fixes an issue with the filter where the destination pool was not passed in to the migration request.

This filter ensures a migration is allowed if:
1) the pool is different on the same vcenter.
2) if the vcenter is different the migration is only allowed on the same
   pool that the volume currently lives on. This prevents data movement.

Change-Id: Ie2a8fc502e335963246aeec64cb5b96ba9c169d3