### PR TITLE
Pin tox virtenv so unit tests can pass

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 minversion = 4.0.0
 # specify virtualenv here to keep local runs consistent with the
 # gate (it sets the versions of pip, setuptools, and wheel)
-requires = virtualenv>=20.17.1
+requires = virtualenv<=20.36
 # this allows tox to infer the base python from the environment name
 # and override any basepython configured in this file
 ignore_basepython_conflict=true


### PR DESCRIPTION
Upstream virtenv has upgraded setuptools to the point where older python installs won't work properly.  This patch pins the virtenv to a version that doesn't upgrade setuptools

Change-Id: I7a17c7e11ffa13a25cad860e7984f27055d64377