### PR TITLE
[SAP] Allow FCD migration to down pools

### DIFF
--- a/cinder/scheduler/filters/sap_pool_down_filter.py
+++ b/cinder/scheduler/filters/sap_pool_down_filter.py
@@ -17,6 +17,7 @@
 from oslo_log import log as logging
 
 from cinder.scheduler import filters
+from cinder import utils as cinder_utils
 
 
 LOG = logging.getLogger(__name__)
@@ -25,12 +26,33 @@ LOG = logging.getLogger(__name__)
 class SAPPoolDownFilter(filters.BaseBackendFilter):
     """Filter out pools that are not marked 'up'."""
 
-    def backend_passes(self, backend_state, filter_properties):
+    def backend_passes(self, host_state, filter_properties):
+        valid_ops = ['migrate_volume', 'find_backend_for_connector']
+        spec = filter_properties.get('request_spec', {})
+        backend = cinder_utils.extract_host(
+            host_state.host, 'backend').split('@')[1]
 
-        if backend_state.pool_state == 'up':
+        # For FCD based volumes, we want to allow a volume migration
+        # to the same pool, even if it's marked down draining.
+        # As the migration is nothing more than a registration to a
+        # new host.  The volume is already on the pool.
+
+        # Just in case we are running on a host that doesn't have a pool_state,
+        # we will assume it is up as that is the default for upstream cinder.
+        if hasattr(host_state, 'pool_state'):
+            pool_state = host_state.pool_state
+        else:
+            LOG.debug("Host %(host)s has no pool_state, assuming it is up",
+                      {'host': host_state.host})
+            pool_state = 'up'
+
+        if pool_state == 'up':
+            return True
+        elif spec.get('operation') in valid_ops and backend == 'vmware_fcd':
+            LOG.debug("Allow migration to a down pool for vmware_fcd only")
             return True
         else:
             LOG.debug("%(id)s pool state is not 'up'. state='%(state)s'",
-                      {'id': backend_state.backend_id,
-                       'state': backend_state.pool_state})
+                      {'id': host_state.backend_id,
+                       'state': host_state.pool_state})
             return False


### PR DESCRIPTION
This patch updates the SAPDownFilter to allow pools to pass the filter if the pool is down if and only if the operation on the volume is migrate and find_backend_for_connector.

This will allow a volume to be migrated from 1 vcenter to another to the same pool/datastore when the target pool is down/drain. It will require to removal of the pool_state extra spec in the volume type, otherwise the capabilities filter will drop the pool.

Change-Id: Ib1ed61ba9d2a9fc798a9210e12dce4d748293beb