### PR TITLE
Fix update ssc don't remove pool during lookup failure

### DIFF
--- a/cinder/tests/unit/volume/drivers/netapp/dataontap/test_nfs_cmode.py
+++ b/cinder/tests/unit/volume/drivers/netapp/dataontap/test_nfs_cmode.py
@@ -390,6 +390,8 @@ class NetAppCmodeNfsDriverTestCase(test.TestCase):
         self.mock_object(self.driver.zapi_client,
                          'get_flexvol',
                          side_effect=side_effect)
+        self.mock_object(self.driver, '_get_flexvol_name_for_share',
+                         return_value=None)
 
         result = self.driver._get_flexvol_to_pool_map()
 

--- a/cinder/volume/drivers/netapp/dataontap/nfs_cmode.py
+++ b/cinder/volume/drivers/netapp/dataontap/nfs_cmode.py
@@ -537,6 +537,11 @@ class NetAppCmodeNfsDriver(nfs_base.NetAppNfsDriver,
                 pools[flexvol['name']] = {'pool_name': share}
             except exception.VolumeBackendAPIException:
                 LOG.exception('Flexvol not found for NFS share %s.', share)
+                # Get flexvol name from ssc in case of failure
+                # We are not dinamicly removing pools
+                flexvol_name = self._get_flexvol_name_for_share(share)
+                if flexvol_name:
+                    pools[flexvol_name] = {'pool_name': share}
 
         return pools
 

--- a/cinder/volume/volume_utils.py
+++ b/cinder/volume/volume_utils.py
@@ -20,6 +20,7 @@ import abc
 import ast
 import functools
 import inspect
+import ipaddress
 import json
 import logging as py_logging
 import math
@@ -1315,9 +1316,14 @@ def resolve_hostname(hostname: str) -> str:
     :param hostname:  Host name to resolve.
     :returns:         IP Address for Host name.
     """
-    ip = socket.getaddrinfo(hostname, None)[0][4][0]
-    LOG.debug('Asked to resolve hostname %(host)s and got IP %(ip)s.',
-              {'host': hostname, 'ip': ip})
+    try:
+        ip = ipaddress.ip_address(hostname)
+        LOG.debug('Asked to resolve already ip format: %s', ip)
+        return hostname
+    except ValueError:
+        ip = socket.getaddrinfo(hostname, None)[0][4][0]
+        LOG.debug('Asked to resolve hostname %(host)s and got IP %(ip)s.',
+                  {'host': hostname, 'ip': ip})
     return ip
 
 


### PR DESCRIPTION
We have a periodic job to update the ssc(Storage Service Catalog), and during the _get_flexvol_to_pool_map, some flex group lookup fails, and pools gets removed from ssc, but the corresponding shares works correctly.
This patch is looking up the flexvol_name from the ssc catalog, if present, and still return the pool.