### PR TITLE
Add file_exists check to file_clone

### DIFF
--- a/cinder/tests/unit/volume/drivers/netapp/dataontap/client/test_client_cmode_rest.py
+++ b/cinder/tests/unit/volume/drivers/netapp/dataontap/client/test_client_cmode_rest.py
@@ -2345,6 +2345,8 @@ class NetAppRestCmodeClientTestCase(test.TestCase):
                          return_value=fake_volume)
         self.mock_object(self.client.connection, 'get_api_version',
                          return_value=api_version)
+        self.mock_object(self.client, 'file_exists',
+                         return_vaule=True)
 
         self.client.clone_file(
             fake_volume['name'], fake_name, fake_new_name, fake.VSERVER_NAME,

--- a/cinder/volume/drivers/netapp/dataontap/client/client_cmode_rest.py
+++ b/cinder/volume/drivers/netapp/dataontap/client/client_cmode_rest.py
@@ -1690,6 +1690,25 @@ class RestClient(object):
         }
         self.send_request('/storage/luns/', 'patch', query=query, body=body)
 
+    def file_exists(self, netapp_vol, file_path):
+
+        file_found = False
+        info_fields = {'type': 'file'}
+        file_elements = file_path.split('/')
+        if len(file_elements) == 1:
+            dir_path = ''
+        else:
+            dir_path = '/'.join(file_elements[:-1])
+        dir_path.replace('.', '%2E').replace('/', '%2F')
+        file_name = file_elements[-1]
+        query = f'/storage/volumes/{netapp_vol["uuid"]}/files/{dir_path}'
+        file_info = self.send_request(query, 'get', body=info_fields)
+        for file in file_info['records']:
+            if file['name'] == file_name:
+                file_found = True
+
+        return file_found
+
     def clone_file(self, flex_vol, src_path, dest_path, vserver,
                    dest_exists=False, source_snapshot=None, is_snapshot=False):
         """Clones file on vserver."""
@@ -1716,7 +1735,7 @@ class RestClient(object):
         if is_snapshot and self.features.BACKUP_CLONE_PARAM:
             body['is_backup'] = True
 
-        if dest_exists:
+        if dest_exists and self.file_exists(volume, dest_path):
             body['overwrite_destination'] = True
 
         self.send_request('/storage/file/clone', 'post', body=body)


### PR DESCRIPTION
Add file_exists check to file_clone
Safeguard clone operation, that failed due to overwrite flag was set, but no file exists.
The api fails if the file does not exists and the overwrite flag is set.
The fix is checking the dest directory if the file exists, it sets the flag, but if not, that omits setting it.
Change-Id: I7c77ad34df4403f35da320ee5e28f404b8cd2493