### PR TITLE
Fix Dns issue in k8s

### DIFF
--- a/cinder/volume/volume_utils.py
+++ b/cinder/volume/volume_utils.py
@@ -20,6 +20,7 @@ import abc
 import ast
 import functools
 import inspect
+import ipaddress
 import json
 import logging as py_logging
 import math
@@ -1315,9 +1316,14 @@ def resolve_hostname(hostname: str) -> str:
     :param hostname:  Host name to resolve.
     :returns:         IP Address for Host name.
     """
-    ip = socket.getaddrinfo(hostname, None)[0][4][0]
-    LOG.debug('Asked to resolve hostname %(host)s and got IP %(ip)s.',
-              {'host': hostname, 'ip': ip})
+    try:
+        ip = ipaddress.ip_address(hostname)
+        LOG.debug('Asked to resolve already ip format: %s', ip)
+        return hostname
+    except ValueError:
+        ip = socket.getaddrinfo(hostname, None)[0][4][0]
+        LOG.debug('Asked to resolve hostname %(host)s and got IP %(ip)s.',
+                  {'host': hostname, 'ip': ip})
     return ip
 
 


### PR DESCRIPTION
In k8s frequent dns queries timeout, and make callouts timeout.
This fix is try to validate already ip format hostnames with the python ipaddress library, and only do socket.getaddrinfo, if we get ValueError for a non ip type hostname

Change-Id: I6ee9011d0077cef9a8db4f3dfd90d830b224c88f