### PR TITLE
Backport: online-extend-netapp-nfs

### DIFF
--- a/cinder/tests/unit/volume/drivers/netapp/dataontap/test_nfs_base.py
+++ b/cinder/tests/unit/volume/drivers/netapp/dataontap/test_nfs_base.py
@@ -732,12 +732,7 @@ class NetAppNfsDriverTestCase(test.TestCase):
         mock_do_qos_for_volume = self.mock_object(self.driver,
                                                   '_do_qos_for_volume')
 
-        if is_locked:
-            self.assertRaises(exception.NovaExtendCompletionRequired,
-                              self.driver.extend_volume, volume, new_size)
-        else:
-            self.driver.extend_volume(volume, new_size)
-
+        self.driver.extend_volume(volume, new_size)
         mock_resize_image_file.assert_called_once_with(path, new_size,
                                                        file_format=file_format)
         mock_get_volume_extra_specs.assert_called_once_with(volume)

--- a/cinder/tests/unit/volume/drivers/netapp/dataontap/test_nfs_base.py
+++ b/cinder/tests/unit/volume/drivers/netapp/dataontap/test_nfs_base.py
@@ -698,10 +698,15 @@ class NetAppNfsDriverTestCase(test.TestCase):
 
         self.assertIn("nfs://host/path/image-id", locations)
 
-    @ddt.data(None, 'raw', 'qcow2')
     @mock.patch('cinder.objects.volume.Volume.get_by_id')
-    def test_extend_volume(self, file_format, mock_get):
+    @ddt.data({'file_format': None, 'is_locked': True},
+              {'file_format': 'raw', 'is_locked': True},
+              {'file_format': 'qcow2', 'is_locked': False})
+    @ddt.unpack
+    def test_extend_volume(self, mock_get, file_format, is_locked):
 
+        self.mock_object(self.driver, '_is_volume_attached',
+                         return_value=is_locked)
         volume = fake_volume.fake_volume_obj(self.ctxt)
         if file_format:
             volume.admin_metadata = {'format': file_format}
@@ -714,14 +719,24 @@ class NetAppNfsDriverTestCase(test.TestCase):
         self.mock_object(self.driver,
                          'local_path',
                          return_value=path)
-        mock_resize_image_file = self.mock_object(self.driver,
-                                                  '_resize_image_file')
+        if is_locked:
+            mock_resize_image_file = self.mock_object(
+                self.driver, '_resize_image_file',
+                side_effect=processutils.ProcessExecutionError(
+                    stderr="another process using the image"))
+        else:
+            mock_resize_image_file = self.mock_object(self.driver,
+                                                      '_resize_image_file')
         mock_get_volume_extra_specs = self.mock_object(
             na_utils, 'get_volume_extra_specs', return_value=fake.EXTRA_SPECS)
         mock_do_qos_for_volume = self.mock_object(self.driver,
                                                   '_do_qos_for_volume')
 
-        self.driver.extend_volume(volume, new_size)
+        if is_locked:
+            self.assertRaises(exception.NovaExtendCompletionRequired,
+                              self.driver.extend_volume, volume, new_size)
+        else:
+            self.driver.extend_volume(volume, new_size)
 
         mock_resize_image_file.assert_called_once_with(path, new_size,
                                                        file_format=file_format)
@@ -731,14 +746,15 @@ class NetAppNfsDriverTestCase(test.TestCase):
                                                        cleanup=False)
 
     @mock.patch('cinder.objects.volume.Volume.get_by_id')
-    def test_extend_volume_resize_error(self, mock_get):
+    @ddt.data(netapp_api.NaApiError, processutils.ProcessExecutionError)
+    def test_extend_volume_resize_error(self, mock_get, exception_obj):
 
         volume = fake_volume.fake_volume_obj(self.ctxt)
         mock_get.return_value = volume
         new_size = 100
-        volume_copy = copy.copy(volume)
-        volume_copy['size'] = new_size
 
+        self.mock_object(self.driver, '_is_volume_attached',
+                         return_value=True)
         path = '%s/%s' % (fake.NFS_SHARE, fake.NFS_VOLUME['name'])
         self.mock_object(self.driver,
                          'local_path',

--- a/cinder/tests/unit/volume/drivers/netapp/dataontap/test_nfs_cmode.py
+++ b/cinder/tests/unit/volume/drivers/netapp/dataontap/test_nfs_cmode.py
@@ -271,7 +271,7 @@ class NetAppCmodeNfsDriverTestCase(test.TestCase):
             'consistencygroup_support': True,
             'consistent_group_snapshot_enabled': True,
             'replication_enabled': False,
-            'online_extend_support': False,
+            'online_extend_support': True,
             'netapp_is_flexgroup': 'false',
         }]
         if report_provisioned_capacity:

