### PR TITLE
Add terminate_connection to NFS rest client

### DIFF
--- a/cinder/volume/drivers/netapp/dataontap/client/client_cmode_rest.py
+++ b/cinder/volume/drivers/netapp/dataontap/client/client_cmode_rest.py
@@ -2834,3 +2834,21 @@ class RestClient(object):
         if (volumes_response and volumes_response.get('num_records', 0) > 0):
             return volumes_response['records'][0]['comment']
         return None
+
+    def break_locks(self, client_ip, path):
+        """Release a lock on a volume"""
+
+        query = {
+            'client_address': client_ip,
+            'path': path,
+            'fields': 'client_address,uuid,type'
+        }
+
+        response = self.send_request('/protocols/locks', 'get', query=query)
+        locks = response.get('records', [])
+        for lock in locks:
+            lock_uuid = lock['uuid']
+            LOG.info('Releasing lock type %s for path:%s', lock['type'], path)
+            self.send_request(f'/protocols/locks/{lock_uuid}', 'delete')
+        if locks == []:
+            LOG.info("There was no lock found on path:%s", path)

--- a/cinder/volume/drivers/netapp/dataontap/nfs_cmode.py
+++ b/cinder/volume/drivers/netapp/dataontap/nfs_cmode.py
@@ -1329,3 +1329,14 @@ class NetAppCmodeNfsDriver(nfs_base.NetAppNfsDriver,
                           self).initialize_connection(volume, connector)
         conn_info['data']['version'] = self.ATTACHMENT_VERSION
         return conn_info
+
+    def terminate_connection(self, volume, connector, **kwargs):
+        srv_ip = volume_utils.resolve_hostname(connector['ip'])
+        prov_id = volume['provider_id']
+        share = volume_utils.extract_host(volume['host'], level='pool')
+        flexvol_name = self._get_flexvol_name_for_share(share)
+        filename = volume['name']
+        if prov_id:
+            filename = prov_id
+        path = '/%s/%s' % (flexvol_name, filename)
+        self.zapi_client.break_locks(srv_ip, path)


### PR DESCRIPTION
Add terminate_connection to NFS client enabling the lock breaking via the normal attach/detach workflow, instead of doing no operation. This would enable to recover a failed vm before the normal lease time expires