### PR TITLE
[SAP] Fix scheduler filter extract_host call

### DIFF
--- a/cinder/scheduler/filters/sap_pool_down_filter.py
+++ b/cinder/scheduler/filters/sap_pool_down_filter.py
@@ -17,7 +17,7 @@
 from oslo_log import log as logging
 
 from cinder.scheduler import filters
-from cinder import utils as cinder_utils
+from cinder.volume import volume_utils
 
 
 LOG = logging.getLogger(__name__)
@@ -29,7 +29,7 @@ class SAPPoolDownFilter(filters.BaseBackendFilter):
     def backend_passes(self, host_state, filter_properties):
         valid_ops = ['migrate_volume', 'find_backend_for_connector']
         spec = filter_properties.get('request_spec', {})
-        backend = cinder_utils.extract_host(
+        backend = volume_utils.extract_host(
             host_state.host, 'backend').split('@')[1]
 
         # For FCD based volumes, we want to allow a volume migration

--- a/cinder/scheduler/filters/shard_filter.py
+++ b/cinder/scheduler/filters/shard_filter.py
@@ -22,6 +22,7 @@ from oslo_log import log as logging
 from cinder.scheduler import filters
 from cinder.service_auth import SERVICE_USER_GROUP
 from cinder import utils as cinder_utils
+from cinder.volume import volume_utils
 
 
 LOG = logging.getLogger(__name__)
@@ -288,9 +289,9 @@ class SAPShardRetypeMigrationFilter(ShardFilter):
             #    '<system_name>@vmware#pool'
             # host entries for fcd base volumes are
             #    '<system_name>@vmware_fcd#pool'
-            vol_backend = cinder_utils.extract_host(
+            vol_backend = volume_utils.extract_host(
                 vol['host'], 'backend').split('@')[1]
-            backend_backend = cinder_utils.extract_host(
+            backend_backend = volume_utils.extract_host(
                 backend_state.host, 'backend').split('@')[1]
             vol_shard = self._extract_shard_from_host(vol['host'])
             backend_shard = self._extract_shard_from_host(backend_state.host)


### PR DESCRIPTION
[SAP] Fix scheduler filter extract_host call
cinder.utils does not have an extract_host function, it was from volume_utils
Change-Id: I694a3d3247bd879996654497e07ce6aee21241e1