### PR TITLE
[SAP] Update service_uuid after migration

### DIFF
--- a/cinder/volume/manager.py
+++ b/cinder/volume/manager.py
@@ -2935,6 +2935,7 @@ class VolumeManager(manager.CleanableManager,
                         'migration_status': 'success',
                         'availability_zone': dst_service.availability_zone,
                         'previous_status': volume.status,
+                        'service_uuid': dst_service.uuid,
                     }
                     if status_update:
                         updates.update(status_update)


### PR DESCRIPTION
This patch ensures that after a successfull driver assisted volume migration, the volume's service_uuid is updated to reflect the destination's service uuid.

Change-Id: I980fbadfc9a6be33c6b490b6ca79cf5b5982557d