### PR TITLE
[SAP] Faster access to selecting ds

### DIFF
--- a/cinder/volume/drivers/vmware/datastore.py
+++ b/cinder/volume/drivers/vmware/datastore.py
@@ -357,6 +357,24 @@ class DatastoreSelector(object):
 
         return datastores
 
+    def get_ds_ref_by_name(self, name):
+        vim = self._session.vim
+
+        retrieve_result = self._session.invoke_api(
+            vim_util,
+            'get_objects',
+            vim,
+            'Datastore',
+            self._max_objects,
+            properties_to_collect=['name'])
+
+        with vim_util.WithRetrieval(vim, retrieve_result) as objects:
+            for obj_content in objects:
+                props = self._get_object_properties(obj_content)
+                if props['name'] == name:
+                    return obj_content.obj
+        return None
+
     def select_datastore_by_name(self, name):
         """Find a datastore by it's name.
 

--- a/cinder/volume/drivers/vmware/fcd.py
+++ b/cinder/volume/drivers/vmware/fcd.py
@@ -141,8 +141,8 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
         <fcd_id>@<datastore moref>
         """
         fcd_id, ds_name = ds_location.split('@')
-        (_, _, ds_ref) = self.ds_sel.select_datastore_by_name(ds_name)
-        return "%s@%s" % (fcd_id, ds_ref.datastore.value)
+        ds_ref = self.ds_sel.get_ds_ref_by_name(ds_name)
+        return "%s@%s" % (fcd_id, vim_util.get_moref_value(ds_ref))
 
     def _snap_provider_location_to_ds_name_location(self, moref_location):
         """Translate the provider location to the datastore name for snapshot.


### PR DESCRIPTION
This adds a new call in datastore.py to fetch a ds_ref by name.  The old call select_datastore_by_name makes a call to fetch all datastores and then fetches hosts for each of those, which is terribly expensive.

Change-Id: Iac0a8b77ed9d8fe12730cec83be486122da385f1