### PR TITLE
Netapp: Option to break locks on terminate_connection

### DIFF
--- a/cinder/tests/unit/volume/drivers/netapp/dataontap/client/test_client_cmode_rest.py
+++ b/cinder/tests/unit/volume/drivers/netapp/dataontap/client/test_client_cmode_rest.py
@@ -4105,3 +4105,35 @@ class NetAppRestCmodeClientTestCase(test.TestCase):
         }
         self.client.send_request.assert_called_once_with(
             '/protocols/nvme/subsystem-maps', 'delete', query=query)
+
+    def test_break_locks(self):
+        client_address = '192.168.1.10'
+        path = '/fake_vol/fake_file'
+        lock_uuid = fake_client.FAKE_UUID
+        get_response = {
+            'records': [{'uuid': lock_uuid}],
+            'num_records': 1,
+        }
+        self.mock_object(self.client, 'send_request',
+                         side_effect=[get_response, None])
+
+        self.client.break_locks(client_address, path)
+
+        self.client.send_request.assert_has_calls([
+            mock.call('/protocols/locks', 'get',
+                      query={'client_address': client_address, 'path': path}),
+            mock.call(f'/protocols/locks/{lock_uuid}', 'delete'),
+        ])
+
+    def test_break_locks_no_locks(self):
+        client_address = '192.168.1.10'
+        path = '/fake_vol/fake_file'
+        get_response = {'records': [], 'num_records': 0}
+        self.mock_object(self.client, 'send_request',
+                         return_value=get_response)
+
+        self.client.break_locks(client_address, path)
+
+        self.client.send_request.assert_called_once_with(
+            '/protocols/locks', 'get',
+            query={'client_address': client_address, 'path': path})

--- a/cinder/tests/unit/volume/drivers/netapp/dataontap/test_nfs_cmode.py
+++ b/cinder/tests/unit/volume/drivers/netapp/dataontap/test_nfs_cmode.py
@@ -2388,3 +2388,65 @@ class NetAppCmodeNfsDriverTestCase(test.TestCase):
                          side_effect=side_effect)
 
         self.driver._swap_files(fake.FLEXVOL, fake.VOLUME_NAME, new_file)
+
+    def test_terminate_connection(self):
+        connector = {'ip': fake.FC_CONNECTOR['ip']}
+        ctxt = mock.Mock()
+        vol_fields = {
+            'id': fake.VOLUME_ID,
+            'name': fake.NFS_FILE_PATH,
+            'host': fake.NFS_HOST_STRING,
+            'provider_location': fake.PROVIDER_LOCATION,
+            'provider_id': None,
+        }
+        volume = fake_volume.fake_volume_obj(ctxt, **vol_fields)
+        path = '/%s/%s' % (fake.FLEXVOL, fake.VOLUME_ID)
+        self.driver.configuration.netapp_use_legacy_client = False
+        self.driver.configuration.netapp_nfs_break_locks = True
+
+        self.mock_object(volume_utils, 'resolve_hostname',
+                         return_value=fake.FC_CONNECTOR['ip'])
+        self.mock_object(self.driver, '_get_flexvol_name_for_share',
+                         return_value=fake.FLEXVOL)
+
+        self.driver.terminate_connection(volume, connector)
+
+        volume_utils.resolve_hostname.assert_called_once_with(
+            connector['ip'])
+        self.driver._get_flexvol_name_for_share.assert_called_once_with(
+            fake.NFS_SHARE)
+        self.driver.zapi_client.break_locks.assert_called_once_with(
+            fake.FC_CONNECTOR['ip'], path)
+
+    def test_terminate_connection_provider_id(self):
+        connector = {'ip': fake.FC_CONNECTOR['ip']}
+        prov_id = 'backing-file-name'
+        ctxt = mock.Mock()
+        vol_fields = {
+            'id': fake.VOLUME_ID,
+            'name': fake.NFS_FILE_PATH,
+            'host': fake.NFS_HOST_STRING,
+            'provider_location': fake.PROVIDER_LOCATION,
+            'provider_id': prov_id,
+        }
+        volume = fake_volume.fake_volume_obj(ctxt, **vol_fields)
+        path = '/%s/%s' % (fake.FLEXVOL, prov_id)
+        self.driver.configuration.netapp_use_legacy_client = False
+        self.driver.configuration.netapp_nfs_break_locks = True
+
+        self.mock_object(volume_utils, 'resolve_hostname',
+                         return_value=fake.FC_CONNECTOR['ip'])
+        self.mock_object(self.driver, '_get_flexvol_name_for_share',
+                         return_value=fake.FLEXVOL)
+
+        self.driver.terminate_connection(volume, connector)
+
+        self.driver.zapi_client.break_locks.assert_called_once_with(
+            fake.FC_CONNECTOR['ip'], path)
+
+    def test_terminate_connection_no_connector(self):
+        self.mock_object(self.driver, '_get_flexvol_name_for_share')
+
+        self.driver.terminate_connection(fake.NFS_VOLUME, None)
+
+        self.driver._get_flexvol_name_for_share.assert_not_called()

