### PR TITLE
Cherry-pick:[vmware] Retry fetch_stream_optimized_image on DuplicateName

### DIFF
--- a/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
@@ -1251,7 +1251,8 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
                                                     get_disk_type,
                                                     get_profile_id,
                                                     select_ds_for_volume,
-                                                    download_error=False):
+                                                    download_error=False,
+                                                    duplicate_name=False):
         host = mock.sentinel.host
         rp = mock.sentinel.rp
         folder = mock.sentinel.folder
@@ -1278,6 +1279,10 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
         if download_error:
             download_image.side_effect = exceptions.VimException
             vops.get_backing.return_value = backing
+        elif duplicate_name:
+            download_image.side_effect = [exceptions.DuplicateName,
+                                          backing]
+            vops.get_backing.return_value = backing
         else:
             download_image.return_value = backing
 
@@ -1300,11 +1305,19 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
                 context, volume, image_service, image_id, image_size,
                 adapter_type)
 
-        select_ds_for_volume.assert_called_once_with(volume)
-        vops.get_create_spec.assert_called_once_with(
+        if duplicate_name:
+            select_ds_for_volume.assert_called_with(volume)
+            vops.get_create_spec.assert_called_with(
+                volume['name'], volume_size_kb, disk_type, summary.name,
+                profile_id=profile_id, adapter_type=adapter_type,
+                extra_config=extra_config)
+        else:
+            select_ds_for_volume.assert_called_once_with(volume)
+            vops.get_create_spec.assert_called_once_with(
             volume['name'], volume_size_kb, disk_type, summary.name,
             profile_id=profile_id, adapter_type=adapter_type,
             extra_config=extra_config)
+
         self.assertEqual(vm_create_spec, import_spec.configSpec)
         download_image.assert_called_with(
             context,
@@ -1323,6 +1336,10 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
         if download_error:
             self.assertFalse(vops.update_backing_disk_uuid.called)
             vops.delete_backing.assert_called_once_with(backing)
+        elif duplicate_name:
+            vops.delete_backing.assert_called_once_with(backing)
+            vops.update_backing_disk_uuid.assert_called_once_with(
+                backing, volume['id'])
         else:
             vops.update_backing_disk_uuid.assert_called_once_with(
                 backing, volume['id'])
@@ -1332,6 +1349,9 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
 
     def test_copy_image_to_volume_stream_optimized_with_download_error(self):
         self._test_copy_image_to_volume_stream_optimized(download_error=True)
+
+    def test_copy_image_to_volume_stream_optimized_with_duplicate_name(self):
+        self._test_copy_image_to_volume_stream_optimized(duplicate_name=True)
 
     @mock.patch.object(VMDK_DRIVER, '_in_use', return_value=True)
     def test_copy_volume_to_image_when_attached(self, in_use):

--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -49,6 +49,7 @@ from cinder.i18n import _
 from cinder.image import image_utils
 from cinder import interface
 from cinder.keymgr import kmip
+from cinder import utils
 from cinder.objects import snapshot as snapshot_obj
 from cinder.scheduler import rpcapi as scheduler_rpcapi
 from cinder.volume import configuration
@@ -1864,6 +1865,9 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                     self._delete_temp_disk(
                         vmdk_path.get_descriptor_ds_file_path(), dc_ref)
 
+    # Retry is needed for VolumeManager.reimage, which triggers the exception
+    # and a subsequent deletion of the backing. The retry reimages the volume.
+    @utils.retry(retry_param=exceptions.DuplicateName)
     def _fetch_stream_optimized_image(self, context, volume, image_service,
                                       image_id, image_size, adapter_type):
         """Creates volume from image using HttpNfc VM import.


### PR DESCRIPTION
fetch_stream_optimized_image currently deletes the backing on any error. The same function is used when reimaging a volume in the VolumeManager, so when a volume with the id already exists, which causes the DuplicateName exception to be raised and in turn not only stops the image from being re-imaged, but the backing to be deleted.

Retrying the method in that case will result in the desired outcome of the volume being re-created from scratch.

Signed-off-by: fabian.wiesel@sap.com
Related-Bug: 2097771
Change-Id: I7723ebcd02a7dd4b107aeab1a4c3c12389664fea