### PR TITLE
[SAP] LOG when the scheduler filter removes host

### DIFF
--- a/cinder/scheduler/filter_scheduler.py
+++ b/cinder/scheduler/filter_scheduler.py
@@ -603,6 +603,9 @@ class FilterScheduler(driver.Scheduler):
                     else volume_utils.extract_host(backend.obj.backend_id)
                 )
                 if backend_id != resource_backend:
+                    LOG.warning("Backend '%s' removed because it doesn't "
+                                "match the resource_backend '%s'.",
+                                backend_id, resource_backend)
                     weighed_backends.remove(backend)
         if not weighed_backends:
             assert filter_properties is not None


### PR DESCRIPTION
This adds a warning log when the scheduler removes a backend from the already filtered backends because the request spec requires that the new volume must land on a specific backend. This happens when creating a volume from a backup, snapshot or volume.

This is a special case only for SAP, because when we deploy FCD support for cinder, we have to manually modify the existing vmware volume type and change the extra specs.  This is not really allowed by the cinder api after a volume is created against an existing volume type.  In our case we wanted a seamless deployment for customers so we changed the volume type extra specs manually, so that all new volumes get FCD and no existing scripts that call the cinder api have to change.  This is not a good thing for us as operators, which is why cinder upstream doesn't allow this case.

This new log warning will at least give us a clue in the logs when we get a failure to find a host when creating a volume from another volume.  Once all volumes in a region are converted to FCD, this special case can't happen.

Change-Id: I2f4c265daf860a58f288fff00c15148af868962d