### PR TITLE
Fix fcd.py, the wrong method was called in initialize_connection

### DIFF
--- a/cinder/volume/drivers/vmware/fcd.py
+++ b/cinder/volume/drivers/vmware/fcd.py
@@ -351,7 +351,7 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
                 volume.provider_location
             )
         )
-        summary = self.volumeops.summary(fcd_loc.ds_ref())
+        summary = self.volumeops.get_summary(fcd_loc.ds_ref())
         if summary.type == "NFS41":
             # We connect to KVM not VMware, only if DS is NFS
             if 'connection_capabilities' not in connector:


### PR DESCRIPTION
To get the datastore summary object, the wrong method was called from volumeops, the correct method is
get_summary
So initialize_connection fails.
Change-Id: I079d1b3133a07620dad329b5c79efdb91d6c9cc3