### PR TITLE
Add backend_state and backend_availability_zone as pool stats to the netapp driver

### DIFF
--- a/cinder/tests/unit/volume/drivers/netapp/dataontap/test_nfs_cmode.py
+++ b/cinder/tests/unit/volume/drivers/netapp/dataontap/test_nfs_cmode.py
@@ -248,6 +248,8 @@ class NetAppCmodeNfsDriverTestCase(test.TestCase):
             'pool_name': '10.10.10.10:/vola',
             'pool_state': 'up',
             'pool_down_reason': '',
+            'backend_state': 'up',
+            'backend_availability_zone': None,
             'reserved_percentage': fake.RESERVED_PERCENTAGE,
             'max_over_subscription_ratio': fake.MAX_OVER_SUBSCRIPTION_RATIO,
             'multiattach': True,

--- a/cinder/volume/drivers/netapp/dataontap/nfs_cmode.py
+++ b/cinder/volume/drivers/netapp/dataontap/nfs_cmode.py
@@ -489,6 +489,13 @@ class NetAppCmodeNfsDriver(nfs_base.NetAppNfsDriver,
             # SAP
             # Get the comment section of the volume and see if
             # it's marked as down by an admin
+            if len(ssc.items()) > 0:
+                pool['backend_state'] = 'up'
+            else:
+                pool['backend_state'] = 'down'
+            backend_az = self.configuration.safe_get(
+                'backend_availability_zone')
+            pool['backend_availability_zone'] = backend_az
             pool['pool_state'] = 'up'
             pool['pool_down_reason'] = ''
             pool_info = self._get_volume_comment(ssc_vol_name)


### PR DESCRIPTION
Add backend_state and backend_availablity_zone as pool stats to the NetApp driver
Change-Id: I113b711be245c9278174d71d33ee95f598bf58d9