### PR TITLE
[SAP] Add version to connection_info

### DIFF
--- a/cinder/volume/drivers/netapp/dataontap/nfs_cmode.py
+++ b/cinder/volume/drivers/netapp/dataontap/nfs_cmode.py
@@ -71,6 +71,13 @@ class NetAppCmodeNfsDriver(nfs_base.NetAppNfsDriver,
 
     VERSION = "3.0.0"
 
+    # SAP: the attachment version
+    # Any changes to the connection_info returned by
+    # the driver's initialize_connection should
+    # increment this version.
+    # 1.0.0 - initial version
+    ATTACHMENT_VERSION = '1.0.0'
+
     REQUIRED_CMODE_FLAGS = ['netapp_vserver']
 
     def __init__(self, *args, **kwargs):
@@ -1252,3 +1259,11 @@ class NetAppCmodeNfsDriver(nfs_base.NetAppNfsDriver,
 
         return self.migrate_volume_ontap_assisted(
             volume, host, self.backend_name, self.configuration.netapp_vserver)
+
+    # SAP: the attachment version
+    # We override this so we can add the version to the connection info
+    # For the volume checker.
+    def initialize_connection(self, volume, connector):
+        conn_info = super().initialize_connection(volume, connector)
+        conn_info['data']['version'] = self.ATTACHMENT_VERSION
+        return conn_info

--- a/cinder/volume/drivers/vmware/fcd.py
+++ b/cinder/volume/drivers/vmware/fcd.py
@@ -68,6 +68,13 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
     # FCD Cross vcenter migration is available in 8.0.3
     FCD_CROSS_VC_MIGRATION_VC_VERSION = '8.0.3'
 
+    # SAP: the attachment version
+    # Any changes to the connection_info returned by
+    # the driver's initialize_connection should
+    # increment this version.
+    # 1.0.0 - initial version
+    ATTACHMENT_VERSION = '1.0.0'
+
     def _driver_name(self):
         return LOCATION_DRIVER_NAME
 
@@ -339,6 +346,7 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
                 'vmdk_size': volume.size * units.Gi,
                 'vmdk_path': vmdk_path,
                 'datacenter': datacenter,
+                'version': self.ATTACHMENT_VERSION,
             }
         }
 

--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -381,6 +381,13 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
     # flag this driver as supporting independent snapshots
     has_independent_snapshots = True
 
+    # SAP: the attachment version
+    # Any changes to the connection_info returned by
+    # the driver's initialize_connection should
+    # increment this version.
+    # 1.0.0 - initial version
+    ATTACHMENT_VERSION = '1.0.0'
+
     def __init__(self, *args, **kwargs):
         super(VMwareVcVmdkDriver, self).__init__(*args, **kwargs)
 
@@ -1129,6 +1136,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
             'name': volume.name,
             'profile_id': self._get_storage_profile_id(volume),
             'datastore': self.volumeops.get_datastore(backing).value,
+            'version': self.ATTACHMENT_VERSION,
         }
 
         # vmdk connector in os-brick needs additional connection info.


### PR DESCRIPTION
This patch adds a version key/value pair in the return of initialize_connection.  This is only a metadata field for the SAP hammer volume checker to know what is the expected schema and values for the cinder volume attachment connection info.  This can be used to help automatically fix known issues.

This version is added to the following SAP used drivers: vmware/vmdk
vmware/fcd
netapp/nfs_cmode

NOTE:
Any changes to the resulting connection_info by the above drivers need a version bump.  So future code reviews need to check that the version is bumped if there are any changes only to the connection_info returned by initialize_connection.

Change-Id: Ica1ea0b563d6dcc7ee30657b372ad0f369316cc0