### PR TITLE
[SAP] Fix scheduler handling of empty pools list from backends

### DIFF
--- a/cinder/scheduler/host_manager.py
+++ b/cinder/scheduler/host_manager.py
@@ -251,6 +251,25 @@ class BackendState(object):
                 cur_pool.update_from_volume_capability(pool_cap, service)
 
                 active_pools.add(pool_name)
+        elif isinstance(pools, list) and len(pools) == 0:
+            # Driver supports pools but reported none (e.g. vCenter
+            # connectivity issue). Preserve existing pools but mark
+            # them down so the scheduler won't place volumes on them.
+            # Without this branch, an empty list [] evaluates to False
+            # and skips the first branch, but is not None so skips
+            # the legacy branch too -- leaving active_pools empty and
+            # wiping all cached pools. On the next stats report, if
+            # pools is still empty or None, the legacy path creates a
+            # single synthetic pool named after volume_backend_name
+            # (e.g. #vmware). Volumes scheduled to this synthetic
+            # pool can never be created because it does not correspond
+            # to any real datastore.
+            LOG.warning("Backend %(host)s reported an empty pools list. "
+                        "Marking all pools as down.",
+                        {'host': self.host})
+            for pool_name, pool in self.pools.items():
+                pool.pool_state = 'down'
+                active_pools.add(pool_name)
         elif pools is None:
             # To handle legacy driver that doesn't report pool
             # information in the capability, we have to prepare


### PR DESCRIPTION
When a backend reports an empty pools list [] (e.g. due to a vCenter connectivity issue), the scheduler would wipe all cached pools and later create a synthetic pool that doesn't correspond to any real datastore, causing volume creation failures.

Mark all existing pools as down instead, so the scheduler preserves pool state and avoids scheduling to nonexistent pools.

Change-Id: If6e349fdc5725169e922ac2b1aa2f85effaf43c0