### PR TITLE
use zapi in _get_flexvol_to_pool_map

### DIFF
--- a/cinder/tests/unit/volume/drivers/netapp/dataontap/test_nfs_cmode.py
+++ b/cinder/tests/unit/volume/drivers/netapp/dataontap/test_nfs_cmode.py
@@ -350,6 +350,9 @@ class NetAppCmodeNfsDriverTestCase(test.TestCase):
         mock_get_flexvol = self.mock_object(
             self.driver.zapi_client, 'get_flexvol',
             return_value={'name': fake.NETAPP_VOLUME})
+        mock_get_flexvol = self.mock_object(
+            self.driver.zapi_client, 'get_flexvol_zapi',
+            return_value={'name': fake.NETAPP_VOLUME})
 
         result = self.driver._get_flexvol_to_pool_map()
 
@@ -389,6 +392,9 @@ class NetAppCmodeNfsDriverTestCase(test.TestCase):
         side_effect = exception.VolumeBackendAPIException(data='fake_data')
         self.mock_object(self.driver.zapi_client,
                          'get_flexvol',
+                         side_effect=side_effect)
+        self.mock_object(self.driver.zapi_client,
+                         'get_flexvol_zapi',
                          side_effect=side_effect)
         self.mock_object(self.driver, '_get_flexvol_name_for_share',
                          return_value=None)

--- a/cinder/volume/drivers/netapp/dataontap/client/client_cmode.py
+++ b/cinder/volume/drivers/netapp/dataontap/client/client_cmode.py
@@ -1458,7 +1458,8 @@ class Client(client_base.Client):
 
     def get_flexvol_zapi(self, flexvol_path=None, flexvol_name=None):
 
-        return self.get_flexvol(flexvol_path=flexvol_path, flexvol_name=flexvol_name)
+        return self.get_flexvol(flexvol_path=flexvol_path,
+                                flexvol_name=flexvol_name)
 
     def get_flexvol(self, flexvol_path=None, flexvol_name=None):
         """Get flexvol attributes needed for the storage service catalog."""

--- a/cinder/volume/drivers/netapp/dataontap/client/client_cmode.py
+++ b/cinder/volume/drivers/netapp/dataontap/client/client_cmode.py
@@ -1456,6 +1456,10 @@ class Client(client_base.Client):
         volume_state = volume_state_attributes.get_child_content('state')
         return volume_state
 
+    def get_flexvol_zapi(self, flexvol_path=None, flexvol_name=None):
+
+        return self.get_flexvol(flexvol_path=flexvol_path, flexvol_name=flexvol_name)
+
     def get_flexvol(self, flexvol_path=None, flexvol_name=None):
         """Get flexvol attributes needed for the storage service catalog."""
 

--- a/cinder/volume/drivers/netapp/dataontap/nfs_cmode.py
+++ b/cinder/volume/drivers/netapp/dataontap/nfs_cmode.py
@@ -532,7 +532,7 @@ class NetAppCmodeNfsDriver(nfs_base.NetAppNfsDriver,
                 continue
 
             try:
-                flexvol = self.zapi_client.get_flexvol(
+                flexvol = self.zapi_client.get_flexvol_zapi(
                     flexvol_path=junction_path)
                 pools[flexvol['name']] = {'pool_name': share}
             except exception.VolumeBackendAPIException:


### PR DESCRIPTION
It looks like the new REST api is not thread-safe, so from periodic job it should call the zapi version of get_flexvol
Change-Id: Id97ed4a576ca7956aea905df9c3176a1cc21b9af