### PR TITLE
Fcd fix delete

### DIFF
--- a/cinder/tests/unit/volume/drivers/vmware/test_fcd.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_fcd.py
@@ -246,7 +246,7 @@ class VMwareVStorageObjectDriverTestCase(test.TestCase):
         provider_loc = mock.sentinel.provider_loc
         self._driver._delete_fcd(provider_loc)
         from_provider_loc.test_assert_called_once_with(provider_loc)
-        vops.delete_fcd.assert_called_once_with(fcd_loc, delete_folder=True)
+        vops.delete_fcd.assert_called_once_with(fcd_loc, delete_folder=False)
 
     @mock.patch.object(FCD_DRIVER, '_provider_location_to_moref_location')
     @mock.patch.object(FCD_DRIVER, '_delete_fcd')

--- a/cinder/volume/drivers/vmware/fcd.py
+++ b/cinder/volume/drivers/vmware/fcd.py
@@ -244,7 +244,7 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
         return {'provider_location': provider_location}
 
     @volume_utils.trace
-    def _delete_fcd(self, provider_loc, delete_folder=True):
+    def _delete_fcd(self, provider_loc, delete_folder=False):
         fcd_loc = vops.FcdLocation.from_provider_location(provider_loc)
         self.volumeops.delete_fcd(fcd_loc, delete_folder=delete_folder)
 

--- a/cinder/volume/drivers/vmware/volumeops.py
+++ b/cinder/volume/drivers/vmware/volumeops.py
@@ -2226,7 +2226,7 @@ class VMwareVolumeOps(object):
         LOG.debug("Created fcd: %s.", fcd_loc)
         return fcd_loc
 
-    def delete_fcd(self, fcd_location, delete_folder=True):
+    def delete_fcd(self, fcd_location, delete_folder=False):
         cf = self._session.vim.client.factory
         vstorage_mgr = self._session.vim.service_content.vStorageObjectManager
         vmdk_file = self.get_vmdk_path_for_fcd(fcd_location.ds_ref(),


### PR DESCRIPTION
In some edge case volume data can end up in wrong folder, and folder delete can cause dataloss.
Volume A ends up in Volume B folder, and B gets deleted...
We need to clean up empty folders with cinder nanny rather than calling the folder delete funcion
