### PR TITLE
fix_rename_file

### DIFF
--- a/cinder/volume/drivers/netapp/dataontap/client/client_cmode_rest.py
+++ b/cinder/volume/drivers/netapp/dataontap/client/client_cmode_rest.py
@@ -2512,7 +2512,6 @@ class RestClient(object):
 
         # Path requires "%2E" to represent "." and "%2F" to represent "/".
         orig_file_name = orig_file_name.replace('.', '%2E').replace('/', '%2F')
-        new_file_name = new_file_name.replace('.', '%2E').replace('/', '%2F')
 
         body = {'path': new_file_name}
 


### PR DESCRIPTION
You don't need to escape the "." and "/" in the json body. The result wold be a bad filename outside the desired directory