### PR TITLE
Quota sync bugfix and SAP Wrapper

### DIFF
--- a/cinder/cmd/manage.py
+++ b/cinder/cmd/manage.py
@@ -490,6 +490,7 @@ class QuotaCommands(object):
         ctxt = context.get_admin_context()
         # Get the quota usage types and their sync methods
         resources = quota.QUOTAS.resources
+        resources.update(quota.GROUP_QUOTAS.resources)
 
         # Get all project ids that have quota usage. Method doesn't lock
         # projects, since newly added projects should not be out of sync and

--- a/cinder/cmd/manage.py
+++ b/cinder/cmd/manage.py
@@ -57,6 +57,7 @@ from pathlib import Path
 import re
 import sys
 import time
+import traceback
 
 from oslo_config import cfg
 from oslo_db import exception as db_exc
@@ -866,6 +867,37 @@ class ConsistencyGroupCommands(object):
 
 class SapCommands:
     """Methods added for SAP-specific purposes"""
+
+    @args('--dry-run', action='store_true', default=False,
+          help='Do not sync any quotas.')
+    @args('--silent', action='store_true', default=False,
+          help='A single failing project sync does not raise exception.')
+    def quota_sync(self, dry_run: bool, silent: bool) -> None:
+        """Sync quotas for all projects.
+
+        Wrapper for Quota Commands that continues to run if a quota check
+        for a single project failed.
+        """
+        last_exception = None
+        failed_projects = {}
+        project_ids = QuotaCommands()._get_quota_projects(ctxt=None,
+                                                          project_id=None)
+        for project_id in project_ids:
+            try:
+                QuotaCommands()._check_sync(project_id, do_fix=not dry_run)
+            except Exception as e:
+                print("Failed to sync quotas for project "
+                      f"{project_id}: {type(e)} {e}")
+                last_exception = e
+                failed_projects[project_id] = traceback.format_exc()
+        for project_id, tb in failed_projects.items():
+            print(f"Project {project_id} failed with traceback: {tb}")
+        if last_exception:
+            print("Failed syncing the following projects: "
+                  f"{failed_projects.keys()}. See tracebacks above.")
+            if not silent:
+                print("Raising last exception:")
+                raise last_exception
 
     @args('--dry-run', action='store_true', default=False,
           help='Do not delete any files.')

--- a/releasenotes/notes/fix-cinder-manage-groups-quota-bug-421ae9c9eb99b22f.yaml
+++ b/releasenotes/notes/fix-cinder-manage-groups-quota-bug-421ae9c9eb99b22f.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    `Bug #2107451 <https://bugs.launchpad.net/cinder/+bug/2107451>`_: Fixed
+    crash of `cinder-manage quota sync` if there is a row in the
+    quota_usage table with the value groups for column resource


### PR DESCRIPTION
This fixes a bug (cherry pick commit from upstream) and provides a wrapper command for `cinder-manage quota-sync`. The SAP wrapper checks all projects for inconsistencies and does not crash if a single project cannot be synced. It continues until all projects are checked and (optionally) re-raises the last exception. 