### PR TITLE
use zapi in _get_ssc_flexvol_info

### DIFF
--- a/cinder/tests/unit/volume/drivers/netapp/dataontap/utils/test_capabilities.py
+++ b/cinder/tests/unit/volume/drivers/netapp/dataontap/utils/test_capabilities.py
@@ -158,6 +158,9 @@ class CapabilitiesLibraryTestCase(test.TestCase):
         self.mock_object(self.ssc_library.zapi_client,
                          'get_flexvol',
                          return_value=fake_client.VOLUME_INFO_SSC)
+        self.mock_object(self.ssc_library.zapi_client,
+                         'get_flexvol_zapi',
+                         return_value=fake_client.VOLUME_INFO_SSC)
 
         result = self.ssc_library._get_ssc_flexvol_info(
             fake_client.VOLUME_NAMES[0])
@@ -170,7 +173,7 @@ class CapabilitiesLibraryTestCase(test.TestCase):
             'netapp_is_flexgroup': 'false',
         }
         self.assertEqual(expected, result)
-        self.zapi_client.get_flexvol.assert_called_once_with(
+        self.zapi_client.get_flexvol_zapi.assert_called_once_with(
             flexvol_name=fake_client.VOLUME_NAMES[0])
 
     @ddt.data({'vol_space_guarantee': 'file', 'lun_space_guarantee': True},
@@ -186,6 +189,9 @@ class CapabilitiesLibraryTestCase(test.TestCase):
         self.mock_object(self.ssc_library.zapi_client,
                          'get_flexvol',
                          return_value=fake_volume_info_ssc)
+        self.mock_object(self.ssc_library.zapi_client,
+                         'get_flexvol_zapi',
+                         return_value=fake_volume_info_ssc)
 
         result = self.ssc_library._get_ssc_flexvol_info(
             fake_client.VOLUME_NAMES[0])
@@ -198,7 +204,7 @@ class CapabilitiesLibraryTestCase(test.TestCase):
             'netapp_is_flexgroup': 'false',
         }
         self.assertEqual(expected, result)
-        self.zapi_client.get_flexvol.assert_called_once_with(
+        self.zapi_client.get_flexvol_zapi.assert_called_once_with(
             flexvol_name=fake_client.VOLUME_NAMES[0])
 
     @ddt.data({'nfs_sparsed_volumes': True},
@@ -212,6 +218,9 @@ class CapabilitiesLibraryTestCase(test.TestCase):
         self.mock_object(self.ssc_library.zapi_client,
                          'get_flexvol',
                          return_value=fake_client.VOLUME_INFO_SSC)
+        self.mock_object(self.ssc_library.zapi_client,
+                         'get_flexvol_zapi',
+                         return_value=fake_client.VOLUME_INFO_SSC)
 
         result = self.ssc_library._get_ssc_flexvol_info(
             fake_client.VOLUME_NAMES[0])
@@ -224,7 +233,7 @@ class CapabilitiesLibraryTestCase(test.TestCase):
             'netapp_is_flexgroup': 'false',
         }
         self.assertEqual(expected, result)
-        self.zapi_client.get_flexvol.assert_called_once_with(
+        self.zapi_client.get_flexvol_zapi.assert_called_once_with(
             flexvol_name=fake_client.VOLUME_NAMES[0])
 
     @ddt.data({'vol_space_guarantee': 'file', 'nfs_sparsed_volumes': True},
@@ -241,6 +250,9 @@ class CapabilitiesLibraryTestCase(test.TestCase):
         self.mock_object(self.ssc_library.zapi_client,
                          'get_flexvol',
                          return_value=fake_volume_info_ssc)
+        self.mock_object(self.ssc_library.zapi_client,
+                         'get_flexvol_zapi',
+                         return_value=fake_volume_info_ssc)
 
         result = self.ssc_library._get_ssc_flexvol_info(
             fake_client.VOLUME_NAMES[0])
@@ -253,7 +265,7 @@ class CapabilitiesLibraryTestCase(test.TestCase):
             'netapp_is_flexgroup': 'false',
         }
         self.assertEqual(expected, result)
-        self.zapi_client.get_flexvol.assert_called_once_with(
+        self.zapi_client.get_flexvol_zapi.assert_called_once_with(
             flexvol_name=fake_client.VOLUME_NAMES[0])
 
     @ddt.data([], ['netapp_dedup'], ['netapp_compression'])

--- a/cinder/volume/drivers/netapp/dataontap/utils/capabilities.py
+++ b/cinder/volume/drivers/netapp/dataontap/utils/capabilities.py
@@ -128,7 +128,8 @@ class CapabilitiesLibrary(object):
     def _get_ssc_flexvol_info(self, flexvol_name):
         """Gather flexvol info and recast into SSC-style volume stats."""
 
-        volume_info = self.zapi_client.get_flexvol(flexvol_name=flexvol_name)
+        volume_info = self.zapi_client.get_flexvol_zapi(
+            flexvol_name=flexvol_name)
 
         netapp_thick = (volume_info.get('space-guarantee-enabled') and
                         (volume_info.get('space-guarantee') == 'file' or


### PR DESCRIPTION
Looks like REST api is not thread safe, failing from loopingcall
This fix is the followup from previous fix of _get_flexvol_to_pool_map
Change-Id: Ic3bdded315e6c52cdccfc27173185eb2fd72b2e1