### PR TITLE
[SAP] Allow SAPFCDFilter for other ops

### DIFF
--- a/cinder/scheduler/filters/sap_fcd_filter.py
+++ b/cinder/scheduler/filters/sap_fcd_filter.py
@@ -44,7 +44,8 @@ class SAPFCDFilter(filters.BaseBackendFilter):
         spec = filter_properties.get('request_spec', {})
         vol = spec.get('volume_properties', {})
 
-        if spec.get('operation') != 'migrate_volume':
+        valid_ops = ['migrate_volume', 'find_backend_for_connector']
+        if spec.get('operation') not in valid_ops:
             return True
 
         # We are migrating a volume.  If we are migrating to a different


### PR DESCRIPTION
This patch allows the SAPFCDFilter to run under 2 operations now.  The operations are 'migrate_volume' and
'find_backend_for_connector'

We want to ensure the FCD filter is run when an attach operation kicks off a ConnectorRejected due to the volume needing to be migrated to another vcenter.

Change-Id: I7837cd045afba42b4f05eb746bf789840b7816c0