### PR TITLE
[SAP] move shared_targets setting into flow

### DIFF
--- a/cinder/tests/unit/volume/flows/test_create_volume_flow.py
+++ b/cinder/tests/unit/volume/flows/test_create_volume_flow.py
@@ -1401,7 +1401,8 @@ class CreateVolumeFlowManagerTestCase(test.TestCase):
                                             mock.sentinel.image_volume_cache)
         onfinish_mock.assert_called_once_with(mock.sentinel.db,
                                               end_notify_suffix,
-                                              service_uuid=None)
+                                              service_uuid=None,
+                                              shared_targets=None)
 
         volume_flow = flow_mock.return_value
         self.assertEqual(len(tasks), volume_flow.add.call_count)

--- a/cinder/tests/unit/volume/test_manage_volume.py
+++ b/cinder/tests/unit/volume/test_manage_volume.py
@@ -110,7 +110,8 @@ class ManageVolumeTestCase(base.BaseVolumeTestCase):
                                               self.manager.host,
                                               mock_volume,
                                               None,
-                                              service_uuid=None)
+                                              service_uuid=None,
+                                              shared_targets=False)
         mock_flow_engine_run.assert_called_once_with()
         mock_flow_engine_fetch.assert_called_once_with('volume')
 
@@ -130,7 +131,8 @@ class ManageVolumeTestCase(base.BaseVolumeTestCase):
                                               self.manager.host,
                                               volume_object,
                                               None,
-                                              service_uuid=None)
+                                              service_uuid=None,
+                                              shared_targets=False)
 
     def test_update_stats_for_managed(self):
         volume_object = self._stub_volume_object_get(self,

--- a/cinder/volume/flows/manager/create_volume.py
+++ b/cinder/volume/flows/manager/create_volume.py
@@ -1285,12 +1285,14 @@ class CreateVolumeOnFinishTask(NotifyVolumeActionTask):
     Reversion strategy: N/A
     """
 
-    def __init__(self, db, event_suffix, service_uuid=None):
+    def __init__(self, db, event_suffix, service_uuid=None,
+                 shared_targets=None):
         super(CreateVolumeOnFinishTask, self).__init__(db, event_suffix)
         self.status_translation = {
             'migration_target_creating': 'migration_target',
         }
         self.service_uuid = service_uuid
+        self.shared_targets = shared_targets
 
     def execute(self, context, volume, volume_spec):
         need_update_volume = volume_spec.pop('need_update_volume', True)
@@ -1304,9 +1306,11 @@ class CreateVolumeOnFinishTask(NotifyVolumeActionTask):
         # TODO(geguileo): service_uuid won't be enough on Active/Active
         # deployments. There can be 2 services handling volumes from the same
         # backend.
+        # Shared targets is only relevant for some connections.
         update = {
             'status': new_status,
             'launched_at': timeutils.utcnow(),
+            'shared_targets': self.shared_targets,
         }
         if self.service_uuid:
             update['service_uuid'] = self.service_uuid
@@ -1333,7 +1337,7 @@ class CreateVolumeOnFinishTask(NotifyVolumeActionTask):
 def get_flow(context, manager, db, driver, scheduler_rpcapi, host, volume,
              allow_reschedule, reschedule_context, request_spec,
              filter_properties, image_volume_cache=None,
-             service_uuid=None):
+             service_uuid=None, shared_targets=None):
 
     """Constructs and returns the manager entrypoint flow.
 
@@ -1389,7 +1393,8 @@ def get_flow(context, manager, db, driver, scheduler_rpcapi, host, volume,
                                              driver,
                                              image_volume_cache),
                     CreateVolumeOnFinishTask(db, end_notify_suffix,
-                                             service_uuid=service_uuid))
+                                             service_uuid=service_uuid,
+                                             shared_targets=shared_targets))
 
     # Now load (but do not run) the flow using the provided initial data.
     return taskflow.engines.load(volume_flow, store=create_what)

--- a/cinder/volume/flows/manager/manage_existing.py
+++ b/cinder/volume/flows/manager/manage_existing.py
@@ -105,7 +105,7 @@ class ManageExistingTask(flow_utils.CinderTask):
 
 
 def get_flow(context, db, driver, host, volume, ref,
-             service_uuid=None):
+             service_uuid=None, shared_targets=None):
     """Constructs and returns the manager entrypoint flow."""
 
     flow_name = ACTION.replace(":", "_") + "_manager"
@@ -130,7 +130,8 @@ def get_flow(context, db, driver, host, volume, ref,
                     create_api.QuotaCommitTask(),
                     create_mgr.CreateVolumeOnFinishTask(
                         db, "manage_existing.end",
-                        service_uuid=service_uuid))
+                        service_uuid=service_uuid,
+                        shared_targets=shared_targets))
 
     # Now load (but do not run) the flow using the provided initial data.
     return taskflow.engines.load(volume_flow, store=create_what)

--- a/cinder/volume/manager.py
+++ b/cinder/volume/manager.py
@@ -978,7 +978,8 @@ class VolumeManager(manager.CleanableManager,
                 request_spec,
                 filter_properties,
                 image_volume_cache=self.image_volume_cache,
-                service_uuid=self.service_uuid
+                service_uuid=self.service_uuid,
+                shared_targets=self._driver_shares_targets()
             )
         except Exception:
             msg = _("Create manager volume flow failed.")
@@ -1041,10 +1042,6 @@ class VolumeManager(manager.CleanableManager,
                 # Volume.host is None now, so we pass the original host value.
                 self._update_allocated_capacity(volume, decrement=True,
                                                 host=original_host)
-
-        # Shared targets is only relevant for some connections.
-        volume.shared_targets = self._driver_shares_targets()
-        volume.save()
 
         # propagate any scheduler hint affinity/anti-affinity metadata to
         # other volumes.
@@ -3636,6 +3633,7 @@ class VolumeManager(manager.CleanableManager,
                 volume,
                 ref,
                 service_uuid=self.service_uuid,
+                shared_targets=self._driver_shares_targets()
             )
         except Exception:
             msg = _("Failed to create manage_existing flow.")


### PR DESCRIPTION
This patch moves the saving of the shared_targets value of a volume into the task flow.  This ensures that the attribute is set prior to the volume getting set into available status.

Change-Id: I4bf92024b136fdb5d568f1e7a02709d43181eb9c