### PR TITLE
[SAP] modify select_datastore_by_name to use a cache

### DIFF
--- a/cinder/volume/drivers/vmware/datastore.py
+++ b/cinder/volume/drivers/vmware/datastore.py
@@ -19,6 +19,7 @@ Classes and utility methods for datastore selection.
 
 from collections.abc import Iterable
 import random
+import time
 
 from oslo_log import log as logging
 from oslo_vmware import pbm
@@ -64,6 +65,8 @@ class DatastoreSelector(object):
         self._max_objects = max_objects
         self._ds_regex = ds_regex
         self._profile_id_cache = {}
+        self._ds_name_cache = {}  # {name: (moref, timestamp)}
+        self._ds_cache_ttl = 300  # 5 minutes
         self._random_ds = random_ds
         self._random_ds_range = random_ds_range
 
@@ -358,6 +361,14 @@ class DatastoreSelector(object):
         return datastores
 
     def get_ds_ref_by_name(self, name):
+        # Check cache first
+        if name in self._ds_name_cache:
+            moref, timestamp = self._ds_name_cache[name]
+            if time.time() - timestamp < self._ds_cache_ttl:
+                return moref
+            # Cache expired, remove it
+            del self._ds_name_cache[name]
+
         vim = self._session.vim
 
         retrieve_result = self._session.invoke_api(
@@ -372,21 +383,55 @@ class DatastoreSelector(object):
             for obj_content in objects:
                 props = self._get_object_properties(obj_content)
                 if props['name'] == name:
+                    # Cache the result
+                    self._ds_name_cache[name] = (obj_content.obj, time.time())
                     return obj_content.obj
         return None
+
+    def _get_datastore_by_name(self, name):
+        """Fetch a single datastore by name with optimized vCenter query.
+
+        Instead of fetching ALL datastores and filtering, this method
+        queries vCenter directly for the specific datastore by name,
+        reducing the amount of data transferred and processing time.
+
+        :param name: Datastore name to find
+        :return: dict with 'summary' and 'host' keys, or None if not found
+        """
+        vim = self._session.vim
+
+        # First, find the datastore reference by name (uses cache)
+        ds_ref = self.get_ds_ref_by_name(name)
+        if not ds_ref:
+            return None
+
+        # Now fetch only the properties we need for this specific datastore
+        retrieve_result = self._session.invoke_api(
+            vim_util,
+            'get_object_properties',
+            vim,
+            ds_ref,
+            ['host', 'summary'])
+
+        if not retrieve_result:
+            return None
+
+        props = self._get_object_properties(retrieve_result[0])
+        if ('host' in props and
+                hasattr(props['host'], 'DatastoreHostMount')):
+            props['host'] = props['host'].DatastoreHostMount
+
+        return props
 
     def select_datastore_by_name(self, name):
         """Find a datastore by it's name.
 
             Returns a host_ref and datastore summary.
-        """
 
-        resource_pool = None
-        datastore = None
-        datastores = self._get_datastores()
-        for k, v in datastores.items():
-            if v['summary'].name == name:
-                datastore = v
+        This method uses an optimized query that fetches only the
+        specific datastore needed rather than all datastores in vCenter.
+        """
+        datastore = self._get_datastore_by_name(name)
 
         if not datastore:
             # this shouldn't ever happen as the scheduler told us


### PR DESCRIPTION
Optimize the select_datastore_by_name method to significantly reduce vCenter API load during high-volume operations like boot-from-volume.

Problem:
The original implementation called _get_datastores() which fetches ALL datastores with their 'host' and 'summary' properties. With ~40 datastores and ~50 hosts each, this transferred ~500KB-2MB of data per call. Under high load (e.g., 96 volume creates in 5 minutes), this caused vCenter connection pool exhaustion and cascading timeouts averaging 530 seconds per _select_ds_for_volume call.

Solution:
1. Add _get_datastore_by_name() method that fetches properties for only the specific datastore needed, reducing data transfer to ~10-20KB.

2. Add a 5-minute TTL cache for datastore name -> moref mappings in get_ds_ref_by_name(). Since volume creates are bursty and typically target the same datastores, this eliminates repeated vCenter queries for the lightweight name lookup on cache hits.

3. The host availability check still queries vCenter on every call to ensure we always have fresh data about which hosts are connected and not in maintenance mode.

Performance impact:
- First call: 1 lightweight query (names only) + 1 targeted query
- Subsequent calls (within 5 min): 1 targeted query only (cache hit)
- Original: 1 heavy query fetching all datastores with all host mounts

Change-Id: If9d46fe833418b67393535384af075a95f2ca4cb