### PR TITLE
[SAP] Add new admin API to set pool state

### DIFF
--- a/cinder/api/contrib/sap.py
+++ b/cinder/api/contrib/sap.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2025 SAP Corporation
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""The SAP Contrib API."""
+
+from http import HTTPStatus
+
+import jsonschema
+from oslo_config import cfg
+from oslo_log import log as logging
+import webob
+
+from cinder.api import common
+from cinder.api import extensions
+from cinder.api import microversions as mv
+from cinder.api.openstack import wsgi
+from cinder.api import validation
+from cinder.api.validation import parameter_types
+from cinder.common import constants
+from cinder import exception
+from cinder.i18n import _
+from cinder.policies import services as policy
+from cinder import volume
+from cinder.volume import rpcapi as volume_rpcapi
+from cinder.volume import volume_utils
+
+CONF = cfg.CONF
+LOG = logging.getLogger(__name__)
+
+
+VALID_POOL_STATES = ["available", "drain"]
+
+# Schema for SAP Contrib
+schema_recount_host_stats = {
+    'type': 'object',
+    'properties': {
+        'host': parameter_types.hostname,
+    },
+    'additionalProperties': False,
+}
+
+schema_set_pool_state = {
+    'type': 'object',
+    'properties': {
+        'host': parameter_types.cinder_host,
+        'status': {'type': ['string', 'null'],
+                   'format': 'pool_status'},
+    },
+    'additionalProperties': False,
+}
+
+
+# The validator for the pool status in the set_pool_state API
+@jsonschema.FormatChecker.cls_checks('pool_status')
+def _validate_pool_status(param_value):
+    POOL_STATES = ["available", "drain"]
+    if param_value and param_value.lower() not in POOL_STATES:
+        msg = _("Pool status: %(status)s is invalid, "
+                "valid statuses are: "
+                "%(valid)s.") % {'status': param_value,
+                                 'valid': POOL_STATES}
+        raise exception.InvalidParameterValue(err=msg)
+    return True
+
+
+class SAPContribController(wsgi.Controller):
+    def __init__(self, ext_mgr=None):
+        self.ext_mgr = ext_mgr
+        super(SAPContribController, self).__init__()
+        self.volume_api = volume.API()
+        self.rpc_apis = {
+            constants.VOLUME_BINARY: volume_rpcapi.VolumeAPI(),
+        }
+
+    def _volume_api_proxy(self, fun, *args):
+        try:
+            return fun(*args)
+        except exception.ServiceNotFound as ex:
+            raise exception.InvalidInput(ex.msg)
+
+    @volume_utils.trace
+    def index(self, req):
+        """List the SAP Contrib, which is none."""
+        context = req.environ['cinder.context']
+        context.authorize(policy.GET_ALL_POLICY)
+        return webob.Response(status_int=HTTPStatus.OK)
+
+    @volume_utils.trace
+    def update(self, req, id, body):
+        """Update the SAP Contrib."""
+        context = req.environ['cinder.context']
+        context.authorize(policy.UPDATE_POLICY)
+
+        if id == "recount_host_stats":
+            return self._recount_host_stats(req, context, body=body)
+        elif id == "set_pool_state":
+            return self._set_pool_state(req, context, body=body)
+        else:
+            raise exception.InvalidInput(reason=_("Unknown action"))
+
+        return webob.Response(status_int=HTTPStatus.ACCEPTED)
+
+    @validation.schema(schema_recount_host_stats)
+    @volume_utils.trace
+    def _recount_host_stats(self, req, context, body):
+        """Ask the volume manager to recount allocated capacity for host."""
+        cluster_name, host = common.get_cluster_host(req, body,
+                                                     mv.REPLICATION_CLUSTER)
+        self._volume_api_proxy(self.volume_api.recount_host_stats, context,
+                               host)
+        return webob.Response(status_int=HTTPStatus.ACCEPTED)
+
+    @volume_utils.trace
+    def _validate_set_pool_state(self, req, body):
+        update = {}
+        status = body.get('status', None).lower()
+        host = body.get('host', None).lower()
+
+        update['status'] = status
+        update['host'] = host
+        return update
+
+    @validation.schema(schema_set_pool_state)
+    @volume_utils.trace
+    def _set_pool_state(self, req, context, body):
+        """Set the pool state for the host."""
+        cluster_name, host = common.get_cluster_host(req, body,
+                                                     mv.REPLICATION_CLUSTER)
+        update = self._validate_set_pool_state(req, body)
+
+        # Make sure the status is valid
+        if update['status'] not in VALID_POOL_STATES:
+            msg = _("Cannot reset-state to %s"
+                    % update.get('status'))
+            raise webob.exc.HTTPBadRequest(explanation=msg)
+
+        self._volume_api_proxy(self.volume_api.set_pool_state,
+                               context, host, update['status'])
+        return webob.Response(status_int=HTTPStatus.ACCEPTED)
+
+
+class Sap(extensions.ExtensionDescriptor):
+    """SAP Contrib support."""
+
+    name = "SAPContrib"
+    alias = "os-sap-contrib"
+    updated = "2025-09-04T00:00:00-00:00"
+
+    def get_resources(self):
+        resources = []
+        controller = SAPContribController(self.ext_mgr)
+        resource = extensions.ResourceExtension('os-sap-contrib', controller)
+        resources.append(resource)
+        return resources

--- a/cinder/api/contrib/services.py
+++ b/cinder/api/contrib/services.py
@@ -153,15 +153,6 @@ class ServiceController(wsgi.Controller):
                                cluster_name, body.get('backend_id'))
         return webob.Response(status_int=HTTPStatus.ACCEPTED)
 
-    @validation.schema(os_services.recount_host_stats)
-    def _recount_host_stats(self, req, context, body):
-        """Ask the volume manager to recount allocated capacity for host."""
-        cluster_name, host = common.get_cluster_host(req, body,
-                                                     mv.REPLICATION_CLUSTER)
-        self._volume_api_proxy(self.volume_api.recount_host_stats, context,
-                               host)
-        return webob.Response(status_int=HTTPStatus.ACCEPTED)
-
     def _log_params_binaries_services(self, context, body):
         """Get binaries and services referred by given log set/get request."""
         query_filters = {'is_up': True}
@@ -282,8 +273,6 @@ class ServiceController(wsgi.Controller):
             return self._set_log(req, context, body=body)
         elif support_dynamic_log and id == 'get-log':
             return self._get_log(req, context, body=body)
-        elif id == "recount_host_stats":
-            return self._recount_host_stats(req, context, body=body)
         else:
             raise exception.InvalidInput(reason=_("Unknown action"))
 

--- a/cinder/policies/__init__.py
+++ b/cinder/policies/__init__.py
@@ -35,6 +35,7 @@ from cinder.policies import messages
 from cinder.policies import qos_specs
 from cinder.policies import quota_class
 from cinder.policies import quotas
+from cinder.policies import sap
 from cinder.policies import scheduler_stats
 from cinder.policies import services
 from cinder.policies import snapshot_actions
@@ -85,4 +86,5 @@ def list_rules():
         type_extra_specs.list_rules(),
         volumes.list_rules(),
         default_types.list_rules(),
+        sap.list_rules(),
     )

--- a/cinder/policies/sap.py
+++ b/cinder/policies/sap.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2025 SAP Corporation
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from oslo_policy import policy
+
+from cinder.policies import base
+
+
+SET_POOL_STATE_POLICY = "sap:set_pool_state"
+RECOUNT_STATS_POLICY = "sap:recount_host_stats"
+
+sap_policies = [
+    policy.DocumentedRuleDefault(
+        name=RECOUNT_STATS_POLICY,
+        check_str=base.RULE_ADMIN_API,
+        description="Recount host stats allocated capacity",
+        operations=[
+            {
+                'method': 'PUT',
+                'path': '/os-sap-contrib/recount_host_stats'
+            }
+        ]),
+    policy.DocumentedRuleDefault(
+        name=SET_POOL_STATE_POLICY,
+        check_str=base.RULE_ADMIN_API,
+        description="Set the pool state for the host",
+        operations=[
+            {
+                'method': 'PUT',
+                'path': '/os-sap-contrib/set_pool_state'
+            }
+        ]),
+]
+
+
+def list_rules():
+    return sap_policies

--- a/cinder/policies/services.py
+++ b/cinder/policies/services.py
@@ -23,7 +23,6 @@ UPDATE_POLICY = "volume_extension:services:update"
 FAILOVER_POLICY = "volume:failover_host"
 FREEZE_POLICY = "volume:freeze_host"
 THAW_POLICY = "volume:thaw_host"
-RECOUNT_STATS_POLICY = "volume:recount_host_stats"
 
 services_policies = [
     policy.DocumentedRuleDefault(
@@ -75,16 +74,6 @@ services_policies = [
             {
                 'method': 'PUT',
                 'path': '/os-services/failover_host'
-            }
-        ]),
-    policy.DocumentedRuleDefault(
-        name=RECOUNT_STATS_POLICY,
-        check_str=base.RULE_ADMIN_API,
-        description="Recount host stats allocated capacity",
-        operations=[
-            {
-                'method': 'PUT',
-                'path': '/os-services/recount_host_stats'
             }
         ]),
 ]

--- a/cinder/tests/unit/volume/drivers/netapp/dataontap/test_nfs_cmode.py
+++ b/cinder/tests/unit/volume/drivers/netapp/dataontap/test_nfs_cmode.py
@@ -246,6 +246,8 @@ class NetAppCmodeNfsDriverTestCase(test.TestCase):
 
         expected = [{
             'pool_name': '10.10.10.10:/vola',
+            'pool_state': 'up',
+            'pool_down_reason': '',
             'reserved_percentage': fake.RESERVED_PERCENTAGE,
             'max_over_subscription_ratio': fake.MAX_OVER_SUBSCRIPTION_RATIO,
             'multiattach': True,

--- a/cinder/volume/api.py
+++ b/cinder/volume/api.py
@@ -53,6 +53,7 @@ from cinder.objects import base as objects_base
 from cinder.objects import fields
 from cinder.objects import volume_type
 from cinder.policies import attachments as attachment_policy
+from cinder.policies import sap as sap_policy
 from cinder.policies import services as svr_policy
 from cinder.policies import snapshot_metadata as s_meta_policy
 from cinder.policies import snapshots as snapshot_policy
@@ -2485,9 +2486,16 @@ class API(base.Base):
         return None
 
     def recount_host_stats(self, ctxt, host):
-        ctxt.authorize(svr_policy.RECOUNT_STATS_POLICY)
+        """SAP.  Recount the host stats for the host/pool."""
+        ctxt.authorize(sap_policy.RECOUNT_STATS_POLICY)
         ctxt = ctxt if ctxt.is_admin else ctxt.elevated()
         self.volume_rpcapi.recount_host_stats(ctxt, host)
+
+    def set_pool_state(self, ctxt, host, status):
+        """SAP.  Set the pool state for the host/pool."""
+        ctxt.authorize(sap_policy.SET_POOL_STATE_POLICY)
+        ctxt = ctxt if ctxt.is_admin else ctxt.elevated()
+        self.volume_rpcapi.set_pool_state(ctxt, host, status)
 
     def check_volume_filters(self,
                              filters: dict,

--- a/cinder/volume/drivers/netapp/dataontap/client/client_cmode_rest.py
+++ b/cinder/volume/drivers/netapp/dataontap/client/client_cmode_rest.py
@@ -2823,11 +2823,14 @@ class RestClient(object):
         body = {'comment': comment}
         self.send_request(f'/storage/volumes/{uuid}', 'patch', body=body)
 
-    def get_volume_comment(self, volume_name):
+    def get_volume_comment(self, volume_name) -> str:
         """get comment on volume"""
 
         query = {'fields': 'name,comment'}
         query['name'] = volume_name
         volumes_response = self.send_request('/storage/volumes',
                                              'get', query=query)
-        return volumes_response['records'][0]['comment']
+        LOG.info('Volumes response: %s', volumes_response)
+        if (volumes_response and volumes_response.get('num_records', 0) > 0):
+            return volumes_response['records'][0]['comment']
+        return None

--- a/cinder/volume/drivers/netapp/dataontap/nfs_cmode.py
+++ b/cinder/volume/drivers/netapp/dataontap/nfs_cmode.py
@@ -21,6 +21,7 @@
 Volume driver for NetApp NFS storage.
 """
 
