### PR TITLE
Pin flake8_import_order version to <0.19.0

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,7 +4,7 @@
 
 # Install bounded pep8/pyflakes first, then let flake8 install
 hacking>=5.0.0,<5.1.0 # Apache-2.0
-flake8-import-order!=0.19.0 # LGPLv3
+flake8-import-order<0.19.0 # LGPLv3
 flake8-logging-format>=0.6.0 # Apache-2.0
 
 stestr>=3.2.1 # Apache-2.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,7 +4,7 @@
 
 # Install bounded pep8/pyflakes first, then let flake8 install
 hacking>=5.0.0,<5.1.0 # Apache-2.0
-flake8-import-order # LGPLv3
+flake8-import-order!=0.19.0 # LGPLv3
 flake8-logging-format>=0.6.0 # Apache-2.0
 
 stestr>=3.2.1 # Apache-2.0


### PR DESCRIPTION
Version 0.19.0 is bugged:
https://github.com/PyCQA/flake8-import-order/issues/212. `tox -e pep8` crashes with 0.19.0.

Closes-Bug: https://bugs.launchpad.net/cinder/+bug/2114747
Change-Id: Ib1f522629919fb3cd585255abaa2bfce0dc7591f