### PR TITLE
Fix create_from_image

### DIFF
--- a/cinder/volume/drivers/vmware/fcd.py
+++ b/cinder/volume/drivers/vmware/fcd.py
@@ -498,7 +498,11 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
 
         # Extend the volume if needed
         # break this up to 2 lines to pass pep8
-        image_gib = int(metadata['virtual_size'] / units.Gi)
+        if hasattr(metadata, 'virtual_size'):
+            image_gib = int(metadata['virtual_size'] / units.Gi)
+        else:
+            image_gib = int(self.volumeops.get_vmdk_size_for_fcd(
+                fcd_loc=fcd_loc) / units.Gi)
         image_size = 1 if image_gib == 0 else image_gib
         self._extend_if_needed(fcd_loc, image_size, volume.size)
         self.volumeops.update_fcd_vmdk_uuid(ds_ref,

--- a/cinder/volume/drivers/vmware/volumeops.py
+++ b/cinder/volume/drivers/vmware/volumeops.py
@@ -2172,6 +2172,21 @@ class VMwareVolumeOps(object):
         vmdk_path = fcd_obj.config.backing.filePath
         return vmdk_path
 
+    def get_vmdk_size_for_fcd(self, ds_ref=None, disk_id=None, fcd_loc=None):
+        cf = self._session.vim.client.factory
+        if fcd_loc:
+            ds_ref = fcd_loc.ds_ref()
+            disk_id = fcd_loc.id(cf)
+        vstorage_mgr = self._session.vim.service_content.vStorageObjectManager
+        fcd_obj = self._session.invoke_api(
+            self._session.vim,
+            'RetrieveVStorageObject',
+            vstorage_mgr,
+            id=disk_id,
+            datastore=ds_ref)
+        size_mb = fcd_obj.config.capacityInMB
+        return size_mb
+
     @volume_utils.trace
     def update_fcd_vmdk_uuid(self, ds_ref, vmdk_path, cinder_uuid):
         def cinder_uuid_to_vmwhex(cinder_uuid):


### PR DESCRIPTION
Lookup the vmdk size of the disk from fcd if virtual_size is not present on the image metadata.
Fixes deployment problem with certain glance images missing the virtual_size property
Change-Id: I3468a79608f9ae1daf50300772eaa0245f28ed4a