### PR TITLE
Fix file_assign_qos ESCAPE special chars in file_path

### DIFF
--- a/cinder/volume/drivers/netapp/dataontap/client/client_cmode_rest.py
+++ b/cinder/volume/drivers/netapp/dataontap/client/client_cmode_rest.py
@@ -1239,7 +1239,8 @@ class RestClient(object):
         body = {
             'qos_policy.name': qos_policy_group_name
         }
-
+        # We need to ESCAPE special chars in the url
+        file_path = file_path.replace('.', '%2E').replace('/', '%2F')
         self.send_request(
             f'/storage/volumes/{volume["uuid"]}/files/{file_path}',
             'patch', body=body, enable_tunneling=False)


### PR DESCRIPTION
Assign QOS did not work on complex path structure as you have to ESCAPE special chars in the url to allow deep directory structures