### PR TITLE
[SAP] Add new sap_netapp_credentials config

### DIFF
--- a/cinder/tests/unit/volume/drivers/vmware/test_fcd.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_fcd.py
@@ -71,6 +71,7 @@ class VMwareVStorageObjectDriverTestCase(test.TestCase):
         self._config.reserved_percentage = self.RESERVED_PERCENTAGE
         self._config.vmware_datastores_as_pools = False
         self._config.vmware_snapshot_format = "COW"
+        self._config.sap_netapp_credentials = {}
         self._driver = fcd.VMwareVStorageObjectDriver(
             configuration=self._config)
         self._driver._vc_version = self.VC_VERSION

--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -28,6 +28,7 @@ import ssl
 
 import OpenSSL
 from oslo_config import cfg
+from oslo_config import types
 from oslo_log import log as logging
 from oslo_utils import excutils
 from oslo_utils import units
@@ -220,6 +221,17 @@ vmdk_opts = [
                'cinder-volume container having to proxy the image between '
                'glance and VMware.'
                ),
+    cfg.MultiOpt(
+        'sap_netapp_credentials',
+        item_type=types.Dict(
+            types.Dict(types.String(), bounds=True)
+        ),
+        default={},
+        help='A dictionary of netapp host connection credentials. '
+        'the format is this: '
+        'sap_netapp_credentials = netapp_1: {user: foo, password: bar},'
+        'netapp_2: {user: baz, password: qux}'
+    ),
 ]
 
 CONF = cfg.CONF
@@ -380,6 +392,14 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         self._remote_api = remote_api.VmdkDriverRemoteApi()
         self._storage_profiles = []
         self._volume_type_by_backend = None
+        self._sap_netapp_credentials = {}
+
+        if self.configuration.sap_netapp_credentials:
+            # This is an artifact of the way the config parser works.
+            # It will return a list of dictionaries, the list will contain
+            # only one item, so we need to get the first one.
+            _conf = self.configuration
+            self._sap_netapp_credentials = _conf.sap_netapp_credentials[0]
 
     @staticmethod
     def get_driver_options():


### PR DESCRIPTION
This adds a new SAP only config option for the vmware/fcd driver to provide a dictionary of N netapp credentials.

The new config option is called: sap_netapp_credentials

This is an oslo.config.types.Dict type, which is a key:value list separated by ,

the format of the dict in the cinder-volume.conf needs to be this:

sap_netapp_credentials = \
netapp_1:{user:foo,password:bar},netapp_2:{user:test,password:something}

Change-Id: If965798eb062869ee19b321fc7953d6e2b4f99be