### PR TITLE
[SAP] add quota_usage_sync command

### DIFF
--- a/cinder/cmd/manage.py
+++ b/cinder/cmd/manage.py
@@ -868,16 +868,12 @@ class ConsistencyGroupCommands(object):
 class SapCommands:
     """Methods added for SAP-specific purposes"""
 
-    def _get_quota_usages_to_sync(self, ctxt, project_id, print_table=True):
+    def _get_quota_usages_to_sync(self, ctxt, volume_types, resource_types,
+                                  project_id, print_table=True):
         """Checks if their is a mismatch between quota usage and real usage.
 
         Returns a dictionary of resources that need to be synced.
         """
-        query = db_api.model_query(ctxt, models.VolumeType, read_deleted="no")
-        volume_types = {row.id: row.name for row in query.all()}
-        query = db_api.model_query(ctxt, models.QuotaUsage.resource,
-                                   read_deleted="no").distinct()
-        resource_types = [row[0] for row in query.all()]
 
         query = db_api.model_query(
             ctxt, models.QuotaUsage, read_deleted="no").filter_by(
@@ -935,8 +931,7 @@ class SapCommands:
             print(tabulate.tabulate(table, headers=header, tablefmt='psql'))
         return quota_usages_to_sync
 
-    def _sync_quota_usage_project(self, ctxt, project_id,
-                                  quota_usages_to_sync):
+    def _sync_quota_usage_project(self, project_id, quota_usages_to_sync):
         print(f"Syncing quota usage for project: {project_id}")
         session = db_api.get_session()
         now = timeutils.utcnow()
@@ -967,10 +962,10 @@ class SapCommands:
         Can be run with either a single project id or all projects.
         """
         if project_id is None and all_projects is None:
-            print("Specify either --project-id or --all_projects.")
+            print("Specify either --project-id or --all-projects.")
             return
         if project_id and all_projects:
-            print("Specify either --project-id or --all_projects, not both")
+            print("Specify either --project-id or --all-projects, not both")
             return
         if dry_run:
             print("Starting in DRY-RUN mode")
@@ -978,12 +973,18 @@ class SapCommands:
         if project_id:
             project_ids = [project_id]
         else:
-            query = db_api.model_query(ctxt, models.QuotaUsage.id).distinct()
+            query = db_api.model_query(ctxt, 
+                                       models.QuotaUsage.project_id).distinct()
             project_ids = [row[0] for row in query.all()]
+        query = db_api.model_query(ctxt, models.VolumeType, read_deleted="no")
+        volume_types = {row.id: row.name for row in query.all()}
+        query = db_api.model_query(ctxt, models.QuotaUsage.resource,
+                                   read_deleted="no").distinct()
+        resource_types = [row[0] for row in query.all()]
 
         for project_id in project_ids:
-            quota_usages_to_sync = self._get_quota_usages_to_sync(ctxt,
-                                                                  project_id)
+            quota_usages_to_sync = self._get_quota_usages_to_sync(
+                ctxt, volume_types, resource_types, project_id)
             if not dry_run:
                 self._sync_quota_usage_project(ctxt, project_id,
                                                quota_usages_to_sync)

--- a/cinder/cmd/manage.py
+++ b/cinder/cmd/manage.py
@@ -63,6 +63,8 @@ from oslo_db import exception as db_exc
 from oslo_db.sqlalchemy import migration
 from oslo_log import log as logging
 from oslo_utils import timeutils
+from sqlalchemy import and_
+from sqlalchemy import update
 import tabulate
 
 # Need to register global_opts
@@ -865,6 +867,126 @@ class ConsistencyGroupCommands(object):
 
 class SapCommands:
     """Methods added for SAP-specific purposes"""
+
+    def _get_quota_usages_to_sync(self, ctxt, project_id, print_table=True):
+        """Checks if their is a mismatch between quota usage and real usage.
+
+        Returns a dictionary of resources that need to be synced.
+        """
+        query = db_api.model_query(ctxt, models.VolumeType, read_deleted="no")
+        volume_types = {row.id: row.name for row in query.all()}
+        query = db_api.model_query(ctxt, models.QuotaUsage.resource,
+                                   read_deleted="no").distinct()
+        resource_types = [row[0] for row in query.all()]
+
+        query = db_api.model_query(
+            ctxt, models.QuotaUsage, read_deleted="no").filter_by(
+            project_id=project_id)
+        quota_usages = {row.resource: row.in_use for row in query.all()}
+
+        query = db_api.model_query(
+            ctxt, models.Volume, read_deleted="no").filter_by(
+            project_id=project_id)
+        volume_usages = {row.volume_type_id: row.size for row in query.all()}
+        real_usages = collections.defaultdict(int)
+        for type_id, size in volume_usages.items():
+            real_usages["volumes"] += 1
+            real_usages[f"volumes_{volume_types[type_id]}"] += 1
+            real_usages["gigabytes"] += size
+            real_usages[f"gigabytes_{volume_types[type_id]}"] += size
+
+        query = db_api.model_query(
+            ctxt, models.Snapshot, read_deleted="no").filter_by(
+            project_id=project_id)
+        snapshot_usages = {
+            row.volume_type_id: row.volume_size for row in query.all()
+        }
+        for type_id, size in snapshot_usages.items():
+            real_usages["snapshots"] += 1
+            real_usages[f"snapshots_{volume_types[type_id]}"] += 1
+            real_usages["gigabytes"] += size
+            real_usages[f"gigabytes_{volume_types[type_id]}"] += size
+
+        # find discrepancies between quota usage and real usage
+        quota_usages_to_sync = {}
+        table = []
+        for resource in resource_types:
+            try:
+                if real_usages[resource] != quota_usages[resource]:
+                    quota_usages_to_sync[resource] = real_usages[resource]
+                    table.append([
+                        project_id,
+                        resource,
+                        f"{quota_usages[resource]} -> {real_usages[resource]}",
+                        '\033[1m\033[91mMISMATCH\033[0m']
+                    )
+                else:
+                    table.append([
+                        project_id,
+                        resource,
+                        f"{quota_usages[resource]} -> {real_usages[resource]}",
+                        '\033[1m\033[92mOK\033[0m']
+                    )
+            except KeyError:
+                pass
+
+        header = ["Project ID", "Resource", "Quota -> Real", "Sync Status"]
+        if len(quota_usages) and print_table:
+            print(tabulate.tabulate(table, headers=header, tablefmt='psql'))
+        return quota_usages_to_sync
+
+    def _sync_quota_usage_project(self, ctxt, project_id,
+                                  quota_usages_to_sync):
+        print(f"Syncing quota usage for project: {project_id}")
+        session = db_api.get_session()
+        now = timeutils.utcnow()
+        for resource, quota_ in quota_usages_to_sync.items():
+            session.execute(
+                update(models.QuotaUsage)
+                .where(
+                    and_(
+                        models.QuotaUsage.project_id == project_id,
+                        models.QuotaUsage.resource == resource
+                    )
+                )
+                .values(updated_at=now, in_use=quota_)
+            )
+            session.commit()
+
+    @args('--dry-run', action='store_true', default=False,
+          help='Do not update database.')
+    @args('--project-id', type=str, default=None,
+          help='Process a specific project.\
+            Specify either --project-id or --all-projects.')
+    @args('--all-projects', action='store_true', default=None,
+          help='Process all projects.\
+            Specify either --project-id or --all-projects.')
+    def quota_usage_sync(self, dry_run, project_id, all_projects):
+        """List quota usage and actual usage, correct if necessary.
+
+        Can be run with either a single project id or all projects.
+        """
+        if project_id is None and all_projects is None:
+            print("Specify either --project-id or --all_projects.")
+            return
+        if project_id and all_projects:
+            print("Specify either --project-id or --all_projects, not both")
+            return
+        if dry_run:
+            print("Starting in DRY-RUN mode")
+        ctxt = context.get_admin_context()
+        if project_id:
+            project_ids = [project_id]
+        else:
+            query = db_api.model_query(ctxt, models.QuotaUsage.id).distinct()
+            project_ids = [row[0] for row in query.all()]
+
+        for project_id in project_ids:
+            quota_usages_to_sync = self._get_quota_usages_to_sync(ctxt,
+                                                                  project_id)
+            if not dry_run:
+                self._sync_quota_usage_project(ctxt, project_id,
+                                               quota_usages_to_sync)
 
     @args('--dry-run', action='store_true', default=False,
           help='Do not delete any files.')

--- a/cinder/cmd/manage.py
+++ b/cinder/cmd/manage.py
@@ -959,7 +959,7 @@ class SapCommands:
     def quota_usage_sync(self, dry_run, project_id, all_projects):
         """List quota usage and actual usage, correct if necessary.
 
-        Can be run with either a single project id or all projects.
+        Can be run with either a single project id or for all projects.
         """
         if project_id is None and all_projects is None:
             print("Specify either --project-id or --all-projects.")
@@ -973,7 +973,7 @@ class SapCommands:
         if project_id:
             project_ids = [project_id]
         else:
-            query = db_api.model_query(ctxt, 
+            query = db_api.model_query(ctxt,
                                        models.QuotaUsage.project_id).distinct()
             project_ids = [row[0] for row in query.all()]
         query = db_api.model_query(ctxt, models.VolumeType, read_deleted="no")

--- a/cinder/cmd/manage.py
+++ b/cinder/cmd/manage.py
@@ -868,8 +868,12 @@ class ConsistencyGroupCommands(object):
 class SapCommands:
     """Methods added for SAP-specific purposes"""
 
-    def _get_quota_usages_to_sync(self, ctxt, volume_types, resource_types,
-                                  project_id, print_table=True):
+    def _get_quota_usages_to_sync(self,
+                                  ctxt: context.RequestContext,
+                                  volume_types: dict[str, int],
+                                  resource_types: list[str],
+                                  project_id: str,
+                                  print_table=True) -> dict[str, int]:
         """Checks if their is a mismatch between quota usage and real usage.
 
         Returns a dictionary of resources that need to be synced.
@@ -931,22 +935,24 @@ class SapCommands:
             print(tabulate.tabulate(table, headers=header, tablefmt='psql'))
         return quota_usages_to_sync
 
-    def _sync_quota_usage_project(self, project_id, quota_usages_to_sync):
+    def _sync_quota_usage_project(self, project_id: str,
+                                  quota_usages_to_sync: dict[str, int]
+                                  ) -> None:
         print(f"Syncing quota usage for project: {project_id}")
         session = db_api.get_session()
         now = timeutils.utcnow()
         for resource, quota_ in quota_usages_to_sync.items():
-            session.execute(
-                update(models.QuotaUsage)
-                .where(
-                    and_(
-                        models.QuotaUsage.project_id == project_id,
-                        models.QuotaUsage.resource == resource
+            with session.begin():
+                session.execute(
+                    update(models.QuotaUsage)
+                    .where(
+                        and_(
+                            models.QuotaUsage.project_id == project_id,
+                            models.QuotaUsage.resource == resource
+                        )
                     )
+                    .values(updated_at=now, in_use=quota_)
                 )
-                .values(updated_at=now, in_use=quota_)
-            )
-            session.commit()
 
     @args('--dry-run', action='store_true', default=False,
           help='Do not update database.')
@@ -956,7 +962,8 @@ class SapCommands:
     @args('--all-projects', action='store_true', default=None,
           help='Process all projects.\
             Specify either --project-id or --all-projects.')
-    def quota_usage_sync(self, dry_run, project_id, all_projects):
+    def quota_usage_sync(self, dry_run: bool, project_id: str,
+                         all_projects: bool) -> None:
         """List quota usage and actual usage, correct if necessary.
 
         Can be run with either a single project id or for all projects.

--- a/cinder/cmd/manage.py
+++ b/cinder/cmd/manage.py
@@ -985,8 +985,11 @@ class SapCommands:
         for project_id in project_ids:
             quota_usages_to_sync = self._get_quota_usages_to_sync(
                 ctxt, volume_types, resource_types, project_id)
+            if not quota_usages_to_sync:
+                print(f"Nothing to be done/synced for project {project_id}")
+                continue
             if not dry_run:
-                self._sync_quota_usage_project(ctxt, project_id,
+                self._sync_quota_usage_project(project_id,
                                                quota_usages_to_sync)
 
     @args('--dry-run', action='store_true', default=False,


### PR DESCRIPTION
WIP

In order to move the cinder nanny functionality closer to cinder, I added the `cinder-quota-sync.py` ([original script](https://github.com/sapcc/openstack-nannies/blob/master/scripts/cinder-quota-sync.py)) to the `cmd/manage.py` code, such that it can be executed with the `cinder-manage sap` command.

So far (26.03.2025) I made use of the already existing ORM models to interact with the Database and replace the existing functions for querying the Database. Despite the ORM's, most of the script remained untouched. I looked into the functionality of the existing `cinder-manage quota` command in order to look for more functionality I can reuse. Although the docstring says it should do the same as our script, there are problems with the existing command:

- It doesn't yield the same results as our script
- I found the existing code complex and the code hard to understand compared to the SAP script
- It crashes for some projects in our infrastructure:
```
2025-03-26 16:06:09,489 391 CRITICAL cinder [req-87e894f2-a41c-4122-b7eb-a608d1c34f51 gNone - - - - - -] Unhandled error: KeyError: 'groups'
2025-03-26 16:06:09,489 391 ERROR cinder Traceback (most recent call last):
2025-03-26 16:06:09,489 391 ERROR cinder   File "/var/lib/openstack/bin/cinder-manage", line 8, in <module>
2025-03-26 16:06:09,489 391 ERROR cinder     sys.exit(main())
2025-03-26 16:06:09,489 391 ERROR cinder   File "/var/lib/openstack/lib/python3.8/site-packages/cinder/cmd/manage.py", line 1215, in main
2025-03-26 16:06:09,489 391 ERROR cinder     fn(**fn_kwargs)
2025-03-26 16:06:09,489 391 ERROR cinder   File "/var/lib/openstack/lib/python3.8/site-packages/cinder/cmd/manage.py", line 379, in check
2025-03-26 16:06:09,489 391 ERROR cinder     result = self._check_sync(project_id, do_fix=False)
2025-03-26 16:06:09,489 391 ERROR cinder   File "/var/lib/openstack/lib/python3.8/site-packages/cinder/cmd/manage.py", line 528, in _check_sync
2025-03-26 16:06:09,489 391 ERROR cinder     updates = db_api._get_sync_updates(ctxt, project, session,
2025-03-26 16:06:09,489 391 ERROR cinder   File "/var/lib/openstack/lib/python3.8/site-packages/cinder/db/sqlalchemy/api.py", line 1142, in _get_sync_updates
2025-03-26 16:06:09,489 391 ERROR cinder     sync = QUOTA_SYNC_FUNCTIONS[resources[resource_name].sync]
2025-03-26 16:06:09,489 391 ERROR cinder KeyError: 'groups'
2025-03-26 16:06:09,489 391 ERROR cinder
```
Before this error is thrown, a resource is fetched from the `quota_usage` table that is not contained in the resources and their sync methods. I found  it hard to wrap my head around this piece of code. https://github.com/sapcc/cinder/blob/78fc9e431971b3a1f1ac44dceda73e122003884c/cinder/cmd/manage.py#L492 `QUOTA` is a global variable within the quota module and it's in capital letters, but it's not a constant. It's an instance of `VolumeTypeQuotaEngine`. The resource property fetches from the DB. `QUOTA` and `VolumeTypeQuotaEngine` are only used in `manage.py` and tests.

**SUMMARY**
There exists functionality for quota sync, but it doesn't work as expected. I see several options going forward:

1. Modify existing code. There are some fixes upstream in the current cinder version, maybe they work as expected.
2. Add SAP command besides existing code. Add Note for checking for more recent versions if the existing code works again.

Option one seems to be a lot more work, I'm unsure if this aligns with our current priorities.