### PR TITLE
Set QOS via NetApp rpc on the vmdk flat-file

### DIFF
--- a/cinder/tests/unit/volume/drivers/vmware/test_fcd.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_fcd.py
@@ -224,8 +224,11 @@ class VMwareVStorageObjectDriverTestCase(test.TestCase):
         fcd_loc.provider_location.return_value = provider_loc
         vops.create_fcd.return_value = fcd_loc
         provider_loc_to_ds_name_loc.return_value = provider_loc
-
-        volume = self._create_volume_obj()
+        extra_specs = {'image_service:store_id': 'fake-store'}
+        test_utils.create_volume_type(
+            self._context.elevated(), id=fake.VOLUME_TYPE_ID,
+            name="test_type", extra_specs=extra_specs)
+        volume = self._create_volume_obj(volume_type_id=fake.VOLUME_TYPE_ID)
         volume.volume_glance_metadata = glance_metadata
         ret = self._driver.create_volume(volume)
 
@@ -703,7 +706,11 @@ class VMwareVStorageObjectDriverTestCase(test.TestCase):
         provider_loc = mock.sentinel.provider_loc
         provider_loc_to_ds_name_loc.return_value = dest_provider_loc
         cur_size = 1
-        volume = self._create_volume_obj()
+        extra_specs = {'image_service:store_id': 'fake-store'}
+        test_utils.create_volume_type(
+            self._context.elevated(), id=fake.VOLUME_TYPE_ID,
+            name="test_type", extra_specs=extra_specs)
+        volume = self._create_volume_obj(volume_type_id=fake.VOLUME_TYPE_ID)
         ret = self._driver._create_volume_from_fcd(
             provider_loc, cur_size, volume)
         self.assertEqual({'provider_location': dest_provider_loc}, ret)

--- a/cinder/volume/drivers/netapp/remote.py
+++ b/cinder/volume/drivers/netapp/remote.py
@@ -51,6 +51,13 @@ class SAPNetappDriverRemoteApi(rpc.RPCAPI):
         cctxt = self._get_cctxt(host=host)
         return cctxt.call(ctxt, 'get_file_sizes_by_dir', path=path)
 
+    def file_assign_qos(self, ctxt, host, vol_name,
+                        qos_policy_group_name, path):
+        cctxt = self._get_cctxt(host=host)
+        return cctxt.call(ctxt, 'file_assign_qos', vol_name=vol_name,
+                          qos_policy_group_name=qos_policy_group_name,
+                          path=path)
+
 
 class SAPNetappDriverRemoteService(object):
     RPC_API_VERSION = SAPNetappDriverRemoteApi.RPC_API_VERSION
@@ -69,3 +76,12 @@ class SAPNetappDriverRemoteService(object):
     def get_file_sizes_by_dir(self, ctxt, path):
         # Returns used bytes of a file
         return self._driver.zapi_client.get_file_sizes_by_dir(path)
+
+    def file_assign_qos(self, ctxt, vol_name,
+                        qos_policy_group_name, path):
+        # Sets QOS policy on a file
+        set_qos = self._driver.zapi_client.file_assign_qos
+        return set_qos(flex_vol=vol_name,
+                       qos_policy_group_name=qos_policy_group_name,
+                       qos_policy_group_is_adaptive=True,
+                       file_path=path)

--- a/cinder/volume/drivers/vmware/fcd.py
+++ b/cinder/volume/drivers/vmware/fcd.py
@@ -95,6 +95,7 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
         self._use_fcd_snapshot = False
         self._storage_policy_enabled = vc_67_compatible
         self._use_fcd_cross_vc_migration = cross_vc_migration
+        self._admin_context = context
 
         if CONF.sap_allow_independent_snapshots:
             # If we setup cinder to allow independent snapshots, we can
@@ -226,6 +227,17 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
             return super(VMwareVStorageObjectDriver,
                          self)._get_adapter_type(volume)
 
