### PR TITLE
[SAP] Allow migration on the same host.

### DIFF
--- a/cinder/scheduler/filters/sap_fcd_filter.py
+++ b/cinder/scheduler/filters/sap_fcd_filter.py
@@ -39,6 +39,8 @@ class SAPFCDFilter(filters.BaseBackendFilter):
     def backend_passes(self, backend_state, filter_properties):
 
         if not self._is_vmware_fcd(backend_state):
+            LOG.debug("SAP FCD Filter ignoring backend %s isn't vmware_fcd"
+                      " driver", backend_state.backend_id)
             return True
 
         spec = filter_properties.get('request_spec', {})
@@ -46,6 +48,8 @@ class SAPFCDFilter(filters.BaseBackendFilter):
 
         valid_ops = ['migrate_volume', 'find_backend_for_connector']
         if spec.get('operation') not in valid_ops:
+            LOG.debug("SAP FCD Filter ignoring operation %s",
+                      spec.get('operation'))
             return True
 
         # We are migrating a volume.  If we are migrating to a different

--- a/cinder/scheduler/filters/shard_filter.py
+++ b/cinder/scheduler/filters/shard_filter.py
@@ -278,6 +278,8 @@ class SAPShardRetypeMigrationFilter(ShardFilter):
             if vol_shard == backend_shard:
                 return True
             else:
+                LOG.debug('Retype Filtering out %s Not on same shard as %s',
+                          backend_state.host, vol['host'])
                 return False
 
         # A migration for vmdk -> fcd(vstorageobject) should land
@@ -295,9 +297,20 @@ class SAPShardRetypeMigrationFilter(ShardFilter):
                 backend_state.host, 'backend').split('@')[1]
             vol_shard = self._extract_shard_from_host(vol['host'])
             backend_shard = self._extract_shard_from_host(backend_state.host)
-            if (vol_backend == 'vmware' and backend_backend == 'vmware_fcd' and
-                    vol_shard == backend_shard):
+
+            # We only care about limiting vmware -> vmware_fcd migrations
+            # to the same shard.
+            if vol_backend != 'vmware':
                 return True
-            return False
-        # Allow any other operation to work
+
+            if backend_backend != 'vmware_fcd':
+                return True
+
+            # Now we know we are migrating from vmware to vmware_fcd,
+            # so we need to check if the shard is the same.
+            if vol_shard != backend_shard:
+                LOG.debug('Migrate Filtering out %s Not on same shard as %s',
+                          backend_state.host, vol['host'])
+                return False
+
         return True


### PR DESCRIPTION
This patch fixes/updates the SAPShardRetypeMigrationFilter
to allow migrating a volume to another pool on the same host.

The filter should only filter out in the case where
we are migrating from vmdk -> fcd and the shards are not the
same.

Change-Id: I40bed3ad7eb84a7d72143ce1523d47a27f53f781