### PR TITLE
Fix the concourse_unit_test_task in 2025.1-m3

### DIFF
--- a/cinder/cmd/manage.py
+++ b/cinder/cmd/manage.py
@@ -1176,7 +1176,7 @@ class SapCommands:
         if len(ids) == 0:
             print("No glance metadata found that is linked to deleted volumes")
         else:
-            print(f"found {len(ids) }glance metadata of volumes that are"
+            print(f"found {len(ids)} glance metadata of volumes that are"
                   f"already deleted: {(', ').join(str(x) for x in ids)}")
         return ids
 

--- a/concourse_unit_test_task
+++ b/concourse_unit_test_task
@@ -1,8 +1,7 @@
 export DEBIAN_FRONTEND=noninteractive && \
 apt-get update && \
-apt-get install -y build-essential python3-pip python3-dev git libpcre++-dev gettext libpq-dev qemu-utils && \
-pip install -U pip && \
-pip install tox && \
+apt-get install -y build-essential python3-pip python3-dev git libpcre2-dev gettext libpq-dev qemu-utils && \
+pip install -U tox --break-system-packages && \
 cd source && \
-export TOX_CONSTRAINTS_FILE=https://raw.githubusercontent.com/sapcc/requirements/stable/2023.1-m3/upper-constraints.txt && \
+export TOX_CONSTRAINTS_FILE=https://raw.githubusercontent.com/sapcc/requirements/stable/2025.1-m3/upper-constraints.txt && \
 tox -e pep8,py3


### PR DESCRIPTION
There are 2 commits here

1. Fixing the concourse_unit_test_task to pass for ubuntu noble
2. Fix 1 pep8 test which was not failing in the pull-request tox, but it fails in the loci pipeline.