### PR TITLE
[SAP] capture the delete fcd not found

### DIFF
--- a/cinder/volume/drivers/vmware/fcd.py
+++ b/cinder/volume/drivers/vmware/fcd.py
@@ -276,7 +276,16 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
     @volume_utils.trace
     def _delete_fcd(self, provider_loc, delete_folder=True):
         fcd_loc = vops.FcdLocation.from_provider_location(provider_loc)
-        return self.volumeops.delete_fcd(fcd_loc, delete_folder=delete_folder)
+        try:
+            return self.volumeops.delete_fcd(
+                fcd_loc, delete_folder=delete_folder
+            )
+        except vexc.VimException as ex:
+            if "could not be found" in str(ex):
+                LOG.warning("FCD not found: %s.", fcd_loc.fcd_id)
+                return True
+            else:
+                raise ex
 
     @volume_utils.trace
     def delete_volume(self, volume):


### PR DESCRIPTION
This wraps the call into volumeops.delete_fcd looking for
any exception where could not be found is raised.   This
allows any failure to find any part of the fcd means it's deleted.

Change-Id: Id1fb48740c42ae648af24041f6ea98e65fbdab86