### PR TITLE
Fix for non-empty folder accidental delete.

### DIFF
--- a/cinder/tests/unit/volume/drivers/vmware/test_fcd.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_fcd.py
@@ -237,16 +237,18 @@ class VMwareVStorageObjectDriverTestCase(test.TestCase):
             get_disk_type.assert_not_called()
             vops.create_fcd.assert_not_called()
 
+    @mock.patch.object(volumeops.VMwareVolumeOps,
+                       'file_list_in_folder')
     @mock.patch.object(volumeops.FcdLocation, 'from_provider_location')
     @mock.patch.object(FCD_DRIVER, 'volumeops')
-    def test_delete_fcd(self, vops, from_provider_loc):
+    def test_delete_fcd(self, vops, from_provider_loc, file_list):
         fcd_loc = mock.sentinel.fcd_loc
         from_provider_loc.return_value = fcd_loc
-
+        file_list.return_value = []
         provider_loc = mock.sentinel.provider_loc
         self._driver._delete_fcd(provider_loc)
         from_provider_loc.test_assert_called_once_with(provider_loc)
-        vops.delete_fcd.assert_called_once_with(fcd_loc, delete_folder=False)
+        vops.delete_fcd.assert_called_once_with(fcd_loc, delete_folder=True)
 
     @mock.patch.object(FCD_DRIVER, '_provider_location_to_moref_location')
     @mock.patch.object(FCD_DRIVER, '_delete_fcd')

--- a/cinder/tests/unit/volume/drivers/vmware/test_vmware_volumeops.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_vmware_volumeops.py
@@ -2026,16 +2026,17 @@ class VolumeOpsTestCase(test.TestCase):
             self.session.vim.service_content.vStorageObjectManager,
             spec=spec)
         self.session.wait_for_task.assert_called_once_with(task)
-
+    @mock.patch('cinder.volume.drivers.vmware.volumeops.VMwareVolumeOps.'
+                'file_list_in_folder')
     @mock.patch('cinder.volume.drivers.vmware.volumeops.VMwareVolumeOps.'
                 'get_dc')
     @mock.patch('cinder.volume.drivers.vmware.volumeops.VMwareVolumeOps.'
                 'get_vmdk_path_for_fcd')
     def test_delete_fcd(self, get_vmdk_path_for_fcd,
-                        get_dc):
+                        get_dc, file_list):
         task = mock.sentinel.task
         self.session.invoke_api.return_value = task
-
+        file_list.return_value = []
         fcd_location = mock.Mock()
         fcd_id = mock.sentinel.fcd_id
         fcd_location.id.return_value = fcd_id

--- a/cinder/tests/unit/volume/drivers/vmware/test_vmware_volumeops.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_vmware_volumeops.py
@@ -2026,6 +2026,7 @@ class VolumeOpsTestCase(test.TestCase):
             self.session.vim.service_content.vStorageObjectManager,
             spec=spec)
         self.session.wait_for_task.assert_called_once_with(task)
+
     @mock.patch('cinder.volume.drivers.vmware.volumeops.VMwareVolumeOps.'
                 'file_list_in_folder')
     @mock.patch('cinder.volume.drivers.vmware.volumeops.VMwareVolumeOps.'

--- a/cinder/volume/drivers/vmware/fcd.py
+++ b/cinder/volume/drivers/vmware/fcd.py
@@ -244,7 +244,7 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
         return {'provider_location': provider_location}
 
     @volume_utils.trace
-    def _delete_fcd(self, provider_loc, delete_folder=False):
+    def _delete_fcd(self, provider_loc, delete_folder=True):
         fcd_loc = vops.FcdLocation.from_provider_location(provider_loc)
         self.volumeops.delete_fcd(fcd_loc, delete_folder=delete_folder)
 


### PR DESCRIPTION
Add check to delete_fcd, check if folder is empty
And only delete if the folder is empty after the fcd_delete vmware task is finished
Change-Id: I55943359769d9028cf457afd3722278cfb35c94d