### PR TITLE
[vmware] Cache images as VM templates

### DIFF
--- a/cinder/scheduler/host_manager.py
+++ b/cinder/scheduler/host_manager.py
@@ -433,6 +433,8 @@ class PoolState(BackendState):
             # provisioned_capacity_gb if it is not set.
             self.provisioned_capacity_gb = capability.get(
                 'provisioned_capacity_gb', self.allocated_capacity_gb)
+            self.provisioned_capacity_gb += capability.get(
+                'extra_provisioned_capacity_gb', 0)
             self.thin_provisioning_support = capability.get(
                 'thin_provisioning_support', False)
             self.thick_provisioning_support = capability.get(

--- a/cinder/tests/unit/scheduler/test_host_manager.py
+++ b/cinder/tests/unit/scheduler/test_host_manager.py
@@ -1280,6 +1280,7 @@ class BackendStateTestCase(test.TestCase):
                              'free_capacity_gb': 512,
                              'provisioned_capacity_gb': 512,
                              'reserved_percentage': 0,
+                             'extra_provisioned_capacity_gb': 0,
                              'timestamp': None}
 
         fake_backend.update_from_volume_capability(volume_capability)
@@ -1293,12 +1294,16 @@ class BackendStateTestCase(test.TestCase):
                          fake_backend.pools['_pool0'].provisioned_capacity_gb)
 
         # Test update for existing host state
-        volume_capability.update(dict(total_capacity_gb=1000))
+        volume_capability.update(dict(total_capacity_gb=1000,
+                                      extra_provisioned_capacity_gb=100))
         fake_backend.update_from_volume_capability(volume_capability)
         self.assertEqual(1000, fake_backend.pools['_pool0'].total_capacity_gb)
+        self.assertEqual(512 + 100,
+                         fake_backend.pools['_pool0'].provisioned_capacity_gb)
 
         # Test update for existing host state with different backend name
-        volume_capability.update(dict(volume_backend_name='magic'))
+        volume_capability.update(dict(volume_backend_name='magic',
+                                      extra_provisioned_capacity_gb=0))
         fake_backend.update_from_volume_capability(volume_capability)
         self.assertEqual(1000, fake_backend.pools['magic'].total_capacity_gb)
         self.assertEqual(512, fake_backend.pools['magic'].free_capacity_gb)
@@ -1333,6 +1338,7 @@ class BackendStateTestCase(test.TestCase):
                  'free_capacity_gb': 1024,
                  'allocated_capacity_gb': 0,
                  'provisioned_capacity_gb': 0,
+                 'extra_provisioned_capacity_gb': 100,
                  'QoS_support': 'False',
                  'reserved_percentage': 0,
                  'dying_disks': 200,
@@ -1365,7 +1371,7 @@ class BackendStateTestCase(test.TestCase):
             1024, fake_backend.pools['2nd pool'].total_capacity_gb)
         self.assertEqual(1024, fake_backend.pools['2nd pool'].free_capacity_gb)
         self.assertEqual(
-            0, fake_backend.pools['2nd pool'].provisioned_capacity_gb)
+            100, fake_backend.pools['2nd pool'].provisioned_capacity_gb)
 
         capability = {
             'volume_backend_name': 'Local iSCSI',

--- a/cinder/tests/unit/volume/drivers/vmware/test_fcd.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_fcd.py
@@ -74,6 +74,7 @@ class VMwareVStorageObjectDriverTestCase(test.TestCase):
         self._config.barbican_url = mock.sentinel.barbican_url
         self._config.vmware_snapshot_format = "COW"
         self._config.sap_netapp_credentials = {}
+        self._config.enable_image_cache = False
         self._driver = fcd.VMwareVStorageObjectDriver(
             configuration=self._config)
         scheduler_rpcapi = mock.MagicMock()

--- a/cinder/tests/unit/volume/drivers/vmware/test_fcd.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_fcd.py
@@ -348,12 +348,11 @@ class VMwareVStorageObjectDriverTestCase(test.TestCase):
     @mock.patch.object(FCD_DRIVER, '_get_adapter_type')
     @mock.patch('cinder.objects.Volume.update')
     @mock.patch('cinder.db.sqlalchemy.api.volume_update')
-    @mock.patch.object(FCD_DRIVER, '_fetch_stream_optimized_image')
     @mock.patch.object(FCD_DRIVER, '_provider_location_to_ds_name_location')
-    @mock.patch.object(FCD_DRIVER, '_get_temp_image_folder_from_volume')
-    @mock.patch.object(FCD_DRIVER, '_create_virtual_disk_from_sparse_image')
-    @mock.patch.object(FCD_DRIVER,
-                       '_create_virtual_disk_from_preallocated_image')
+    @mock.patch.object(VMDK_DRIVER,
+                       '_create_volume_from_non_stream_optimized_image')
+    @mock.patch.object(VMDK_DRIVER,
+                       '_fetch_stream_optimized_image')
     @mock.patch.object(FCD_DRIVER, 'volumeops')
     @mock.patch.object(datastore, 'DatastoreURL')
     @mock.patch.object(FCD_DRIVER, '_get_storage_profile_id')
@@ -364,11 +363,9 @@ class VMwareVStorageObjectDriverTestCase(test.TestCase):
                                   get_storage_profile_id,
                                   datastore_url_cls,
                                   vops,
-                                  create_disk_from_preallocated_image,
-                                  create_disk_from_sparse_image,
-                                  get_temp_image_folder,
+                                  create_disk_stream_opt_image,
+                                  create_disk_non_stream_image,
                                   provider_loc_to_ds_name_loc,
-                                  _fetch_stream_optimized_image,
                                   db_volume_update,
                                   volume_update,
                                   get_adapter_type):
