### PR TITLE
Cleanup glance image metadata during instance reschedule

### DIFF
--- a/cinder/tests/unit/volume/flows/test_create_volume_flow.py
+++ b/cinder/tests/unit/volume/flows/test_create_volume_flow.py
@@ -2511,3 +2511,38 @@ class CreateVolumeFlowManagerImageCacheTestCase(test.TestCase):
                 image_meta,
                 self.mock_image_service,
                 update_cache=True)
+
+    @ddt.data([], ['fake_entry'])
+    @mock.patch('cinder.image.image_utils.verify_glance_image_signature')
+    @mock.patch('cinder.image.image_utils.qemu_img_info')
+    def test__create_from_image_cache_or_download(
+            self, glance_metadata, mock_qemu_img, mock_verify,
+            mock_get_internal_context, mock_create_from_img_dl,
+            mock_create_from_src, mock_handle_bootable, mock_fetch_img):
+        fake_db = mock.MagicMock()
+        fake_driver = mock.MagicMock()
+        fake_volume_manager = mock.MagicMock()
+        fake_db.volume_glance_metadata_get.return_value = glance_metadata
+        fake_manager = create_volume_manager.CreateVolumeFromSpecTask(
+            fake_volume_manager, fake_db, fake_driver)
+        volume = fake_volume.fake_volume_obj(self.ctxt,
+                                             id=fakes.VOLUME_ID,
+                                             host='host@backend#pool')
+        image_location = 'someImageLocationStr'
+        image_id = fakes.IMAGE_ID
+        image_meta = {'virtual_size': '1073741824', 'size': 1073741824}
+        mock_verify.return_value = True
+
+        mock_create_from_img_dl.side_effect = exception.CinderException
+        self.assertRaises(
+            exception.CinderException,
+            fake_manager._create_from_image_cache_or_download,
+            self.ctxt, volume, image_location, image_id, image_meta,
+            self.mock_image_service)
+        fake_db.volume_glance_metadata_bulk_create.assert_called_once_with(
+            self.ctxt, volume.id, {'signature_verified': True})
+        fake_db.volume_glance_metadata_get.assert_called_once_with(
+            self.ctxt, volume.id)
+        if glance_metadata:
+            fake_db.volume_glance_metadata_delete_by_volume.\
+                assert_called_once_with(self.ctxt, volume.id)

--- a/cinder/volume/flows/manager/create_volume.py
+++ b/cinder/volume/flows/manager/create_volume.py
@@ -1048,6 +1048,13 @@ class CreateVolumeFromSpecTask(flow_utils.CinderTask):
                                                               volume,
                                                               image_id,
                                                               image_meta)
+        except Exception:
+            with excutils.save_and_reraise_exception():
+                vol_glance_metadata = self.db.volume_glance_metadata_get(
+                    context, volume.id)
+                if vol_glance_metadata:
+                    self.db.volume_glance_metadata_delete_by_volume(
+                        context, volume.id)
         finally:
             # If we created the volume as the minimal size, extend it back to
             # what was originally requested. If an exception has occurred or

--- a/releasenotes/notes/glance-image-metadata-cleanup-e0dcc6a32331a04f.yaml
+++ b/releasenotes/notes/glance-image-metadata-cleanup-e0dcc6a32331a04f.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    `Bug 1936474
+    <https://bugs.launchpad.net/cinder/+bug/1936474>`__
+    Fixed improper cleanup of glance image metadata when
+    rescheduling instance.


### PR DESCRIPTION
## Summary
- Backport of fix from stable/2023.1-m3 (PR #320)
- Cleans up glance image metadata when volume creation from image fails during instance reschedule
- Prevents failures on subsequent reschedule attempts due to leftover metadata

## Bug
Closes-Bug: #1936474

When creating an instance using a volume, if the instance create fails the first time and reschedules, the glance image metadata was not being cleaned up properly, causing failures on the cinder side.

## Changes
- Added exception handler in `_create_from_image_cache_or_download()` to delete glance metadata on failure
- Added unit test to verify cleanup behavior
- Added release notes