### PR TITLE
NetAppCmodeNfsDriver call explicit super

### DIFF
--- a/cinder/volume/drivers/netapp/dataontap/nfs_cmode.py
+++ b/cinder/volume/drivers/netapp/dataontap/nfs_cmode.py
@@ -1272,6 +1272,7 @@ class NetAppCmodeNfsDriver(nfs_base.NetAppNfsDriver,
     # We override this so we can add the version to the connection info
     # For the volume checker.
     def initialize_connection(self, volume, connector):
-        conn_info = super().initialize_connection(volume, connector)
+        conn_info = super(nfs_base.NetAppNfsDriver,
+                          self).initialize_connection(volume, connector)
         conn_info['data']['version'] = self.ATTACHMENT_VERSION
         return conn_info


### PR DESCRIPTION
Plain super() was raising exception, despite it should being virtual identical.

Change-Id: Icac44472c190194a200872700758bb66fd4bbd28