### PR TITLE
Allow quota sync to actually fix quota issues

### DIFF
--- a/cinder/cmd/manage.py
+++ b/cinder/cmd/manage.py
@@ -532,7 +532,7 @@ class QuotaCommands(object):
         print('Action successfully completed')
         return discrepancy
 
-    @db_api.main_context_manager.reader
+    @db_api.main_context_manager.writer
     def _check_project_sync(self,
                             ctxt: context.RequestContext,
                             project: str,


### PR DESCRIPTION
As db reader changes cannot be committed to the database, run as writer instead. Fixes a regression introduced in [0].

[0] Ic8c37145c66069e9194458fa7f622d98022fee4f

Related-Bug: #2047693
Closes-Bug: #2104322
Change-Id: I448699a03644e6536e9f829ae1a5ae014f02f5d3