### PR TITLE
[SAP] Allow a retype of vmdk -> fcd

### DIFF
--- a/cinder/scheduler/filters/shard_filter.py
+++ b/cinder/scheduler/filters/shard_filter.py
@@ -246,3 +246,55 @@ class ShardFilter(filters.BaseBackendFilter):
                        'backend_shards': configured_shards_set,
                        'project_shards': shards})
             return False
+
+
+class SAPShardRetypeMigrationFilter(ShardFilter):
+    """Filters backends by shard of the project
+
+    When a volume is retyping or migrating from vmdk -> vstorageobject, we want
+    to ensure that the volume is migrated to the same shard as the original
+    volume.
+
+    """
+
+    def backend_passes(self, backend_state, filter_properties):
+        # We only need the shard filter for vmware based pools
+        if backend_state.vendor_name != 'VMware':
+            LOG.info(
+                "Shard Filter ignoring backend %s as it's not vmware based"
+                " driver", backend_state.backend_id)
+            return True
+
+        spec = filter_properties.get('request_spec', {})
+        vol = spec.get('volume_properties', {})
+
+        # Any retyping of a vmware based volume should land on the same shard.
+        if spec.get('operation') == 'retype_volume':
+            # The backend can only be on the same shard as
+            # the volume is currently on.
+            vol_shard = self._extract_shard_from_host(vol['host'])
+            backend_shard = self._extract_shard_from_host(backend_state.host)
+            if vol_shard == backend_shard:
+                return True
+            else:
+                return False
+
+        # A migration for vmdk -> fcd(vstorageobject) should land
+        # on the same shard.
+        if spec.get('operation') == 'migrate_volume':
+            # The backend can only be on the same shard as
+            # the volume is currently on.
+            # host entries for vmdk base volumes are
+            #    '<system_name>@vmware#pool'
+            # host entries for fcd base volumes are
+            #    '<system_name>@vmware_fcd#pool'
+            vol_backend = cinder_utils.extract_host(
+                vol['host'], 'backend').split('@')[1]
+            backend_backend = cinder_utils.extract_host(
+                backend_state.host, 'backend').split('@')[1]
+            vol_shard = self._extract_shard_from_host(vol['host'])
+            backend_shard = self._extract_shard_from_host(backend_state.host)
+            if (vol_backend == 'vmware' and backend_backend == 'vmware_fcd' and
+                    vol_shard == backend_shard):
+                return True
+            return False