--- a/cinder/volume/drivers/netapp/dataontap/client/client_cmode_rest.py
+++ b/cinder/volume/drivers/netapp/dataontap/client/client_cmode_rest.py
@@ -2542,6 +2542,22 @@ class RestClient(object):
             f'/storage/volumes/{unique_volume["uuid"]}/files/{orig_file_name}',
             'patch', body=body)
 
+    def break_locks(self, client_address, path):
+        """Break all NFS locks on path held by client_address."""
+        query = {'client_address': client_address, 'path': path}
+        locks = self.send_request(
+            '/protocols/locks', 'get', query=query).get('records', [])
+        # Warning as it should only happen in instance-ha use-case
+        # but not in normal operations
+        for lock in locks:
+            lock_uuid = lock.get('uuid')
+            if not lock_uuid:
+                continue
+            LOG.warning('Breaking NFS lock %s on %s for %s.',
+                        lock_uuid, path, client_address)
+            self.send_request(
+                f'/protocols/locks/{lock_uuid}', 'delete')
+
     def get_namespace_list(self):
         """Gets the list of namespaces on filer.
 

--- a/cinder/volume/drivers/netapp/dataontap/nfs_cmode.py
+++ b/cinder/volume/drivers/netapp/dataontap/nfs_cmode.py
@@ -1336,3 +1336,19 @@ class NetAppCmodeNfsDriver(nfs_base.NetAppNfsDriver,
                           self).initialize_connection(volume, connector)
         conn_info['data']['version'] = self.ATTACHMENT_VERSION
         return conn_info
+
+    def terminate_connection(self, volume, connector, **kwargs):
+        if not connector:
+            return
+        if (self.configuration.netapp_use_legacy_client
+                or not self.configuration.netapp_nfs_break_locks):
+            return
+        srv_ip = volume_utils.resolve_hostname(connector['ip'])
+        prov_id = volume['provider_id']
+        share = volume_utils.extract_host(volume['host'], level='pool')
+        flexvol_name = self._get_flexvol_name_for_share(share)
+        filename = volume.name_id
+        if prov_id:
+            filename = prov_id
+        path = '/%s/%s' % (flexvol_name, filename)
+        self.zapi_client.break_locks(srv_ip, path)

--- a/cinder/volume/drivers/netapp/options.py
+++ b/cinder/volume/drivers/netapp/options.py
@@ -157,7 +157,15 @@ netapp_nfs_extra_opts = [
                      'cinder-volume process to execute the file.'),
                deprecated_for_removal=True,
                deprecated_reason='The CopyOfflload tool is no longer '
-                                 'available for downloading.'), ]
+                                 'available for downloading.'),
+    cfg.BoolOpt('netapp_nfs_break_locks',
+                default=False,
+                help=('When enabled, all NFS locks held by the detaching '
+                      'host on the backing file are broken on '
+                      'terminate_connection. This requires the REST client '
+                      '(netapp_use_legacy_client = False); if the legacy '
+                      'ZAPI client is active this option has no effect.'
+                      'Primary use-case is instance HA failover.')), ]
 netapp_san_opts = [
     cfg.StrOpt('netapp_lun_ostype',
                help=('This option defines the type of operating system that'


### PR DESCRIPTION
Normally, the compute service would remove the volume from the hypervisor, which would in turn release the locks.

But in the case of instance-ha, that is not possible, so either one has to wait for the locks to expire, which delays the recovery or one breaks the locks.

This adds the config option netapp_nfs_break_locks as an opt-in to that behavior. It requires netapp_use_legacy_client to be disabled, as it uses the REST-API.


Change-Id: I77872fff916e461e923f5c953cbdc0a778b637ec