+import json
 import os
 import uuid
 
@@ -330,6 +331,29 @@ class NetAppCmodeNfsDriver(nfs_base.NetAppNfsDriver,
                                                               export_path)
         return vserver, exp_volume
 
+    @volume_utils.trace
+    def set_pool_state(self, pool_name, state, state_reason):
+        """Set the pool state for the volume."""
+
+        # The pool_name is in the format of
+        # <ip_address>:/<volume_name>   or
+        # <ip_address>:<volume_name>/<qtree_name>
+        # We have to extract the volume_name from the pool_name.
+        volume_name = pool_name.split('/')[1]
+
+        pool_json = json.dumps(
+            {'pool_state': state, 'pool_down_reason': state_reason}
+        )
+        LOG.info("Setting pool state for %s to '%s'", volume_name, pool_json)
+
+        # Set a json string in the comment field to keep track
+        # of the pool state and the reason for the pool state.
+        if hasattr(self.zapi_client, 'set_volume_comment'):
+            self.zapi_client.set_volume_comment(volume_name, pool_json)
+        else:
+            LOG.warning("Driver %s can't set the pool state",
+                        self.driver_name)
+
     def _update_volume_stats(self):
         """Retrieve stats info from vserver."""
 
@@ -351,6 +375,18 @@ class NetAppCmodeNfsDriver(nfs_base.NetAppNfsDriver,
         data['replication_enabled'] = self.replication_enabled
 
         self._stats = data
+
+    @volume_utils.trace
+    def _get_volume_comment(self, volume_name):
+        """Get the comment for a volume."""
+        if hasattr(self.zapi_client, 'get_volume_comment'):
+            comments = self.zapi_client.get_volume_comment(volume_name)
+            try:
+                info = json.loads(comments)
+            except Exception:
+                return None
+            return info
+        return None
 
     def _get_pool_stats(self, filter_function=None, goodness_function=None):
         """Retrieve pool (Data ONTAP flexvol) stats.
@@ -449,6 +485,18 @@ class NetAppCmodeNfsDriver(nfs_base.NetAppNfsDriver,
             pool['goodness_function'] = goodness_function
             netapp_server_fqdn = self.configuration.netapp_server_hostname
             pool['netapp_server_hostname'] = netapp_server_fqdn
+
+            # SAP
+            # Get the comment section of the volume and see if
+            # it's marked as down by an admin
+            pool['pool_state'] = 'up'
+            pool['pool_down_reason'] = ''
+            pool_info = self._get_volume_comment(ssc_vol_name)
+            if pool_info:
+                pool['pool_state'] = pool_info.get('pool_state', 'up')
+                pool['pool_down_reason'] = pool_info.get('pool_down_reason')
+            LOG.info('Pool state for volume %s: %s',
+                     ssc_vol_name, pool['pool_state'])
 
             # Add replication capabilities/stats
             pool.update(

--- a/cinder/volume/manager.py
+++ b/cinder/volume/manager.py
@@ -655,6 +655,47 @@ class VolumeManager(manager.CleanableManager,
     def recount_host_stats(self, context):
         self._count_host_stats(context, export_volumes=False)
 
+    @volume_utils.trace
+    def set_pool_state(self, context, host, status):
+        # Set the pool state for the host.
+        # The status is either "available" or "drain".
+        # If the status is "drain", we will set the pool state to "down".
+        # If the status is "available", we will set the pool state to "up".
+        # We will also set the pool state reason to the status.
+
+        # extract the pool name from the host
+        requested_pool_name = volume_utils.extract_host(host, 'pool')
+        requested_pool_state = "up" if status == "available" else "down"
+        if status == "drain":
+            requested_pool_state_reason = "pool marked as draining"
+        else:
+            requested_pool_state_reason = ""
+        LOG.info(
+            "Setting pool '%s' state to '%s' with reason '%s'",
+            requested_pool_name,
+            requested_pool_state,
+            requested_pool_state_reason
+        )
+        for pool_name in self.stats['pools']:
+            pool = self.stats['pools'][pool_name]
+            if pool_name == requested_pool_name:
+                pool['pool_state'] = requested_pool_state
+                pool['pool_state_reason'] = requested_pool_state_reason
+
+        # if the driver has the ability to set the pool state,
+        # we will call the driver to set the pool state.
+        if hasattr(self.driver, 'set_pool_state'):
+            self.driver.set_pool_state(
+                requested_pool_name,
+                requested_pool_state,
+                requested_pool_state_reason,
+            )
+        else:
+            LOG.warning(
+                "Driver %s does not have the ability to set the pool state.",
+                self.driver.__class__.__name__
+            )
+
     @coordination.synchronized('volume-stats-{self.host}')
     def _count_host_stats(self, context, export_volumes=False):
         """Recount the number of volumes and allocated capacity."""

--- a/cinder/volume/rpcapi.py
+++ b/cinder/volume/rpcapi.py
@@ -141,6 +141,7 @@ class VolumeAPI(rpc.RPCAPI):
         3.17 - Make get_backup_device a cast (async)
         3.17 - SAP - Added recount_host_stats (async)
         3.18 - Add reimage method
+        3.18 - SAP - Added set_pool_state (async)
     """
 
     RPC_API_VERSION = '3.18'
@@ -172,6 +173,11 @@ class VolumeAPI(rpc.RPCAPI):
     def recount_host_stats(self, ctxt, host):
         cctxt = self._get_cctxt(host=host)
         cctxt.cast(ctxt, 'recount_host_stats')
+
+    @rpc.assert_min_rpc_version('3.18')
+    def set_pool_state(self, ctxt, host, status):
+        cctxt = self._get_cctxt(host=host)
+        cctxt.cast(ctxt, 'set_pool_state', host=host, status=status)
 
     def create_volume(self,
                       ctxt: context.RequestContext,


### PR DESCRIPTION
This patch adds a new admin API to allow an admin
to set the state of a cinder pool.  This allows
admins to set a pool to drain or available.  When a pool is set to drain, then the pool is marked as down and the SAPPoolDownFilter will not allow new provisioning against that pool.

This patch also moves the custom SAP recount_host_stats API call from the cinder builtin services contrib API to the new SAP contrib API.  This localizes changes for SAP's code.

Change-Id: I4a2c6bb6ce178a2e3b175b2b1152a7522430af32