### PR TITLE
[SAP] Remove datastore cluster attribute log noise

### DIFF
--- a/cinder/volume/drivers/vmware/datastore.py
+++ b/cinder/volume/drivers/vmware/datastore.py
@@ -128,8 +128,6 @@ class DatastoreSelector(object):
 
         attrs = self._vops.get_cluster_custom_attributes(
             host_cluster_ref, props=cluster_cache.get(host_cluster_value))
-        LOG.debug("Cluster %s custom attributes: %s",
-                  host_cluster_value, attrs)
 
         if not attrs or 'buildup' not in attrs:
             return False


### PR DESCRIPTION
This removes some very noisy log for the datastore cluster custom attributes.

Change-Id: I6ac44892dd41d2b2e68b5b0990a82a55321809a2