### PR TITLE
[SAP] Add internal_only_middleware to custom-requirements

### DIFF
--- a/custom-requirements.txt
+++ b/custom-requirements.txt
@@ -11,3 +11,4 @@ jaeger-client
 -e git+https://github.com/sapcc/openstack-rate-limit-middleware.git#egg=rate-limit-middleware
 -e git+https://github.com/sapcc/os-brick.git@stable/2023.1-m3#egg=os-brick
 -e git+https://github.com/sapcc/oslo.vmware.git@stable/2023.1-m3#egg=oslo.vmware
+-e git+https://github.wdf.sap.corp/sap-cloud-infrastructure/internal-only-middleware.git@main#egg=internal_only_middleware


### PR DESCRIPTION
This is needed for making the "internal" endpoint publicly available without allowing external requests.

Change-Id: Ifacf0ed2a40d5db29331120c317be39f97703d69