--- a/cinder/volume/manager.py
+++ b/cinder/volume/manager.py
@@ -2881,29 +2881,34 @@ class VolumeManager(manager.CleanableManager,
 
         volume.migration_status = 'migrating'
         volume.save()
-        LOG.debug(f"migrate_volume: force_host_copy: {force_host_copy}, new_type_id: {new_type_id}")
+
         # Hack to allow migration to a different host if the storage protocol
         # is vmdk -> vstorageobject
         # We know the vmdk driver can migrate to an fcd.
         def _can_host_migrate(volume, force_host_copy, new_type_id):
             if not force_host_copy and new_type_id:
-                # now check to see if the storage protocols between source and destination
-                # can tolerate the migration.
-                source_volume_type = objects.VolumeType.get_by_id(ctxt, volume.volume_type_id)
-                dest_volume_type = objects.VolumeType.get_by_id(ctxt, new_type_id)
-                LOG.debug(f"migrate_volume: source_volume_type: {source_volume_type}, dest_volume_type: {dest_volume_type}")
+                # now check to see if the storage protocols between
+                # source and destination can tolerate the migration
+                source_volume_type = objects.VolumeType.get_by_id(
+                    ctxt, volume.volume_type_id)
+                dest_volume_type = objects.VolumeType.get_by_id(
+                    ctxt, new_type_id)
 
                 # We only allow vmdk -> fcd migration currently.
-                if (source_volume_type.extra_specs.get('storage_protocol') == 'vmdk' and
-                    dest_volume_type.extra_specs.get('storage_protocol') == 'vstorageobject'):
+                src_storage_protocol = source_volume_type.extra_specs.get(
+                    'storage_protocol')
+                dest_storage_protocol = dest_volume_type.extra_specs.get(
+                    'storage_protocol')
+                if (src_storage_protocol == 'vmdk' and
+                        dest_storage_protocol == 'vstorageobject'):
                     return True
             elif not force_host_copy and not new_type_id:
-                # If no new_type_id is specified, we allow migration to any host.
+                # If no new_type_id is specified, we allow migration
+                # to any host.
                 return True
             return False
 
         if _can_host_migrate(volume, force_host_copy, new_type_id):
-            LOG.debug(f"migrate_volume: can migrate volume {volume.id} to {host['host']}")
             try:
                 LOG.debug("Issue driver.migrate_volume.", resource=volume)
                 # Update the remote host's allocated_capacity_gb first

--- a/cinder/volume/manager.py
+++ b/cinder/volume/manager.py
@@ -2881,7 +2881,29 @@ class VolumeManager(manager.CleanableManager,
 
         volume.migration_status = 'migrating'
         volume.save()
-        if not force_host_copy and new_type_id is None:
+        LOG.debug(f"migrate_volume: force_host_copy: {force_host_copy}, new_type_id: {new_type_id}")
+        # Hack to allow migration to a different host if the storage protocol
+        # is vmdk -> vstorageobject
+        # We know the vmdk driver can migrate to an fcd.
+        def _can_host_migrate(volume, force_host_copy, new_type_id):
+            if not force_host_copy and new_type_id:
+                # now check to see if the storage protocols between source and destination
+                # can tolerate the migration.
+                source_volume_type = objects.VolumeType.get_by_id(ctxt, volume.volume_type_id)
+                dest_volume_type = objects.VolumeType.get_by_id(ctxt, new_type_id)
+                LOG.debug(f"migrate_volume: source_volume_type: {source_volume_type}, dest_volume_type: {dest_volume_type}")
+
+                # We only allow vmdk -> fcd migration currently.
+                if (source_volume_type.extra_specs.get('storage_protocol') == 'vmdk' and
+                    dest_volume_type.extra_specs.get('storage_protocol') == 'vstorageobject'):
+                    return True
+            elif not force_host_copy and not new_type_id:
+                # If no new_type_id is specified, we allow migration to any host.
+                return True
+            return False
+
+        if _can_host_migrate(volume, force_host_copy, new_type_id):
+            LOG.debug(f"migrate_volume: can migrate volume {volume.id} to {host['host']}")
             try:
                 LOG.debug("Issue driver.migrate_volume.", resource=volume)
                 # Update the remote host's allocated_capacity_gb first

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ cinder.scheduler.filters =
     InstanceLocalityFilter = cinder.scheduler.filters.instance_locality_filter:InstanceLocalityFilter
     ShardFilter = cinder.scheduler.filters.shard_filter:ShardFilter
     SAPFCDFilter = cinder.scheduler.filters.sap_fcd_filter:SAPFCDFilter
+    SAPShardRetypeMigrationFilter = cinder.scheduler.filters.sap_fcd_filter:SAPShardRetypeMigrationFilter
     SAPLargeVolumeFilter = cinder.scheduler.filters.sap_large_volume_filter:SAPLargeVolumeFilter
     SAPDifferentBackendFilter = cinder.scheduler.filters.sap_affinity_filter:SAPDifferentBackendFilter
     SAPSameBackendFilter = cinder.scheduler.filters.sap_affinity_filter:SAPSameBackendFilter


### PR DESCRIPTION
This patch adds some checks in the volume manager during a retype operation that kicks off a migration to allow a host base migration for only a vmdk -> fcd change.  All others will use the generic migration.

Change-Id: If9915bde9e2e46b24ad680fb40c5d54755d60653