### PR TITLE
Allow extend_volume even with storage_protocol mismatch

### DIFF
--- a/cinder/scheduler/filters/capabilities_filter.py
+++ b/cinder/scheduler/filters/capabilities_filter.py
@@ -33,11 +33,11 @@ class CapabilitiesFilter(filters.BaseBackendFilter):
         """
 
         req_spec = filter_properties.get('request_spec')
+        allow_proto_mismatch = False
         if req_spec and req_spec.get('operation') == 'extend_volume':
             # NOTE(erlon): By default, cinder considers that every backend
             # supports volume online extending. Those backends that don't
             # support it should report online_extend_support=False.
-            allow_proto_mismatch = False
             online_extends = capabilities.get('online_extend_support', True)
             if online_extends is False:
                 vol_prop = req_spec.get('volume_properties')

--- a/cinder/scheduler/filters/capabilities_filter.py
+++ b/cinder/scheduler/filters/capabilities_filter.py
@@ -37,6 +37,7 @@ class CapabilitiesFilter(filters.BaseBackendFilter):
             # NOTE(erlon): By default, cinder considers that every backend
             # supports volume online extending. Those backends that don't
             # support it should report online_extend_support=False.
+            allow_proto_mismatch = False
             online_extends = capabilities.get('online_extend_support', True)
             if online_extends is False:
                 vol_prop = req_spec.get('volume_properties')
@@ -44,6 +45,8 @@ class CapabilitiesFilter(filters.BaseBackendFilter):
                 if attach_status != VolumeAttachStatus.DETACHED:
                     LOG.debug("Backend doesn't support attached volume extend")
                     return False
+            if capabilities.get('storage_protocol') == 'vmdk':
+                allow_proto_mismatch = True
 
         resource_type = filter_properties.get('resource_type')
         if not resource_type:
@@ -54,7 +57,10 @@ class CapabilitiesFilter(filters.BaseBackendFilter):
             return True
 
         for key, req in extra_specs.items():
-
+            # Allow extend_volume on the old backend
+            if allow_proto_mismatch and key == 'storage_protocol':
+                if req == "vstorageobject":
+                    continue
             # Either not scoped format, or in capabilities scope
             scope = key.split(':')
 

--- a/cinder/scheduler/filters/capabilities_filter.py
+++ b/cinder/scheduler/filters/capabilities_filter.py
@@ -58,6 +58,7 @@ class CapabilitiesFilter(filters.BaseBackendFilter):
 
         for key, req in extra_specs.items():
             # Allow extend_volume on the old backend
+            # Temporary till migration to fcd/kvm is finished
             if allow_proto_mismatch and key == 'storage_protocol':
                 if req == "vstorageobject":
                     continue


### PR DESCRIPTION
Allow extend_volume call, that would fail because of caps filter, due to storage_protocol mismatch between vmdk and vstorage object driver. We need this patch to allow volume_extend to work if the volume is not yet migrated to fcd

Change-Id: I02ac06dbe01d00cab739675b34cf600dea107360