### PR TITLE
[SAP] Ensure service_uuid during volume create

### DIFF
--- a/cinder/tests/unit/volume/flows/test_create_volume_flow.py
+++ b/cinder/tests/unit/volume/flows/test_create_volume_flow.py
@@ -1400,7 +1400,8 @@ class CreateVolumeFlowManagerTestCase(test.TestCase):
                                             mock.sentinel.driver,
                                             mock.sentinel.image_volume_cache)
         onfinish_mock.assert_called_once_with(mock.sentinel.db,
-                                              end_notify_suffix)
+                                              end_notify_suffix,
+                                              service_uuid=None)
 
         volume_flow = flow_mock.return_value
         self.assertEqual(len(tasks), volume_flow.add.call_count)

--- a/cinder/tests/unit/volume/test_manage_volume.py
+++ b/cinder/tests/unit/volume/test_manage_volume.py
@@ -109,7 +109,8 @@ class ManageVolumeTestCase(base.BaseVolumeTestCase):
                                               self.manager.driver,
                                               self.manager.host,
                                               mock_volume,
-                                              None)
+                                              None,
+                                              service_uuid=None)
         mock_flow_engine_run.assert_called_once_with()
         mock_flow_engine_fetch.assert_called_once_with('volume')
 
@@ -128,7 +129,8 @@ class ManageVolumeTestCase(base.BaseVolumeTestCase):
                                               self.manager.driver,
                                               self.manager.host,
                                               volume_object,
-                                              None)
+                                              None,
+                                              service_uuid=None)
 
     def test_update_stats_for_managed(self):
         volume_object = self._stub_volume_object_get(self,

--- a/cinder/volume/flows/manager/create_volume.py
+++ b/cinder/volume/flows/manager/create_volume.py
@@ -1285,11 +1285,12 @@ class CreateVolumeOnFinishTask(NotifyVolumeActionTask):
     Reversion strategy: N/A
     """
 
-    def __init__(self, db, event_suffix):
+    def __init__(self, db, event_suffix, service_uuid=None):
         super(CreateVolumeOnFinishTask, self).__init__(db, event_suffix)
         self.status_translation = {
             'migration_target_creating': 'migration_target',
         }
+        self.service_uuid = service_uuid
 
     def execute(self, context, volume, volume_spec):
         need_update_volume = volume_spec.pop('need_update_volume', True)
@@ -1299,10 +1300,16 @@ class CreateVolumeOnFinishTask(NotifyVolumeActionTask):
 
         new_status = self.status_translation.get(volume_spec.get('status'),
                                                  'available')
+
+        # TODO(geguileo): service_uuid won't be enough on Active/Active
+        # deployments. There can be 2 services handling volumes from the same
+        # backend.
         update = {
             'status': new_status,
             'launched_at': timeutils.utcnow(),
         }
+        if self.service_uuid:
+            update['service_uuid'] = self.service_uuid
         try:
             # TODO(harlowja): is it acceptable to only log if this fails??
             # or are there other side-effects that this will cause if the
@@ -1325,7 +1332,8 @@ class CreateVolumeOnFinishTask(NotifyVolumeActionTask):
 
 def get_flow(context, manager, db, driver, scheduler_rpcapi, host, volume,
              allow_reschedule, reschedule_context, request_spec,
-             filter_properties, image_volume_cache=None):
+             filter_properties, image_volume_cache=None,
+             service_uuid=None):
 
     """Constructs and returns the manager entrypoint flow.
 
@@ -1380,7 +1388,8 @@ def get_flow(context, manager, db, driver, scheduler_rpcapi, host, volume,
                                              db,
                                              driver,
                                              image_volume_cache),
-                    CreateVolumeOnFinishTask(db, end_notify_suffix))
+                    CreateVolumeOnFinishTask(db, end_notify_suffix,
+                                             service_uuid=service_uuid))
 
     # Now load (but do not run) the flow using the provided initial data.
     return taskflow.engines.load(volume_flow, store=create_what)

--- a/cinder/volume/flows/manager/manage_existing.py
+++ b/cinder/volume/flows/manager/manage_existing.py
@@ -104,7 +104,8 @@ class ManageExistingTask(flow_utils.CinderTask):
         return {'volume': volume}
 
 
-def get_flow(context, db, driver, host, volume, ref):
+def get_flow(context, db, driver, host, volume, ref,
+             service_uuid=None):
     """Constructs and returns the manager entrypoint flow."""
 
     flow_name = ACTION.replace(":", "_") + "_manager"
@@ -127,8 +128,9 @@ def get_flow(context, db, driver, host, volume, ref):
                     create_api.QuotaReserveTask(),
                     ManageExistingTask(db, driver),
                     create_api.QuotaCommitTask(),
-                    create_mgr.CreateVolumeOnFinishTask(db,
-                                                        "manage_existing.end"))
+                    create_mgr.CreateVolumeOnFinishTask(
+                        db, "manage_existing.end",
+                        service_uuid=service_uuid))
 
     # Now load (but do not run) the flow using the provided initial data.
     return taskflow.engines.load(volume_flow, store=create_what)

--- a/cinder/volume/manager.py
+++ b/cinder/volume/manager.py
@@ -978,6 +978,7 @@ class VolumeManager(manager.CleanableManager,
                 request_spec,
                 filter_properties,
                 image_volume_cache=self.image_volume_cache,
+                service_uuid=self.service_uuid
             )
         except Exception:
             msg = _("Create manager volume flow failed.")
@@ -1043,10 +1044,6 @@ class VolumeManager(manager.CleanableManager,
 
         # Shared targets is only relevant for some connections.
         volume.shared_targets = self._driver_shares_targets()
-        # TODO(geguileo): service_uuid won't be enough on Active/Active
-        # deployments. There can be 2 services handling volumes from the same
-        # backend.
-        volume.service_uuid = self.service_uuid
         volume.save()
 
         # propagate any scheduler hint affinity/anti-affinity metadata to
@@ -3638,6 +3635,7 @@ class VolumeManager(manager.CleanableManager,
                 self.host,
                 volume,
                 ref,
+                service_uuid=self.service_uuid,
             )
         except Exception:
             msg = _("Failed to create manage_existing flow.")


### PR DESCRIPTION
This patch adds the service_uuid of the volume manager to the task flow that creates a volume.  When the volume creation is complete and the volume is set to available, the service_uuid is set. This changes how it was done previously.  The volume manager used to wait until the task flow was completed to set the service_uuid. this would leave a short window between when a volume was available and when the service_uuid was set, causing a race condition for attaches that required the service_uuid.

Change-Id: Ifa1ffe09271d3598cd0b78610e42a76290fb3401