@@ -382,7 +379,6 @@ class VMwareVStorageObjectDriverTestCase(test.TestCase):
         summary.name = 'ds1'
         vops.get_datastore.return_value = datastore
         folder_path = mock.sentinel.folder_path
-        get_temp_image_folder.return_value = (dc_ref, summary, folder_path)
 
         adapter_type = mock.sentinel.adapter_type
         get_adapter_type.return_value = adapter_type
@@ -391,13 +387,13 @@ class VMwareVStorageObjectDriverTestCase(test.TestCase):
         vmdk_path.get_descriptor_ds_file_path.return_value = (
             "[ds1] cinder_vol/foo.vmdk")
         if disk_type == vmdk.ImageDiskType.PREALLOCATED:
-            create_disk_from_preallocated_image.return_value = vmdk_path
+            create_disk_non_stream_image.return_value = vmdk_path
         elif disk_type == vmdk.ImageDiskType.SPARSE:
-            create_disk_from_sparse_image.return_value = vmdk_path
+            create_disk_non_stream_image.return_value = vmdk_path
         elif disk_type == vmdk.ImageDiskType.STREAM_OPTIMIZED:
-            _fetch_stream_optimized_image.return_value =\
+            create_disk_stream_opt_image.return_value =\
                 mock.sentinel.backing
-            vops.get_vmdk_path.return_value = "[ds1] cinder_vol/foo.vmdk"
+        vops.get_vmdk_path.return_value = "[ds1] cinder_vol/foo.vmdk"
 
         dc_path = '/test-dc'
         vops.get_inventory_path.return_value = dc_path
@@ -412,6 +408,8 @@ class VMwareVStorageObjectDriverTestCase(test.TestCase):
         provider_location = mock.sentinel.provider_location
         fcd_loc.provider_location.return_value = provider_location
         vops.register_disk.return_value = fcd_loc
+        vops.get_backing_by_uuid.return_value = mock.sentinel.backing
+        vops.get_disk_size.return_value = 2 * units.Gi
         provider_loc_to_ds_name_loc.return_value = provider_location
 
         extra_specs = {
@@ -426,18 +424,17 @@ class VMwareVStorageObjectDriverTestCase(test.TestCase):
             self._context, volume, image_service, image_id)
 
         if disk_type == vmdk.ImageDiskType.PREALLOCATED:
-            get_temp_image_folder.assert_called_once_with(volume)
-            create_disk_from_preallocated_image.assert_called_once_with(
-                self._context, image_service, image_id, image_meta['size'],
-                dc_ref, summary.name, folder_path, volume.id,
-                volumeops.VirtualDiskAdapterType.LSI_LOGIC)
+            create_disk_non_stream_image.assert_called_once_with(
+                self._context, volume, image_service, image_id,
+                image_meta['size'],
+                volumeops.VirtualDiskAdapterType.LSI_LOGIC, disk_type)
         elif disk_type == vmdk.ImageDiskType.SPARSE:
-            get_temp_image_folder.assert_called_once_with(volume)
-            create_disk_from_sparse_image.assert_called_once_with(
-                self._context, image_service, image_id, image_meta['size'],
-                dc_ref, summary.name, folder_path, volume.id)
+            create_disk_non_stream_image.assert_called_once_with(
+                self._context, volume, image_service, image_id,
+                image_meta['size'],
+                volumeops.VirtualDiskAdapterType.LSI_LOGIC, disk_type)
         elif disk_type == vmdk.ImageDiskType.STREAM_OPTIMIZED:
