### PR TITLE
[SAP] delete snapshot return True

### DIFF
--- a/cinder/volume/drivers/vmware/fcd.py
+++ b/cinder/volume/drivers/vmware/fcd.py
@@ -275,7 +275,7 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
     @volume_utils.trace
     def _delete_fcd(self, provider_loc, delete_folder=True):
         fcd_loc = vops.FcdLocation.from_provider_location(provider_loc)
-        self.volumeops.delete_fcd(fcd_loc, delete_folder=delete_folder)
+        return self.volumeops.delete_fcd(fcd_loc, delete_folder=delete_folder)
 
     @volume_utils.trace
     def delete_volume(self, volume):
@@ -732,12 +732,12 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
         if snap_location:
             fcd_snap_loc = vops.FcdSnapshotLocation.from_provider_location(
                 snap_location)
-            self.volumeops.delete_fcd_snapshot(fcd_snap_loc)
+            return self.volumeops.delete_fcd_snapshot(fcd_snap_loc)
         else:
             provider_loc = self._provider_location_to_moref_location(
                 snapshot.provider_location
             )
-            self._delete_fcd(provider_loc)
+            return self._delete_fcd(provider_loc)
 
     def _extend_if_needed(self, fcd_loc, cur_size, new_size):
         if new_size > cur_size:

--- a/cinder/volume/drivers/vmware/volumeops.py
+++ b/cinder/volume/drivers/vmware/volumeops.py
@@ -2311,17 +2311,23 @@ class VMwareVolumeOps(object):
         dc_ref = self.get_dc(fcd_location.ds_ref())
         ds_name, folder, _ = split_datastore_path(vmdk_file)
         LOG.debug("Deleting fcd: %s.", fcd_location)
-        task = self._session.invoke_api(self._session.vim,
-                                        'DeleteVStorageObject_Task',
-                                        vstorage_mgr,
-                                        id=fcd_location.id(cf),
-                                        datastore=fcd_location.ds_ref())
-        self._session.wait_for_task(task)
-        folder_path = f"[{ds_name}] {folder}"
-        file_list = self.file_list_in_folder(fcd_location.ds_ref(),
-                                             folder_path)
-        if delete_folder and file_list == []:
-            self.delete_datastore_folder(ds_name, folder, dc_ref)
+        try:
+            task = self._session.invoke_api(self._session.vim,
+                                            'DeleteVStorageObject_Task',
+                                            vstorage_mgr,
+                                            id=fcd_location.id(cf),
+                                            datastore=fcd_location.ds_ref())
+            self._session.wait_for_task(task)
+        except exceptions.NotFound:
+            LOG.warning("Fcd not found: %s.", fcd_location.fcd_id)
+        else:
+            folder_path = f"[{ds_name}] {folder}"
+            file_list = self.file_list_in_folder(fcd_location.ds_ref(),
+                                                 folder_path)
+            if delete_folder and file_list == []:
+                self.delete_datastore_folder(ds_name, folder, dc_ref)
+
+            return True
 
     def clone_fcd(
             self, volume, fcd_location, dest_ds_ref,
@@ -2518,14 +2524,19 @@ class VMwareVolumeOps(object):
 
         vstorage_mgr = self._session.vim.service_content.vStorageObjectManager
         cf = self._session.vim.client.factory
-        task = self._session.invoke_api(
-            self._session.vim,
-            'DeleteSnapshot_Task',
-            vstorage_mgr,
-            id=fcd_snap_loc.fcd_loc.id(cf),
-            datastore=fcd_snap_loc.fcd_loc.ds_ref(),
-            snapshotId=fcd_snap_loc.id(cf))
-        self._session.wait_for_task(task)
+        try:
+            task = self._session.invoke_api(
+                self._session.vim,
+                'DeleteSnapshot_Task',
+                vstorage_mgr,
+                id=fcd_snap_loc.fcd_loc.id(cf),
+                datastore=fcd_snap_loc.fcd_loc.ds_ref(),
+                snapshotId=fcd_snap_loc.id(cf))
+            self._session.wait_for_task(task)
+        except exceptions.NotFound:
+            LOG.warning("Fcd snapshot not found: %s.", fcd_snap_loc.snap_id)
+            return True
+        return True
 
     def create_fcd_from_snapshot(self, fcd_snap_loc, name,
                                  cinder_uuid, profile_id=None, key_id=None):


### PR DESCRIPTION
If the fcd delete snapshot results in the FCD not being found we return True.  This prevents the snapshot from being put into error_deleting state.  Since the object isn't found, delete can be considered successful.

Change-Id: Ie4d68a5ced29007c81f595ef1a2091da18c171b9