### PR TITLE
[SAP] Allow FCD migration to down pools

### DIFF
--- a/cinder/scheduler/filters/sap_pool_down_filter.py
+++ b/cinder/scheduler/filters/sap_pool_down_filter.py
@@ -27,7 +27,17 @@ class SAPPoolDownFilter(filters.BaseBackendFilter):
 
     def backend_passes(self, backend_state, filter_properties):
 
+        valid_ops = ['migrate_volume', 'find_backend_for_connector']
+        spec = filter_properties.get('request_spec', {})
+
+        # For FCD based volumes, we want to allow a volume migration
+        # to the same pool, even if it's marked down draining.
+        # As the migration is nothing more than a registration to a
+        # new host.  The volume is already on the pool.
         if backend_state.pool_state == 'up':
+            return True
+        elif spec.get('operation') in valid_ops:
+            LOG.debug("Allow migration to a down/drain pool.")
             return True
         else:
             LOG.debug("%(id)s pool state is not 'up'. state='%(state)s'",


### PR DESCRIPTION
This patch updates the SAPDownFilter to allow pools to pass the filter if the pool is down if and only if the operation on the volume is migrate and find_backend_for_connector.

This will allow a volume to be migrated from 1 vcenter to another to the same pool/datastore when the target pool is down/drain. It will require to removal of the pool_state extra spec in the volume type, otherwise the capabilities filter will drop the pool.

Change-Id: I9bd6119bb3d7203bf2358c317e2699fac6730337