+    def set_qos_on_fcd(self, fcd_loc, qos_profile_name):
+        ds_ref = fcd_loc.ds_ref()
+        context = self._admin_context
+        netapp_api = self._remote_netapp_api
+        netapp_fqdn = self.volumeops.get_netapp_for_ds(ds_ref)
+        netapp_host = self.get_netapp_cinder_host(netapp_fqdn)
+        vmdk_path = self.volumeops.get_vmdk_path_for_fcd(fcd_loc=fcd_loc)
+        if qos_profile_name and netapp_host:
+            self.volumeops.set_qos(context, ds_ref, netapp_api, netapp_host,
+                                   vmdk_path, qos_profile_name)
+
     @volume_utils.trace
     def create_volume(self, volume):
         """Create a new volume on the backend.
@@ -244,6 +256,13 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
         fcd_loc = self.volumeops.create_fcd(
             volume.id, volume.name, volume.size * units.Ki, ds_ref,
             disk_type, profile_id=profile_id, key_id=key_id)
+        qos_profile_name = volume.volume_type.extra_specs.get(
+            'vmware:netapp_qos_profile')
+        try:
+            self.set_qos_on_fcd(fcd_loc, qos_profile_name)
+        except Exception:
+            LOG.warning("Can't apply %s QOS profile on %s volume",
+                        qos_profile_name, volume.id)
 
         # Convert the provider_location from the moref format to the
         # datastore name format to store in the cinder DB.
@@ -532,7 +551,13 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
                 fcd_loc=fcd_loc) / units.Gi)
         image_size = 1 if image_gib == 0 else image_gib
         self._extend_if_needed(fcd_loc, image_size, volume.size)
-
+        qos_profile_name = volume.volume_type.extra_specs.get(
+            'vmware:netapp_qos_profile')
+        try:
+            self.set_qos_on_fcd(fcd_loc, qos_profile_name)
+        except Exception:
+            LOG.warning("Can't apply %s QOS profile on %s volume",
+                        qos_profile_name, volume.id)
         provider_location = self._provider_location_to_ds_name_location(
             fcd_loc.provider_location()
         )
@@ -733,6 +758,13 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
             provider_loc, volume, ds_ref, disk_type=disk_type,
             profile_id=profile_id, key_id=key_id)
         self._extend_if_needed(cloned_fcd_loc, cur_size, volume.size)
+        qos_profile_name = volume.volume_type.extra_specs.get(
+            'vmware:netapp_qos_profile')
+        try:
+            self.set_qos_on_fcd(cloned_fcd_loc, qos_profile_name)
+        except Exception:
+            LOG.warning("Can't apply %s QOS profile on %s volume",
+                        qos_profile_name, volume.id)
         # Convert the provider location from the moref format to the
         # datastore name format to store in the cinder DB.
         p_location = self._provider_location_to_ds_name_location(

--- a/cinder/volume/drivers/vmware/volumeops.py
+++ b/cinder/volume/drivers/vmware/volumeops.py
@@ -2786,6 +2786,29 @@ class VMwareVolumeOps(object):
         # If the move is success, than the src bytes are the same as the dst.
         return src_bytes == dst_bytes
 
+    def set_qos(self, context, ds_ref, netapp_api, netapp_host,
+                vmdk_path,
+                qos_profile_name):
+        mpath = self._get_mount_path(ds_ref).split(':')[1]
+        netapp_vol = mpath.split('/')[1]
+        len_mpath = len(mpath.split('/'))
+        _, folder_path, src_vmdk_file = split_datastore_path(vmdk_path)
+        src_flat_file = src_vmdk_file.replace('.vmdk', '-flat.vmdk')
+        if len_mpath == 2:
+            rel_path_to_ds = "%s%s" % (folder_path, src_flat_file)
+        if len_mpath == 3:
+            # qtree longer mount path
+            qtree_name = mpath.split('/')[2]
+            rel_path_to_ds = "%s/%s%s" % (qtree_name, folder_path,
+                                          src_flat_file)
+        if len_mpath > 3:
+            # longer mount path not supported
+            return NotImplementedError
+        netapp_api.file_assign_qos(context, host=netapp_host,
+                                   vol_name=netapp_vol,
+                                   os_policy_group_name=qos_profile_name,
+                                   path=rel_path_to_ds)
+
 
 class FcdLocation(object):
 


### PR DESCRIPTION
Set QOS via NetApp rpc on the vmdk flat-file
The profile name can be specified via the vmware:netapp_qos_profile volume_type property