### PR TITLE
[SAP] Corner case fix for deleting snapshot fcd/vmdk

### DIFF
--- a/cinder/volume/drivers/vmware/fcd.py
+++ b/cinder/volume/drivers/vmware/fcd.py
@@ -706,6 +706,14 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
         if not snapshot.provider_location:
             LOG.debug("FCD snapshot location is empty.")
             return
+
+        # We might be in a situation where the snapshot is still a vmdk
+        # based snapshot, but the owning volume has been migrated to fcd.
+        # in which case the provider_location still looks like a vmdk path.
+        # If so, we need to call the parent class to delete the snapshot.
+        if '/' in snapshot.provider_location:
+            return super(VMwareVStorageObjectDriver,
+                         self).delete_snapshot(snapshot)
         snap_location = self._snap_provider_location_to_moref_location(
             snapshot.provider_location
         )


### PR DESCRIPTION
This patch includes a fix where a snapshot is still a vmdk snap, but the fcd driver has been called because the owning volume has been migrated to fcd, but the snapshot hasn't yet.  The fcd driver now detects if the provider_location is a vmdk path instead of an fcd based provider_location, it will call the vmdk's delete_snapshot

Change-Id: Id06361c7a00b2bbe7c2a36201fb0dc58bf997f9e