-            _fetch_stream_optimized_image.assert_called_once_with(
+            create_disk_stream_opt_image.assert_called_once_with(
                 self._context, volume, image_service, image_id,
                 image_meta['size'],
                 image_meta['properties']['vmware_adaptertype'])

--- a/cinder/tests/unit/volume/drivers/vmware/test_fcd.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_fcd.py
@@ -373,13 +373,10 @@ class VMwareVStorageObjectDriverTestCase(test.TestCase):
         image_service = mock.Mock()
         image_service.show.return_value = image_meta
 
-        dc_ref = mock.sentinel.dc_ref
         datastore = mock.sentinel.datastore
         summary = mock.Mock(datastore=datastore)
         summary.name = 'ds1'
         vops.get_datastore.return_value = datastore
-        folder_path = mock.sentinel.folder_path
-
         adapter_type = mock.sentinel.adapter_type
         get_adapter_type.return_value = adapter_type
 

--- a/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_vmware_vmdk.py
@@ -124,6 +124,8 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
             vmware_random_datastore_range=None,
             vmware_datastores_as_pools=False,
             allow_pulling_images_from_url=False,
+            enable_image_cache=False,
+            image_cache_max_size_gb=0,
         )
 
         self._driver = vmdk.VMwareVcVmdkDriver(configuration=self._config,
@@ -169,20 +171,40 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
         get_profile_id_by_name.assert_called_once_with(session,
                                                        self.STORAGE_PROFILE)
 
+    @mock.patch.object(VMDK_DRIVER, '_get_cached_images')
     @mock.patch.object(VMDK_DRIVER, 'session')
-    def test_get_volume_stats_no_pools(self, session):
+    def test_get_volume_stats_no_pools(self, session, mock_get_cached):
+        self._config.enable_image_cache = True
         retr_result_mock = mock.Mock(spec=['objects'])
         retr_result_mock.objects = []
         session.vim.RetrievePropertiesEx.return_value = retr_result_mock
         session.vim.service_content.about.instanceUuid = 'fake-service'
+        mock_get_cached.return_value = [
+            {
+                'name': self.IMAGE_ID,
+                'vm_ref': mock.sentinel.backing,
+                'ds_ref': mock.sentinel.datastore,
+                'disk_size': 100 * units.Gi,
+                'created_at': None
+            },
+            {
+                'name': self.IMAGE_ID,
+                'vm_ref': mock.sentinel.backing,
+                'ds_ref': mock.sentinel.datastore,
+                'disk_size': 200 * units.Gi,
+                'created_at': None
+            }
+        ]
         stats = self._driver.get_volume_stats()
 
+        mock_get_cached.assert_called_once_with()
         self.assertEqual('VMware', stats['vendor_name'])
         self.assertEqual(self._driver.VERSION, stats['driver_version'])
         self.assertEqual('vmdk', stats['storage_protocol'])
         self.assertEqual(0, stats['reserved_percentage'])
         self.assertEqual(0, stats['total_capacity_gb'])
         self.assertEqual(0, stats['free_capacity_gb'])
+        self.assertEqual(300, stats['extra_provisioned_capacity_gb'])
         self.assertEqual(vmdk.LOCATION_DRIVER_NAME + ":fake-service",
                          stats['location_info'])
 
@@ -215,27 +237,46 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
 
         class result(object):
             objects = [props()]
-
+        ds_obj = vim_util.get_moref("datastore-85", "Datastore")
         datastores = {"datastore-85": {"summary": summary,
-                                       "storage_profile": {"name": "Gold"}}}
+                                       "storage_profile": {"name": "Gold"},
+                                       "datastore_object": ds_obj}}
         return result(), datastores
 
+    @mock.patch.object(VMDK_DRIVER, '_get_cached_images')
     @mock.patch('cinder.volume.drivers.vmware.datastore.'
                 'DatastoreSelector.is_datastore_usable')
     @mock.patch.object(VMDK_DRIVER, '_collect_backend_stats')
     @mock.patch.object(VMDK_DRIVER, 'session')
     def test_get_volume_stats_pools(self, session, mock_stats,
-                                    datastore_usable):
+                                    datastore_usable, mock_get_cached):
         fake_result, fake_datastore_profiles = self._fake_stats_result()
         mock_stats.return_value = (fake_result, fake_datastore_profiles)
         datastore_usable.return_value = True
         self._config.vmware_datastores_as_pools = True
+        self._config.enable_image_cache = True
         self._driver = vmdk.VMwareVcVmdkDriver(configuration=self._config,
                                                additional_endpoints=[])
         self._driver._ds_sel = mock.MagicMock()
         scheduler_rpcapi = mock.MagicMock()
         scheduler_rpcapi.get_pools.return_value = []
         self._driver._scheduler_rpcapi = scheduler_rpcapi
+        mock_get_cached.return_value = [
+            {
+                'name': self.IMAGE_ID,
+                'vm_ref': mock.sentinel.backing,
+                'ds_ref': vim_util.get_moref("datastore-85", "Datastore"),
+                'disk_size': 100 * units.Gi,
+                'created_at': None
+            },
+            {
+                'name': self.IMAGE_ID,
+                'vm_ref': mock.sentinel.backing,
+                'ds_ref': vim_util.get_moref("unknown-ds", "Datastore"),
+                'disk_size': 200 * units.Gi,
+                'created_at': None
+            }
+        ]
 
         retr_result_mock = mock.Mock(spec=['objects'])
         retr_result_mock.objects = []
@@ -243,6 +284,7 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
         session.vim.service_content.about.instanceUuid = 'fake-service'
         stats = self._driver.get_volume_stats()
 
+        mock_get_cached.assert_called_once_with()
         self.assertEqual('VMware', stats['vendor_name'])
         self.assertEqual(self._driver.VERSION, stats['driver_version'])
         self.assertEqual('vmdk', stats['storage_protocol'])
