### PR TITLE
Fix cross-vc-attach vmdk-to-fcd

### DIFF
--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -3499,6 +3499,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
     @volume_utils.trace
     def _migrate_to_fcd(self, context, volume, host):
 
+        cross_vc = False
         info = host['capabilities']['location_info']
         false_ret = (False, None)
         if 'location_info' not in host['capabilities']:
@@ -3508,6 +3509,8 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
             (driver_name, vcenter) = info.split(':')
         except ValueError:
             return false_ret
+        if self._vcenter_instance_uuid != vcenter:
+            cross_vc = True
         dest_host = host['host']
         tgt_ds = self._remote_api.select_ds_for_volume(
             context, cinder_host=dest_host, volume=volume
@@ -3517,7 +3520,9 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         if not backing:
             # we need to create the backing and then migrate it.
             LOG.debug("Backing does not exist for volume.", resource=volume)
-            backing = self._create_backing(volume)
+            # backing = self._create_backing(volume)
+            # At the moment due to a bug we created lot of emptry backing
+            # We fail if backing does not exists...
             if not backing:
                 msg = ("Failed to create backing for vmdk volume prior to "
                        "migration to fcd.")
@@ -3558,17 +3563,25 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
         self.volumeops.delete_backing(backing)
         ds_ref = vim_util.get_moref(tgt_ds['datastore'], 'Datastore')
         profile_id = tgt_ds.get('profile_id')
+        get_sl = self._remote_api.get_service_locator_info
         if (ds_ref.value != summary.datastore.value):
             # Migration required
             if volume['attach_status'] == 'detached':
+                if cross_vc:
+                    service_locator = get_sl(context, dest_host)
+                else:
+                    service_locator = None
                 self.volumeops.relocate_fcd(fcd_loc, ds_ref, volume.name,
-                                            service=None,
+                                            service=service_locator,
                                             profile_id=profile_id)
                 old_mref = summary.datastore.value
                 new_prov_loc = prov_loc.replace(old_mref, ds_ref.value)
-                prov_loc = self._provider_location_to_ds_name_location(
-                    new_prov_loc
-                )
+                if cross_vc:
+                    prov_loc = self._remote_api.get_fcd_provider_location(
+                        context, dest_host, fcd_loc.fcd_id, ds_ref.value)
+                else:
+                    prov_loc = self._provider_location_to_ds_name_location(
+                        new_prov_loc)
                 volume.update({'provider_location': prov_loc})
                 volume.save()
                 return (True, None)


### PR DESCRIPTION
Fcd migration can be triggered by automation trying to attach volume to another node in different vcenter(eg. k8s)
If this happens the code failed as the appropriate cinder host does not have a local datastore due to qtree(separate ds/vc)
This patch triggers a cross vc relocate_fcd call in this case, this won't have any extra cost, as the data would be copied over to NFS anyway. 
Change-Id: If7f283e8770a09f767f7da7b6570d5b2031c3469