--- a/cinder/volume/drivers/netapp/dataontap/nfs_base.py
+++ b/cinder/volume/drivers/netapp/dataontap/nfs_base.py
@@ -935,7 +935,7 @@ class NetAppNfsDriver(driver.ManageableVD,
         """Extend an existing volume to the new size."""
 
         LOG.info('Extending volume %s.', volume['name'])
-
+        require_nova_completion = False
         try:
             path = self.local_path(volume)
             file_format = None
@@ -943,8 +943,11 @@ class NetAppNfsDriver(driver.ManageableVD,
                 context.get_admin_context(), volume.id).admin_metadata
             if admin_metadata and 'format' in admin_metadata:
                 file_format = admin_metadata['format']
-            self._resize_image_file(
-                path, new_size, file_format=file_format)
+            if (self._is_volume_attached(volume)):
+                require_nova_completion = True
+            else:
+                self._resize_image_file(path, new_size,
+                                        file_format=file_format)
         except Exception as err:
             exception_msg = (_("Failed to extend volume "
                                "%(name)s, Error msg: %(msg)s.") %
@@ -966,6 +969,9 @@ class NetAppNfsDriver(driver.ManageableVD,
                              {'name': volume['name'],
                               'msg': six.text_type(err)})
             raise exception.VolumeBackendAPIException(data=exception_msg)
+
+        if require_nova_completion:
+            raise exception.NovaExtendCompletionRequired()
 
     def _is_share_clone_compatible(self, volume, share):
         """Checks if share is compatible with volume to host its clone."""

--- a/cinder/volume/drivers/netapp/dataontap/nfs_base.py
+++ b/cinder/volume/drivers/netapp/dataontap/nfs_base.py
@@ -946,7 +946,7 @@ class NetAppNfsDriver(driver.ManageableVD,
             self._resize_image_file(path, new_size,
                                     file_format=file_format)
         except processutils.ProcessExecutionError as ex:
-            if (self._is_volume_attached(volume)):
+            if (self._is_volume_attached(volume) and ex.stderr):
                 require_nova_completion = True
             else:
                 raise
@@ -975,6 +975,7 @@ class NetAppNfsDriver(driver.ManageableVD,
         if require_nova_completion:
             LOG.warning('Extend volume continune on nova side for vol:%s',
                         volume['id'])
+
     def _is_share_clone_compatible(self, volume, share):
         """Checks if share is compatible with volume to host its clone."""
         raise NotImplementedError()

--- a/cinder/volume/drivers/netapp/dataontap/nfs_base.py
+++ b/cinder/volume/drivers/netapp/dataontap/nfs_base.py
@@ -943,11 +943,13 @@ class NetAppNfsDriver(driver.ManageableVD,
                 context.get_admin_context(), volume.id).admin_metadata
             if admin_metadata and 'format' in admin_metadata:
                 file_format = admin_metadata['format']
+            self._resize_image_file(path, new_size,
+                                    file_format=file_format)
+        except processutils.ProcessExecutionError as ex:
             if (self._is_volume_attached(volume)):
                 require_nova_completion = True
             else:
-                self._resize_image_file(path, new_size,
-                                        file_format=file_format)
+                raise
         except Exception as err:
             exception_msg = (_("Failed to extend volume "
                                "%(name)s, Error msg: %(msg)s.") %
@@ -971,8 +973,8 @@ class NetAppNfsDriver(driver.ManageableVD,
             raise exception.VolumeBackendAPIException(data=exception_msg)
 
         if require_nova_completion:
-            raise exception.NovaExtendCompletionRequired()
-
+            LOG.warning('Extend volume continune on nova side for vol:%s',
+                        volume['id'])
     def _is_share_clone_compatible(self, volume, share):
         """Checks if share is compatible with volume to host its clone."""
         raise NotImplementedError()

--- a/cinder/volume/drivers/netapp/dataontap/nfs_cmode.py
+++ b/cinder/volume/drivers/netapp/dataontap/nfs_cmode.py
@@ -428,7 +428,7 @@ class NetAppCmodeNfsDriver(nfs_base.NetAppNfsDriver,
             pool['consistencygroup_support'] = True
             pool['consistent_group_snapshot_enabled'] = True
             pool['multiattach'] = True
-            pool['online_extend_support'] = False
+            pool['online_extend_support'] = True
 
             is_flexgroup = ssc_vol_info.get('netapp_is_flexgroup') == 'true'
             if is_flexgroup:


### PR DESCRIPTION
https://review.opendev.org/c/openstack/cinder/+/873889 Netapp NFS: Add online extend support
Add online extend support to the Netapp NFS driver by relying on Nova to call back to the extend volume completion action.
This is adapted from the previous changes at
https://review.opendev.org/c/openstack/cinder/+/739079 and https://review.opendev.org/c/openstack/cinder/+/820578
Implements: bp extend-volume-completion-action
Change-Id: Iddb530369773e8c2a6d06b74cb40966fc4e064a9