@@ -251,6 +293,8 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
         self.assertEqual(0, stats["pools"][0]['reserved_percentage'])
         self.assertEqual(9313, stats["pools"][0]['total_capacity_gb'])
         self.assertEqual(4657, stats["pools"][0]['free_capacity_gb'])
+        self.assertEqual(100,
+                         stats["pools"][0]["extra_provisioned_capacity_gb"])
         self.assertEqual('up', stats["pools"][0]['pool_state'])
         self.assertEqual('up', stats["backend_state"])
         self.assertFalse(stats["pools"][0]['multiattach'])
@@ -291,6 +335,7 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
                 'size': size,
                 'volume_attachment': attachment,
                 'project_id': project_id,
+                'metadata': {},
                 }
 
     def _create_volume_obj(self,
@@ -841,6 +886,72 @@ class VMwareVcVmdkDriverTestCase(test.TestCase):
 
     def test_copy_image_to_volume_with_ova_container(self):
         self._test_copy_image_to_volume(container_format='ova')
+
+    @ddt.data(
+        ({'enable_image_cache': False},
+         False),
+        ({'enable_image_cache': True, 'use_image_cache': 'N/A'},
+         False),
+        ({'enable_image_cache': True, 'use_image_cache': 'true',
+          'image_cache_max_size_gb': 1, 'image_size': 2 * units.Gi},
+         False),
+        ({'enable_image_cache': True, 'use_image_cache': 'True',
+          'image_cache_max_size_gb': 1, 'image_size': 2 * units.Gi},
+         False),
+        ({'enable_image_cache': True, 'use_image_cache': 'true',
+          'image_cache_max_size_gb': 2, 'image_size': 2 * units.Gi},
+         True)
+    )
+    @ddt.unpack
+    @mock.patch.object(VMDK_DRIVER, '_do_copy_image_to_volume')
+    @mock.patch.object(VMDK_DRIVER, 'volumeops')
+    @mock.patch.object(VMDK_DRIVER, '_extend_backing')
+    @mock.patch.object(VMDK_DRIVER, '_create_volume_from_cached_image')
+    @mock.patch.object(VMDK_DRIVER,
+                       '_get_or_create_cached_image_backing')
+    def test_copy_image_to_volume_cached(self, params, expected,
+                                         mock_get_cached_backing,
+                                         mock_create_from_cached,
+                                         mock_extend_backing,
+                                         mock_volumeops,
+                                         mock_do_copy_image):
+        self._config.enable_image_cache = (
+            params.get('enable_image_cache', False))
+        self._config.image_cache_max_size_gb = (
+            params.get('image_cache_max_size_gb', 0))
+
+        volume = self._create_volume_dict()
+
+        use_image_cache = params.get('use_image_cache')
+        if use_image_cache:
+            volume['metadata']['use_image_cache'] = use_image_cache
+
+        backing = mock.sentinel.backing
+        mock_volumeops.get_backing.return_value = backing
+        mock_volumeops.get_disk_size.return_value = self.VOL_SIZE * units.Gi
+
+        mock_get_cached_backing.return_value = mock.sentinel.backing
+
+        image_service = mock.Mock()
+        image_meta = self._create_image_meta(
+            size=params.get('image_size', 1 * units.Gi))
+        image_service.show.return_value = image_meta
+
+        self._driver.copy_image_to_volume(
+            mock.sentinel.context, volume, image_service, self.IMAGE_ID)
+
+        if expected:
+            mock_do_copy_image.assert_not_called()
+            mock_get_cached_backing.assert_called_once_with(
+                mock.sentinel.context, volume,
+                image_service, self.IMAGE_ID, image_meta)
+            mock_create_from_cached.assert_called_once_with(
+                volume, backing)
+        else:
+            mock_get_cached_backing.assert_not_called()
+            mock_do_copy_image.assert_called_once_with(
+                mock.sentinel.context, volume,
+                image_service, self.IMAGE_ID, image_meta)
 
     @mock.patch('cinder.volume.drivers.vmware.vmdk.VMwareVcVmdkDriver.'
                 '_get_disk_type')

--- a/cinder/volume/drivers/vmware/fcd.py
+++ b/cinder/volume/drivers/vmware/fcd.py
@@ -478,47 +478,14 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
                                This parameter is ignored by VMware driver.
         :returns: Model updates.
         """
-        metadata = image_service.show(context, image_id)
-        self._validate_disk_format(metadata['disk_format'])
-        self._validate_container_format(
-            metadata.get('container_format'), image_id)
-
-        properties = metadata['properties'] or {}
-        disk_type = properties.get('vmware_disktype',
-                                   vmdk.ImageDiskType.PREALLOCATED)
-        vmdk.ImageDiskType.validate(disk_type)
-
-        size_bytes = metadata['size']
-        if disk_type == vmdk.ImageDiskType.STREAM_OPTIMIZED:
-            image_adapter_type = self._get_adapter_type(volume)
-            properties = metadata['properties']
-            if properties:
-                if 'vmware_adaptertype' in properties:
-                    image_adapter_type = properties['vmware_adaptertype']
-            backing = self._fetch_stream_optimized_image(
-                context, volume,
-                image_service, image_id, size_bytes,
-                image_adapter_type)
-            ds_ref = self.volumeops.get_datastore(backing)
-            dc_ref = self.volumeops.get_dc(ds_ref)
-            vmdk_path = self.volumeops.get_vmdk_path(backing)
-            self._destroy_backing(backing)
-        else:
-            disk_name = volume.id
-            dc_ref, summary, folder_path = \
-                self._get_temp_image_folder_from_volume(volume)
-            if disk_type == vmdk.ImageDiskType.SPARSE:
-                vmdk_path = self._create_virtual_disk_from_sparse_image(
-                    context, image_service, image_id, size_bytes, dc_ref,
-                    summary.name, folder_path, disk_name)
-            else:
-                vmdk_path = self._create_virtual_disk_from_preallocated_image(
-                    context, image_service, image_id, size_bytes, dc_ref,
-                    summary.name, folder_path, disk_name,
-                    vops.VirtualDiskAdapterType.LSI_LOGIC)
-            vmdk_path = vmdk_path.get_descriptor_ds_file_path()
-            ds_ref = summary.datastore
-
+        super(VMwareVStorageObjectDriver,
+              self).copy_image_to_volume(context, volume, image_service,
+                                         image_id, disable_sparse)
+        backing = self.volumeops.get_backing_by_uuid(volume.id)
+        ds_ref = self.volumeops.get_datastore(backing)
+        dc_ref = self.volumeops.get_dc(ds_ref)
+        vmdk_path = self.volumeops.get_vmdk_path(backing)
+        self._destroy_backing(backing)
         ds_path = datastore.DatastorePath.parse(vmdk_path)
         dc_path = self.volumeops.get_inventory_path(dc_ref)
 
@@ -544,6 +511,7 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
 
         # Extend the volume if needed
         # break this up to 2 lines to pass pep8
+        metadata = image_service.show(context, image_id)
         if hasattr(metadata, 'virtual_size'):
             image_gib = int(metadata['virtual_size'] / units.Gi)
         else:

--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -21,7 +21,7 @@ Disk) files stored in datastores. For ease of managing the VMDKs, the
 driver creates a virtual machine for each of the volumes. This virtual
 machine is never powered on and is often referred as the shadow VM.
 """
-
+import itertools
 import math
 import re
 import ssl
@@ -30,7 +30,9 @@ import OpenSSL
 from oslo_config import cfg
 from oslo_config import types
 from oslo_log import log as logging
+from oslo_service import loopingcall
 from oslo_utils import excutils
+from oslo_utils import timeutils
 from oslo_utils import units
 from oslo_utils import uuidutils
 from oslo_utils import versionutils
@@ -45,11 +47,13 @@ from cinder import context
 from cinder import exception
 # This is needed to register the SAP config options
 from cinder.common import sap # noqa
+from cinder import coordination
 from cinder.i18n import _
 from cinder.image import image_utils
 from cinder import interface
 from cinder.keymgr import kmip
 from cinder.objects import snapshot as snapshot_obj
+from cinder.objects import volume as volume_obj
 from cinder.scheduler import rpcapi as scheduler_rpcapi
 from cinder.volume import configuration
 from cinder.volume import driver
@@ -72,6 +76,7 @@ CREATE_PARAM_DISK_LESS = 'disk_less'
 CREATE_PARAM_BACKING_NAME = 'name'
 CREATE_PARAM_DISK_SIZE = 'disk_size'
 CREATE_PARAM_TEMP_BACKING = 'temp_backing'
+CREATE_PARAM_USE_IMAGE_CACHE = 'use_image_cache'
 
 TMP_IMAGES_DATASTORE_FOLDER_PATH = "cinder_temp/"
 
@@ -242,6 +247,17 @@ vmdk_opts = [
                default="http://barbican-api:9311",
                help='Barbican base URL passed to the KMIP API to register a '
                     'key. The URL must be accessible by the KMIP API.'),
+    cfg.BoolOpt('enable_image_cache', default=False,
+                help='Enable the image cache feature for the backend.'),
+    cfg.IntOpt('image_cache_max_size_gb', default=100,
+               help='Maximum size in GiB that an image is allowed to '
+                    'have in order to be cached.'),
+    cfg.IntOpt('image_cache_purge_interval', default=600,
+               help='Number of seconds between runs of the periodic task '
+                    'to purge the cached volume images.'),
+    cfg.IntOpt('image_cache_age_seconds', default=3600 * 24,
+               help='Minimum number of seconds after which a cached image '
+                    'has to be deleted.'),
 ]
 
 CONF = cfg.CONF
