### PR TITLE
Add exception handling to vmdk_path/dc lookup to support nova migration

### DIFF
--- a/cinder/volume/drivers/vmware/fcd.py
+++ b/cinder/volume/drivers/vmware/fcd.py
@@ -359,9 +359,15 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
             datacenter = vim_util.get_moref_value(
                 self.volumeops.get_dc(backing))
         else:
-            vmdk_path = self.volumeops.get_vmdk_path_for_fcd(fcd_loc=fcd_loc)
-            datacenter = vim_util.get_moref_value(
-                self.volumeops.get_dc(fcd_loc.ds_ref()))
+            try:
+                vmdk_path = self.volumeops.get_vmdk_path_for_fcd(
+                    fcd_loc=fcd_loc)
+                datacenter = vim_util.get_moref_value(
+                    self.volumeops.get_dc(fcd_loc.ds_ref()))
+            except Exception:
+                LOG.warning("Can't find the fcd object: %s, "
+                            "this can be due to nova migration or "
+                            "VMware issue", fcd_loc.fcd_id)
 
         connection_info = {
             'driver_volume_type': self.STORAGE_TYPE,


### PR DESCRIPTION
Fix Nova cross vc migration, because during live migration the data file is not yet available in the target vcenter
This issue happens due to the new qtree design, where not all the datastores are mounted to all hosts.
So cross vcenter, before the migration the datafiles are not yet available

Change-Id: I067154c4da647c9519405525c47e991b2e9bbbbe