### PR TITLE
SAP: let qemu-img detect image format during conversion check

### DIFF
--- a/cinder/image/image_utils.py
+++ b/cinder/image/image_utils.py
@@ -177,8 +177,13 @@ def qemu_img_info(
         raise exception.Invalid(
             reason=_('Image/Volume failed safety check'))
 
-    cmd = ['env', 'LC_ALL=C', 'qemu-img', 'info',
-           '-f', format_name, '--output=json']
+
+    # NOTE(anokfireball): Upstream passes `'-f', format_name` here, but the
+    # format inspector does not reliably detect our VMDKs (returns 'raw'). In
+    # these cases, format checks will fail due an inconsistecy between requested
+    # and detected format. NOT passing `-f` here allows qemu-img to detect the
+    # format automatically, which is more reliable for the formats we use.
+    cmd = ['env', 'LC_ALL=C', 'qemu-img', 'info', '--output=json']
     if force_share:
         cmd.append('--force-share')
     cmd.append(path)


### PR DESCRIPTION
The current implementation of the VMDKInspector fails to reliably detect some (all?) of our VMDK volumes as such and reports them as RAW. While this is _technically_ not a lie for streamOptimized VMDKs, this results in an inability to convert disks with Error

> The image format was claimed to be 'vmdk' but the image data appears to be in a different format.

By removing the `--format` specifier for `qemu-img`, we let the binary detect the actual format instead of overriding any detected values.

Change-Id: I6d8a7e14b0f235b8e213b142e88a7f8195e85852