@@ -469,6 +485,8 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                                   % storage_profile)
                         raise exception.InvalidInput(reason=reason)
 
+        self._start_periodic_tasks()
+
     def _init_vendor_properties(self):
         """Set some vmware specific properties."""
 
@@ -631,6 +649,11 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         if not datastores:
             backend_state = 'down'
             data['backend_state'] = backend_state
+
+        cached_images = []
+        if self.configuration.enable_image_cache:
+            cached_images = self._get_cached_images()
+
         if self.configuration.vmware_datastores_as_pools:
             pools = []
             for ds_name in datastores:
@@ -683,6 +706,15 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                         summary.datastore)
                 else:
                     mount_path = ""
+                # Calculate the extra capacity consumed by cached images
+                extra_capacity = 0
+                for cached_img in cached_images:
+                    ds_ref = cached_img['ds_ref']
+                    if (ds_ref and vim_util.get_moref_value(ds_ref) ==
+                            vim_util.get_moref_value(
+                                datastore['datastore_object'])):
+                        extra_capacity += cached_img['disk_size'] / units.Gi
+
                 pool = {'pool_name': summary.name,
                         'total_capacity_gb': round(
                             summary.capacity / units.Gi),
@@ -705,6 +737,8 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                         'custom_attributes': custom_attributes,
                         'independent_snapshots': independent_snapshot,
                         'mount_path': mount_path,
+                        'extra_provisioned_capacity_gb': (
+                            int(math.ceil(extra_capacity))),
                         }
                 if aggregate_id:
                     pool['aggregate_id'] = aggregate_id
@@ -734,6 +768,11 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                     global_capacity += summary.capacity
                     global_free += summary.freeSpace
 
+        # Calculate the extra capacity consumed by cached images
+        extra_capacity = 0
+        for cached_img in cached_images:
+            extra_capacity += cached_img['disk_size'] / units.Gi
+
         data_no_pools = {
             'reserved_percentage': self.configuration.reserved_percentage,
             'total_capacity_gb': round(global_capacity / units.Gi),
@@ -742,6 +781,8 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
             'thick_provisioning_support': True,
             'max_over_subscription_ratio': max_over_subscription_ratio,
             'connection_capabilities': connection_capabilities,
+            'extra_provisioned_capacity_gb': (
+                int(math.ceil(extra_capacity))),
         }
         data.update(data_no_pools)
 
@@ -1979,36 +2020,8 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
             context, volume, image_service, image_meta['id'])
         return (ret, True)
 
-    def copy_image_to_volume(self, context, volume, image_service, image_id,
-                             disable_sparse=False):
-        """Creates volume from image.
-
-        This method only supports Glance image of VMDK disk format.
-        Uses flat vmdk file copy for "sparse" and "preallocated" disk types
-        Uses HttpNfc import API for "streamOptimized" disk types. This API
-        creates a backing VM that wraps the VMDK in the vCenter inventory.
-
-        :param context: context
-        :param volume: Volume object
-        :param image_service: Glance image service
-        :param image_id: Glance image id
-        :param disable_sparse: Enable or disable sparse copy. Default=False.
-                               This parameter is ignored by VMDK driver.
-        """
-        LOG.debug("Copy glance image: %s to create new volume.", image_id)
-
-        # Verify glance image is vmdk disk format
-        metadata = image_service.show(context, image_id)
-        VMwareVcVmdkDriver._validate_disk_format(metadata['disk_format'])
-
-        # Validate container format; only 'bare' and 'ova' are supported.
-        container_format = metadata.get('container_format')
-        if (container_format and container_format not in ['bare', 'ova']):
-            msg = _("Container format: %s is unsupported, only 'bare' and "
-                    "'ova' are supported.") % container_format
-            LOG.error(msg)
-            raise exception.ImageUnacceptable(image_id=image_id, reason=msg)
-
+    def _do_copy_image_to_volume(self, context, volume, image_service,
+                                 image_id, metadata):
         # Get the disk type, adapter type and size of vmdk image
         image_disk_type = ImageDiskType.PREALLOCATED
         image_adapter_type = self._get_adapter_type(volume)
@@ -2041,6 +2054,47 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                               "to volume: %(vol)s.",
                               {'id': image_id, 'vol': volume['name']})
 
+    def copy_image_to_volume(self, context, volume, image_service, image_id,
+                             disable_sparse=False):
+        """Creates volume from image.
+
+        This method only supports Glance image of VMDK disk format.
+        Uses flat vmdk file copy for "sparse" and "preallocated" disk types
+        Uses HttpNfc import API for "streamOptimized" disk types. This API
+        creates a backing VM that wraps the VMDK in the vCenter inventory.
+
+        :param context: context
+        :param volume: Volume object
+        :param image_service: Glance image service
+        :param image_id: Glance image id
+        :param disable_sparse: Enable or disable sparse copy. Default=False.
+                               This parameter is ignored by VMDK driver.
+        """
+        LOG.debug("Copy glance image: %s to create new volume.", image_id)
+
+        # Verify glance image is vmdk disk format
+        metadata = image_service.show(context, image_id)
+        VMwareVcVmdkDriver._validate_disk_format(metadata['disk_format'])
+
+        # Validate container format; only 'bare' and 'ova' are supported.
+        container_format = metadata.get('container_format')
+        if (container_format and container_format not in ['bare', 'ova']):
+            msg = _("Container format: %s is unsupported, only 'bare' and "
+                    "'ova' are supported.") % container_format
+            LOG.error(msg)
+            raise exception.ImageUnacceptable(image_id=image_id, reason=msg)
+
+        img_backing = None
+        if self._can_use_image_cache(volume, metadata['size']):
+            img_backing = self._get_or_create_cached_image_backing(
+                context, volume, image_service, image_id, metadata)
+
+        if img_backing:
+            self._create_volume_from_cached_image(volume, img_backing)
+        else:
+            self._do_copy_image_to_volume(
+                context, volume, image_service, image_id, metadata)
+
         LOG.debug("Volume: %(id)s created from image: %(image_id)s.",
                   {'id': volume['id'],
                    'image_id': image_id})
@@ -2065,6 +2119,51 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
             self, context, volume, image_service, image_id):
         # We don't do anything special as encryption is handled by the vCenter
         self.copy_image_to_volume(context, volume, image_service, image_id)
+
+    def _can_use_image_cache(self, volume, image_size):
+        if not self.configuration.enable_image_cache:
+            LOG.debug("Image cache was requested for volume %s, but it "
+                      "wasn't enabled in the backend configuration.",
+                      volume['id'])
+            return False
+
+        max_size = self.configuration.image_cache_max_size_gb * units.Gi
+        if image_size > max_size:
+            LOG.debug("The requested image cannot be cached because it's "
+                      "too big (%(image_size)s > %(max_size)s)",
+                      {'image_size': image_size,
+                       'max_size': max_size})
+            return False
+
+        return True
+
+    @coordination.synchronized("image-cache-{image_id}")
+    def _get_or_create_cached_image_backing(self, context, volume,
+                                            image_service,
+                                            image_id, metadata):
+        """Caches the image as VM Templates and returns the mo-ref"""
+        backing = self.volumeops.get_backing(image_id, image_id)
+        image_size_in_bytes = metadata['size']
+        if not backing:
+            img_volume = volume_obj.Volume._from_db_object(
+                context, volume_obj.Volume(), dict(
+                    id=image_id,
+                    host=volume['host'],
+                    volume_type_id=volume['volume_type_id'],
+                    project_id=self._cache_project_name(),
+                    size=image_size_in_bytes / units.Gi
+                ))
+            self._do_copy_image_to_volume(
+                context, img_volume, image_service, image_id, metadata)
+            backing = self.volumeops.get_backing(image_id, image_id)
+            cache_name = f"{self._cache_project_name()} ({image_id})"
+            self.volumeops.rename_backing(backing, cache_name)
+            self.volumeops.mark_backing_as_template(backing)
+        return backing
+
+    def _cache_project_name(self):
+        backend_name = self.configuration.safe_get('volume_backend_name')
+        return f"{backend_name}_image_cache"
 
     def copy_volume_to_image(self, context, volume, image_service, image_meta):
         """Creates glance image from volume.
@@ -2969,6 +3068,26 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
                                  VMwareVcVmdkDriver._get_disk_type(volume))
         LOG.info("Successfully created clone: %s.", clone)
 
+    def _create_volume_from_cached_image(self, volume, img_backing):
+        (host, rp, folder, summary) = self._select_ds_for_volume(
+            volume)
+        datastore = summary.datastore
+        disk_type = VMwareVcVmdkDriver._get_disk_type(volume)
+
+        backing = self.volumeops.clone_backing(
+            volume['id'],
+            img_backing,
+            None,
+            volumeops.FULL_CLONE_TYPE,
+            datastore,
+            disk_type=disk_type,
+            host=host,
+            resource_pool=rp,
+            folder=folder)
+
+        self.volumeops.update_backing_uuid(backing, volume['id'])
+        self.volumeops.update_backing_disk_uuid(backing, volume['id'])
+
     @volume_utils.trace
     def _create_volume_from_template(self, volume, path):
         LOG.debug("Creating backing for volume: %(volume_id)s from template "
@@ -3518,3 +3637,133 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
             return None
 
         return volume_utils.extract_host(pools[0]['name'], 'backend')
+
+    def _start_periodic_tasks(self):
+        if self.configuration.enable_image_cache:
+            lock_name = f"{self._cache_project_name()}-purge_cache"
+
+            @coordination.synchronized(lock_name)
+            def _purge_image_cache_locked():
+                self._purge_image_cache()
+
+            LOG.info("Starting the purge_image_cache periodic task.")
+            image_cache_ptask = loopingcall.FixedIntervalLoopingCall(
+                _purge_image_cache_locked,)
+            image_cache_ptask.start(
+                interval=self.configuration.image_cache_purge_interval,
+                stop_on_exception=False)
+
+    def _purge_image_cache(self):
+        """Deletes expired images from the cache"""
+        cached_images = self._get_cached_images()
+        age_seconds = self.configuration.image_cache_age_seconds
+        for cached_image in cached_images:
+            if not timeutils.is_older_than(
+                    cached_image['created_at'],
+                    age_seconds):
+                continue
+
+            try:
+                self.volumeops.delete_backing(cached_image['vm_ref'])
+                LOG.debug("Deleted expired image (%s) from the cache.",
+                          cached_image['name'])
+            except exceptions.VimException:
+                LOG.exception("Failed to delete the expired image %s",
+                              cached_image['name'])
+
+    def _get_cached_images(self):
+        folder_refs = self._get_image_cache_folder_refs()
+        return list(itertools.chain(
+            *[self._get_cached_images_in_folder(folder_ref)
+              for folder_ref in folder_refs]))
+
+    def _get_image_cache_folder_refs(self):
+        vim = self.session.vim
+        max_objects = self.configuration.vmware_max_objects_retrieval
+        retrieve_result = self.session.invoke_api(
+            vim_util, 'get_objects', vim, 'Datacenter', max_objects)
+        folder_refs = []
+        with vim_util.WithRetrieval(vim, retrieve_result) as objects:
+            for dc_obj in objects:
+                if not dc_obj.propSet[0].val:
+                    continue
+                folder_ref = self._get_volume_group_folder(
+                    dc_obj.obj, self._cache_project_name())
+                folder_refs.append(folder_ref)
+        return folder_refs
+
+    def _get_cached_images_in_folder(self, folder_ref):
+        """Returns the cached images as list of dict
+
+        [{"name": "<uuid>",
+          "vm_ref": ManagedObjectReference,
+          "ds_ref": ManagedObjectReference,
+          "disk_size: 1024,
+          "created_at": datetime}]
+
+        Where
+            - name: the name of the template VM ("Cinder Cache ({image_id})")
+            - vm_ref: ManagedObjectReference to the template VM
+            - ds_ref: ManagedObjectReference to the VM's datastore
+            - disk_size: size in bytes
+            - created_at: date when the image cache was created
+        """
+        client_factory = self.session.vim.client.factory
+        prop_spec = vim_util.build_property_spec(
+            client_factory, 'VirtualMachine',
+            ['name', 'config.template', 'config.hardware.device',
+             'config.createDate'])
+        obj_spec = vim_util.build_object_spec(
+            client_factory, folder_ref,
+            [vim_util.build_recursive_traversal_spec(client_factory)])
+        filter_spec = vim_util.build_property_filter_spec(
+            client_factory, [prop_spec], [obj_spec])
+
+        options = client_factory.create('ns0:RetrieveOptions')
+        max_objects = self.configuration.vmware_max_objects_retrieval
+        options.maxObjects = max_objects
+        try:
+            retrieve_result = self.session.vim.RetrievePropertiesEx(
+                self.session.vim.service_content.propertyCollector,
+                specSet=[filter_spec], options=options)
+        except exceptions.VimFaultException as excep:
+            if exceptions.NOT_AUTHENTICATED in excep.fault_list:
+                # Check if session is active to decide if NotAuthenticated
+                # indicates empty result returned by RetrievePropertiesEx (as
+                # implemented in oslo.vmware) or it's a real exception.
+                if self.session.is_current_session_active():
+                    return []
+            raise
+
+        cached_images = []
+        with vim_util.WithRetrieval(self.session.vim,
+                                    retrieve_result) as results:
+            for obj in results:
+                props = vim_util.propset_dict(obj.propSet)
+                if not props:
+                    continue
+                name = props.get('name')
+                is_template = props.get('config.template')
+                devices = props.get('config.hardware.device')
+                created_at = props.get('config.createDate')
+                disk_size = 0
+                ds_ref = None
+                if devices.__class__.__name__ == "ArrayOfVirtualDevice":
+                    devices = devices.VirtualDevice
+
+                for device in devices:
+                    if device.__class__.__name__ == "VirtualDisk":
+                        disk_size = device.capacityInKB * units.Ki
+                        if device.backing:
+                            ds_ref = device.backing.datastore
+                        break
+
+                if is_template and created_at:
+                    cached_images.append({
+                        'name': name,
+                        'vm_ref': obj.obj,
+                        'ds_ref': ds_ref,
+                        'disk_size': disk_size,
+                        'created_at': created_at
+                    })
+        return cached_images


### PR DESCRIPTION
Upon user request, the driver can cache the image as a VM Template and reuse that to create the volume(s). This feature is useful when creating many volumes in parallel from the same image.

We're not using the cinder built-in cache functionality because we need a few extra features:
- the built-in cache doesn't account for shards. The cache entry will be placed on any backend/shard and could trigger a lot of slower cross-vc migrations when creating volumes from it.
- the built-in cache doesn't have a periodic task for deleting the expired cache entries
- we want to cache the images only when the customer requests it

Users can request the image cache feature when creating the volume, by passing the use_image_cache='true' as a property (metadata).

The feature must be enabled per backend, for example:
```
[vmware]
enable_image_cache = true
```
This will enable the image cache feature for the vmware backend.

The image templates will then be stored in a folder similar to the volumes folder: OpensStack/Project (vmware_image_cache)/Volumes, where {backend}_image_cache is used as a project name.

The driver will periodically delete the cached images that are expired. The expiry time can be controlled via the property `image_cache_age_seconds` set on the backend configuration.

Only images smaller than the configured `image_cache_max_size_gb` will be cached.

Change-Id: Id26f61104339e5ccc1db3a6017f159462c8cba37