### PR TITLE
[SAP] Add aggregate_id support to NetApp NFS driver for scheduler aggregate volumes

### DIFF
--- a/cinder/api/contrib/sap.py
+++ b/cinder/api/contrib/sap.py
@@ -61,6 +61,23 @@ schema_set_pool_state = {
     'additionalProperties': False,
 }
 
+schema_set_aggregate_id = {
+    'type': 'object',
+    'properties': {
+        'host': parameter_types.cinder_host,
+        'aggregate_id': {'type': ['string', 'null']},
+    },
+    'additionalProperties': False,
+}
+
+schema_get_aggregate_id = {
+    'type': 'object',
+    'properties': {
+        'host': parameter_types.cinder_host,
+    },
+    'additionalProperties': False,
+}
+
 
 # The validator for the pool status in the set_pool_state API
 @jsonschema.FormatChecker.cls_checks('pool_status')
@@ -107,6 +124,10 @@ class SAPContribController(wsgi.Controller):
             return self._recount_host_stats(req, context, body=body)
         elif id == "set_pool_state":
             return self._set_pool_state(req, context, body=body)
+        elif id == "set_aggregate_id":
+            return self._set_aggregate_id(req, context, body=body)
+        elif id == "get_aggregate_id":
+            return self._get_aggregate_id(req, context, body=body)
         else:
             raise exception.InvalidInput(reason=_("Unknown action"))
 
@@ -149,6 +170,30 @@ class SAPContribController(wsgi.Controller):
         self._volume_api_proxy(self.volume_api.set_pool_state,
                                context, host, update['status'])
         return webob.Response(status_int=HTTPStatus.ACCEPTED)
+
+    @validation.schema(schema_set_aggregate_id)
+    @volume_utils.trace
+    def _set_aggregate_id(self, req, context, body):
+        """Set the aggregate_id for a pool."""
+        cluster_name, host = common.get_cluster_host(req, body,
+                                                     mv.REPLICATION_CLUSTER)
+        aggregate_id = body.get('aggregate_id', None)
+
+        self._volume_api_proxy(self.volume_api.set_aggregate_id,
+                               context, host, aggregate_id)
+        return webob.Response(status_int=HTTPStatus.ACCEPTED)
+
+    @validation.schema(schema_get_aggregate_id)
+    @volume_utils.trace
+    def _get_aggregate_id(self, req, context, body):
+        """Get the aggregate_id for a pool from the backend driver."""
+        cluster_name, host = common.get_cluster_host(req, body,
+                                                     mv.REPLICATION_CLUSTER)
+        aggregate_id = self._volume_api_proxy(
+            self.volume_api.get_aggregate_id, context, host)
+
+        resp_body = {'host': host, 'aggregate_id': aggregate_id}
+        return {'aggregate_info': resp_body}
 
 
 class Sap(extensions.ExtensionDescriptor):

--- a/cinder/policies/sap.py
+++ b/cinder/policies/sap.py
@@ -19,6 +19,8 @@ from cinder.policies import base
 
 
 SET_POOL_STATE_POLICY = "sap:set_pool_state"
+SET_AGGREGATE_ID_POLICY = "sap:set_aggregate_id"
+GET_AGGREGATE_ID_POLICY = "sap:get_aggregate_id"
 RECOUNT_STATS_POLICY = "sap:recount_host_stats"
 
 sap_policies = [
@@ -40,6 +42,26 @@ sap_policies = [
             {
                 'method': 'PUT',
                 'path': '/os-sap-contrib/set_pool_state'
+            }
+        ]),
+    policy.DocumentedRuleDefault(
+        name=SET_AGGREGATE_ID_POLICY,
+        check_str=base.RULE_ADMIN_API,
+        description="Set or remove the aggregate_id for a pool",
+        operations=[
+            {
+                'method': 'PUT',
+                'path': '/os-sap-contrib/set_aggregate_id'
+            }
+        ]),
+    policy.DocumentedRuleDefault(
+        name=GET_AGGREGATE_ID_POLICY,
+        check_str=base.RULE_ADMIN_API,
+        description="Get the aggregate_id for a pool",
+        operations=[
+            {
+                'method': 'PUT',
+                'path': '/os-sap-contrib/get_aggregate_id'
             }
         ]),
 ]

--- a/cinder/tests/unit/scheduler/test_host_manager_aggregate.py
+++ b/cinder/tests/unit/scheduler/test_host_manager_aggregate.py
@@ -1,0 +1,395 @@
+# Copyright (c) 2025 SAP Corporation
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#    implied. See the License for the specific language governing
+#    permissions and limitations under the License.
+
+"""Tests for the scheduler aggregate pool feature in HostManager."""
+
+from unittest import mock
+
+from cinder.scheduler import host_manager
+from cinder.tests.unit import test
+
+
+class PropagateAggregateStatsTestCase(test.TestCase):
+    """Tests for HostManager._propagate_aggregate_stats."""
+
+    def setUp(self):
+        super(PropagateAggregateStatsTestCase, self).setUp()
+        self.host_manager = host_manager.HostManager()
+
+    def test_propagate_single_backend_pooled(self):
+        """First backend reporting an aggregate_id — no other backends yet."""
+        capabilities = {
+            'pools': [{
+                'pool_name': 'ds-nfs-01',
+                'aggregate_id': 'shared-ds-001',
+                'allocated_capacity_gb': 100,
+            }]
+        }
+        result = self.host_manager._propagate_aggregate_stats(
+            'fcd-vc01', capabilities)
+
+        # No other backends, so allocated_capacity_gb stays at 100
+        self.assertEqual(100, result['pools'][0]['allocated_capacity_gb'])
+        # Verify it was saved in aggregate_service_states
+        self.assertIn('fcd-vc01',
+                      self.host_manager.aggregate_service_states)
+        self.assertEqual(
+            100,
+            self.host_manager.aggregate_service_states[
+                'fcd-vc01']['shared-ds-001']['allocated_capacity_gb'])
+
+    def test_propagate_two_fcd_backends_same_aggregate(self):
+        """Two FCD backends sharing the same aggregate_id."""
+        # First backend reports
+        caps_vc01 = {
+            'pools': [{
+                'pool_name': 'ds-nfs-01',
+                'aggregate_id': 'shared-ds-001',
+                'allocated_capacity_gb': 100,
+            }]
+        }
+        self.host_manager._propagate_aggregate_stats('fcd-vc01', caps_vc01)
+
+        # Second backend reports
+        caps_vc02 = {
+            'pools': [{
+                'pool_name': 'ds-nfs-01',
+                'aggregate_id': 'shared-ds-001',
+                'allocated_capacity_gb': 50,
+            }]
+        }
+        result = self.host_manager._propagate_aggregate_stats(
+            'fcd-vc02', caps_vc02)
+
+        # Second backend should see 50 (own) + 100 (from vc01) = 150
+        self.assertEqual(
+            150, result['pools'][0]['allocated_capacity_gb'])
+
+    def test_propagate_cross_driver_fcd_and_netapp(self):
+        """FCD and NetApp backends sharing the same aggregate_id.
+
+        This is the key scenario: a NetApp NFS pool and a VMware FCD pool
+        both point to the same physical storage via aggregate_id.
+        """
+        # NetApp backend reports first (it now sets has_aggregate_pool)
+        caps_netapp = {
+            'pools': [{
+                'pool_name': '10.10.10.10:/vola',
+                'aggregate_id': 'shared-ds-001',
+                'allocated_capacity_gb': 200,
+            }]
+        }
+        self.host_manager._propagate_aggregate_stats(
+            'netapp-nfs-01', caps_netapp)
+
+        # FCD backend reports second
+        caps_fcd = {
+            'pools': [{
+                'pool_name': 'ds-nfs-01',
+                'aggregate_id': 'shared-ds-001',
+                'allocated_capacity_gb': 100,
+            }]
+        }
+        result = self.host_manager._propagate_aggregate_stats(
+            'fcd-vc01', caps_fcd)
+
+        # FCD should see 100 (own) + 200 (from NetApp) = 300
+        self.assertEqual(
+            300, result['pools'][0]['allocated_capacity_gb'])
+
+    def test_propagate_bidirectional_update(self):
+        """Both backends update each other across successive stats cycles."""
+        # First cycle: NetApp reports
+        caps_netapp_1 = {
+            'pools': [{
+                'pool_name': '10.10.10.10:/vola',
+                'aggregate_id': 'shared-ds-001',
+                'allocated_capacity_gb': 200,
+            }]
+        }
+        self.host_manager._propagate_aggregate_stats(
+            'netapp-nfs-01', caps_netapp_1)
+
+        # First cycle: FCD reports (picks up NetApp's 200)
+        caps_fcd_1 = {
+            'pools': [{
+                'pool_name': 'ds-nfs-01',
+                'aggregate_id': 'shared-ds-001',
+                'allocated_capacity_gb': 100,
+            }]
+        }
+        result_fcd = self.host_manager._propagate_aggregate_stats(
+            'fcd-vc01', caps_fcd_1)
+        self.assertEqual(
+            300, result_fcd['pools'][0]['allocated_capacity_gb'])
+
+        # Second cycle: NetApp reports again (should pick up FCD's 100)
+        caps_netapp_2 = {
+            'pools': [{
+                'pool_name': '10.10.10.10:/vola',
+                'aggregate_id': 'shared-ds-001',
+                'allocated_capacity_gb': 210,
+            }]
+        }
+        result_netapp = self.host_manager._propagate_aggregate_stats(
+            'netapp-nfs-01', caps_netapp_2)
+        # NetApp should see 210 (own) + 100 (FCD's last reported) = 310
+        self.assertEqual(
+            310, result_netapp['pools'][0]['allocated_capacity_gb'])
+
+    def test_propagate_different_aggregate_ids(self):
+        """Backends with different aggregate_ids don't affect each other."""
+        caps_a = {
+            'pools': [{
+                'pool_name': 'ds-nfs-01',
+                'aggregate_id': 'agg-A',
+                'allocated_capacity_gb': 100,
+            }]
+        }
+        self.host_manager._propagate_aggregate_stats('backend-a', caps_a)
+
+        caps_b = {
+            'pools': [{
+                'pool_name': 'ds-nfs-02',
+                'aggregate_id': 'agg-B',
+                'allocated_capacity_gb': 50,
+            }]
+        }
+        result = self.host_manager._propagate_aggregate_stats(
+            'backend-b', caps_b)
+
+        # Should stay at 50 - different aggregate_id
+        self.assertEqual(
+            50, result['pools'][0]['allocated_capacity_gb'])
+
+    def test_propagate_pool_without_aggregate_id_ignored(self):
+        """Pools without aggregate_id should be untouched."""
+        caps = {
+            'pools': [
+                {
+                    'pool_name': 'ds-nfs-01',
+                    'aggregate_id': 'shared-ds-001',
+                    'allocated_capacity_gb': 100,
+                },
+                {
+                    'pool_name': 'ds-nfs-02',
+                    'allocated_capacity_gb': 50,
+                },
+            ]
+        }
+        result = self.host_manager._propagate_aggregate_stats(
+            'backend-a', caps)
+
+        # Pool without aggregate_id should be unchanged
+        self.assertEqual(50, result['pools'][1]['allocated_capacity_gb'])
+
+    def test_propagate_non_pooled_backend(self):
+        """Test non-pooled backend (aggregate_id at top level)."""
+        caps = {
+            'aggregate_id': 'shared-ds-001',
+            'allocated_capacity_gb': 100,
+        }
+        result = self.host_manager._propagate_aggregate_stats(
+            'backend-a', caps)
+
+        self.assertEqual(100, result['allocated_capacity_gb'])
+        self.assertIn('backend-a',
+                      self.host_manager.aggregate_service_states)
+
+
+class ConsumeFromVolumeAggregateTestCase(test.TestCase):
+    """Tests for HostManager.consume_from_volume_aggregate."""
+
+    def setUp(self):
+        super(ConsumeFromVolumeAggregateTestCase, self).setUp()
+        self.host_manager = host_manager.HostManager()
+
+    def test_consume_no_aggregate_states(self):
+        """Backend not in aggregate_service_states -> no-op."""
+        backend = mock.Mock()
+        backend.host = 'host@backend-a#pool1'
+
+        # Should not raise
+        self.host_manager.consume_from_volume_aggregate(backend, 10)
+
+    def test_consume_propagates_to_matching_pools(self):
+        """Consuming from one pool propagates to all with same agg_id."""
+        # Set up aggregate_service_states (normally done by _propagate)
+        # Keys are the backend portion of host string (host@backend)
+        self.host_manager.aggregate_service_states = {
+            'host@fcd-vc01': {
+                'shared-ds-001': {
+                    'allocated_capacity_gb': 100,
+                    'pool_name': 'ds-nfs-01',
+                },
+            },
+        }
+
+        # Set up backend_state_map with two backends sharing aggregate_id
+        fcd_caps = {
+            'aggregate_id': 'shared-ds-001',
+            'total_capacity_gb': 500,
+            'free_capacity_gb': 400,
+            'allocated_capacity_gb': 100,
+            'reserved_percentage': 0,
+            'max_over_subscription_ratio': 1.0,
+            'thin_provisioning_support': False,
+            'thick_provisioning_support': True,
+            'provisioned_capacity_gb': 100,
+            'timestamp': None,
+            'pool_name': 'ds-nfs-01',
+        }
+        netapp_caps = {
+            'aggregate_id': 'shared-ds-001',
+            'total_capacity_gb': 500,
+            'free_capacity_gb': 300,
+            'allocated_capacity_gb': 200,
+            'reserved_percentage': 0,
+            'max_over_subscription_ratio': 1.0,
+            'thin_provisioning_support': False,
+            'thick_provisioning_support': True,
+            'provisioned_capacity_gb': 200,
+            'timestamp': None,
+            'pool_name': '10.10.10.10:/vola',
+        }
+
+        fcd_state = host_manager.BackendState('host@fcd-vc01', None)
+        fcd_pool = host_manager.PoolState(
+            'host@fcd-vc01', None, fcd_caps, 'ds-nfs-01')
+        fcd_pool.update_from_volume_capability(fcd_caps)
+        fcd_state.pools['ds-nfs-01'] = fcd_pool
+
+        netapp_state = host_manager.BackendState('host@netapp-nfs-01', None)
+        netapp_pool = host_manager.PoolState(
+            'host@netapp-nfs-01', None, netapp_caps, '10.10.10.10:/vola')
+        netapp_pool.update_from_volume_capability(netapp_caps)
+        netapp_state.pools['10.10.10.10:/vola'] = netapp_pool
+
+        self.host_manager.backend_state_map = {
+            'host@fcd-vc01': fcd_state,
+            'host@netapp-nfs-01': netapp_state,
+        }
+
+        # Simulate scheduling a 10GB volume to fcd-vc01#ds-nfs-01
+        backend = mock.Mock()
+        backend.host = 'host@fcd-vc01#ds-nfs-01'
+
+        self.host_manager.consume_from_volume_aggregate(backend, 10)
+
+        # The NetApp pool should have its allocated_capacity_gb increased
+        self.assertEqual(210, netapp_pool.allocated_capacity_gb)
+
+    def test_consume_skips_pools_without_matching_agg_id(self):
+        """Pools with different or no aggregate_id not affected."""
+        self.host_manager.aggregate_service_states = {
+            'host@backend-a': {
+                'agg-A': {
+                    'allocated_capacity_gb': 100,
+                    'pool_name': 'pool-a',
+                },
+            },
+        }
+
+        caps_a = {
+            'aggregate_id': 'agg-A',
+            'total_capacity_gb': 500,
+            'free_capacity_gb': 400,
+            'allocated_capacity_gb': 100,
+            'reserved_percentage': 0,
+            'max_over_subscription_ratio': 1.0,
+            'thin_provisioning_support': False,
+            'thick_provisioning_support': True,
+            'provisioned_capacity_gb': 100,
+            'timestamp': None,
+            'pool_name': 'pool-a',
+        }
+        caps_b = {
+            'aggregate_id': 'agg-B',
+            'total_capacity_gb': 500,
+            'free_capacity_gb': 400,
+            'allocated_capacity_gb': 100,
+            'reserved_percentage': 0,
+            'max_over_subscription_ratio': 1.0,
+            'thin_provisioning_support': False,
+            'thick_provisioning_support': True,
+            'provisioned_capacity_gb': 100,
+            'timestamp': None,
+            'pool_name': 'pool-b',
+        }
+
+        state_a = host_manager.BackendState('host@backend-a', None)
+        pool_a = host_manager.PoolState(
+            'host@backend-a', None, caps_a, 'pool-a')
+        pool_a.update_from_volume_capability(caps_a)
+        state_a.pools['pool-a'] = pool_a
+
+        state_b = host_manager.BackendState('host@backend-b', None)
+        pool_b = host_manager.PoolState(
+            'host@backend-b', None, caps_b, 'pool-b')
+        pool_b.update_from_volume_capability(caps_b)
+        state_b.pools['pool-b'] = pool_b
+
+        self.host_manager.backend_state_map = {
+            'host@backend-a': state_a,
+            'host@backend-b': state_b,
+        }
+
+        backend = mock.Mock()
+        backend.host = 'host@backend-a#pool-a'
+
+        self.host_manager.consume_from_volume_aggregate(backend, 10)
+
+        # backend-b should NOT be affected (different agg_id)
+        self.assertEqual(100, pool_b.allocated_capacity_gb)
+
+
+class UpdateServiceCapabilitiesAggregateTestCase(test.TestCase):
+    """Tests for the has_aggregate_pool gate in update_service_capabilities."""
+
+    def setUp(self):
+        super(UpdateServiceCapabilitiesAggregateTestCase, self).setUp()
+        self.host_manager = host_manager.HostManager()
+
+    @mock.patch.object(host_manager.HostManager,
+                       '_propagate_aggregate_stats')
+    def test_aggregate_pool_triggers_propagation(self, mock_propagate):
+        """has_aggregate_pool=True triggers _propagate_aggregate_stats."""
+        mock_propagate.return_value = {}
+        capabilities = {
+            'has_aggregate_pool': True,
+            'pools': [{'pool_name': 'p1', 'aggregate_id': 'agg-1',
+                       'allocated_capacity_gb': 100}],
+            'timestamp': None,
+        }
+
+        self.host_manager.update_service_capabilities(
+            'volume', 'host@backend', capabilities, None, None)
+
+        mock_propagate.assert_called_once()
+
+    @mock.patch.object(host_manager.HostManager,
+                       '_propagate_aggregate_stats')
+    def test_no_aggregate_pool_skips_propagation(self, mock_propagate):
+        """has_aggregate_pool=False does not trigger propagation."""
+        capabilities = {
+            'pools': [{'pool_name': 'p1',
+                       'allocated_capacity_gb': 100}],
+            'timestamp': None,
+        }
+
+        self.host_manager.update_service_capabilities(
+            'volume', 'host@backend', capabilities, None, None)
+
+        mock_propagate.assert_not_called()

--- a/cinder/tests/unit/volume/drivers/netapp/dataontap/test_nfs_cmode.py
+++ b/cinder/tests/unit/volume/drivers/netapp/dataontap/test_nfs_cmode.py
@@ -14,6 +14,7 @@
 #    under the License.
 """Mock unit tests for the NetApp cmode nfs storage driver."""
 
+import json
 from unittest import mock
 import uuid
 
@@ -141,6 +142,7 @@ class NetAppCmodeNfsDriverTestCase(test.TestCase):
         self.mock_object(self.driver, '_get_pool_stats', return_value={})
         expected_stats = {
             'driver_version': self.driver.VERSION,
+            'has_aggregate_pool': False,
             'netapp_server_hostname': '127.0.0.1',
             'pools': {},
             'sparse_copy_volume': True,
@@ -311,6 +313,199 @@ class NetAppCmodeNfsDriverTestCase(test.TestCase):
         if cluster_credentials:
             mock_get_aggrs.assert_called_once_with()
             mock_get_aggr_capacities.assert_called_once_with(['aggr1'])
+
+    def test_get_pool_stats_with_aggregate_id(self):
+        """Test that aggregate_id from comment field appears in pool stats."""
+        self.driver.using_cluster_credentials = True
+        conf = self.driver.configuration
+        conf.netapp_driver_reports_provisioned_capacity = False
+        self.driver.zapi_client = mock.Mock()
+        ssc = {
+            'vola': {
+                'pool_name': '10.10.10.10:/vola',
+                'thick_provisioning_support': True,
+                'thin_provisioning_support': False,
+                'netapp_thin_provisioned': 'false',
+                'netapp_compression': 'false',
+                'netapp_mirrored': 'false',
+                'netapp_dedup': 'true',
+                'netapp_aggregate': 'aggr1',
+                'netapp_raid_type': 'raid_dp',
+                'netapp_disk_type': 'SSD',
+                'consistent_group_snapshot_enabled': True,
+                'netapp_is_flexgroup': 'false',
+            },
+        }
+        self.mock_object(self.driver.ssc_library, 'get_ssc',
+                         return_value=ssc)
+        self.mock_object(self.driver.ssc_library, 'get_ssc_aggregates',
+                         return_value=['aggr1'])
+        self.mock_object(self.driver, 'get_replication_backend_names',
+                         return_value=[])
+
+        capacity = {
+            'reserved_percentage': fake.RESERVED_PERCENTAGE,
+            'max_over_subscription_ratio': fake.MAX_OVER_SUBSCRIPTION_RATIO,
+            'total_capacity_gb': 100.0,
+            'free_capacity_gb': 80.0,
+        }
+        self.mock_object(self.driver, '_get_share_capacity_info',
+                         return_value=capacity)
+        self.mock_object(self.driver.zapi_client,
+                         'get_flexvol_dedupe_used_percent',
+                         return_value=55.0)
+        aggr_capacities = {
+            'aggr1': {
+                'percent-used': 45,
+                'size-available': 59055800320.0,
+                'size-total': 107374182400.0,
+            },
+        }
+        self.mock_object(self.driver.zapi_client, 'get_aggregate_capacities',
+                         return_value=aggr_capacities)
+        self.driver.perf_library.get_node_utilization_for_pool = (
+            mock.Mock(return_value=30.0))
+
+        # Mock the comment field to return an aggregate_id
+        self.mock_object(
+            self.driver, '_get_volume_comment',
+            return_value={'pool_state': 'up', 'pool_down_reason': '',
+                          'aggregate_id': 'shared-ds-001'})
+
+        result = self.driver._get_pool_stats(filter_function='filter',
+                                             goodness_function='goodness')
+
+        self.assertEqual('shared-ds-001', result[0]['aggregate_id'])
+
+    def test_update_volume_stats_has_aggregate_pool(self):
+        """Test that has_aggregate_pool is set when pools have aggregate_id."""
+        pool_with_agg = {
+            'pool_name': '10.10.10.10:/vola',
+            'aggregate_id': 'shared-ds-001',
+        }
+        pool_without_agg = {
+            'pool_name': '10.10.10.10:/volb',
+        }
+        self.mock_object(self.driver, '_get_pool_stats',
+                         return_value=[pool_with_agg, pool_without_agg])
+        self.mock_object(self.driver, 'get_filter_function',
+                         return_value=None)
+        self.mock_object(self.driver, 'get_goodness_function',
+                         return_value=None)
+
+        self.driver._update_volume_stats()
+
+        self.assertTrue(self.driver._stats['has_aggregate_pool'])
+
+    def test_update_volume_stats_no_aggregate_pool(self):
+        """Test has_aggregate_pool is False when no pools have aggregate_id."""
+        pool_without_agg = {
+            'pool_name': '10.10.10.10:/vola',
+        }
+        self.mock_object(self.driver, '_get_pool_stats',
+                         return_value=[pool_without_agg])
+        self.mock_object(self.driver, 'get_filter_function',
+                         return_value=None)
+        self.mock_object(self.driver, 'get_goodness_function',
+                         return_value=None)
+
+        self.driver._update_volume_stats()
+
+        self.assertFalse(self.driver._stats.get('has_aggregate_pool', False))
+
+    def test_set_pool_state_preserves_existing_comment(self):
+        """Test that set_pool_state does not blow away other comment fields."""
+        self.driver.zapi_client = mock.Mock()
+        # Existing comment has an aggregate_id
+        self.driver.zapi_client.get_volume_comment = mock.Mock(
+            return_value='{"aggregate_id": "shared-ds-001"}')
+        self.driver.zapi_client.set_volume_comment = mock.Mock()
+
+        self.driver.set_pool_state('10.10.10.10:/vola', 'down',
+                                   'pool marked as draining')
+
+        # Verify the aggregate_id was preserved
+        call_args = self.driver.zapi_client.set_volume_comment.call_args
+        written_json = json.loads(call_args[0][1])
+        self.assertEqual('shared-ds-001', written_json['aggregate_id'])
+        self.assertEqual('down', written_json['pool_state'])
+        self.assertEqual('pool marked as draining',
+                         written_json['pool_down_reason'])
+
+    def test_set_aggregate_id(self):
+        """Test setting aggregate_id in the flexvol comment field."""
+        self.driver.zapi_client = mock.Mock()
+        self.driver.zapi_client.get_volume_comment = mock.Mock(
+            return_value='{"pool_state": "up", "pool_down_reason": ""}')
+        self.driver.zapi_client.set_volume_comment = mock.Mock()
+
+        self.driver.set_aggregate_id('10.10.10.10:/vola', 'shared-ds-001')
+
+        # Verify it merged into existing comment JSON
+        call_args = self.driver.zapi_client.set_volume_comment.call_args
+        written_json = json.loads(call_args[0][1])
+        self.assertEqual('shared-ds-001', written_json['aggregate_id'])
+        self.assertEqual('up', written_json['pool_state'])
+        self.assertEqual('', written_json['pool_down_reason'])
+
+    def test_set_aggregate_id_no_existing_comment(self):
+        """Test setting aggregate_id when no existing comment exists."""
+        self.driver.zapi_client = mock.Mock()
+        self.driver.zapi_client.get_volume_comment = mock.Mock(
+            return_value=None)
+        self.driver.zapi_client.set_volume_comment = mock.Mock()
+
+        self.driver.set_aggregate_id('10.10.10.10:/vola', 'shared-ds-001')
+
+        call_args = self.driver.zapi_client.set_volume_comment.call_args
+        written_json = json.loads(call_args[0][1])
+        self.assertEqual('shared-ds-001', written_json['aggregate_id'])
+
+    def test_remove_aggregate_id(self):
+        """Test removing aggregate_id by passing None."""
+        self.driver.zapi_client = mock.Mock()
+        self.driver.zapi_client.get_volume_comment = mock.Mock(
+            return_value='{"pool_state": "up", "pool_down_reason": "", '
+                         '"aggregate_id": "shared-ds-001"}')
+        self.driver.zapi_client.set_volume_comment = mock.Mock()
+
+        self.driver.set_aggregate_id('10.10.10.10:/vola', None)
+
+        call_args = self.driver.zapi_client.set_volume_comment.call_args
+        written_json = json.loads(call_args[0][1])
+        self.assertNotIn('aggregate_id', written_json)
+        self.assertEqual('up', written_json['pool_state'])
+
+    def test_get_aggregate_id(self):
+        """Test getting aggregate_id from the flexvol comment field."""
+        self.driver.zapi_client = mock.Mock()
+        self.driver.zapi_client.get_volume_comment = mock.Mock(
+            return_value='{"pool_state": "up", "aggregate_id": '
+                         '"shared-ds-001"}')
+
+        result = self.driver.get_aggregate_id('10.10.10.10:/vola')
+
+        self.assertEqual('shared-ds-001', result)
+
+    def test_get_aggregate_id_not_set(self):
+        """Test getting aggregate_id when none is set."""
+        self.driver.zapi_client = mock.Mock()
+        self.driver.zapi_client.get_volume_comment = mock.Mock(
+            return_value='{"pool_state": "up"}')
+
+        result = self.driver.get_aggregate_id('10.10.10.10:/vola')
+
+        self.assertIsNone(result)
+
+    def test_get_aggregate_id_no_comment(self):
+        """Test getting aggregate_id when no comment exists."""
+        self.driver.zapi_client = mock.Mock()
+        self.driver.zapi_client.get_volume_comment = mock.Mock(
+            return_value=None)
+
+        result = self.driver.get_aggregate_id('10.10.10.10:/vola')
+
+        self.assertIsNone(result)
 
     @ddt.data({}, None)
     def test_get_pool_stats_no_ssc_vols(self, ssc):

--- a/cinder/volume/api.py
+++ b/cinder/volume/api.py
@@ -2497,6 +2497,18 @@ class API(base.Base):
         ctxt = ctxt if ctxt.is_admin else ctxt.elevated()
         self.volume_rpcapi.set_pool_state(ctxt, host, status)
 
+    def set_aggregate_id(self, ctxt, host, aggregate_id):
+        """SAP.  Set the aggregate_id for the host/pool."""
+        ctxt.authorize(sap_policy.SET_AGGREGATE_ID_POLICY)
+        ctxt = ctxt if ctxt.is_admin else ctxt.elevated()
+        self.volume_rpcapi.set_aggregate_id(ctxt, host, aggregate_id)
+
+    def get_aggregate_id(self, ctxt, host):
+        """SAP.  Get the aggregate_id for the host/pool."""
+        ctxt.authorize(sap_policy.GET_AGGREGATE_ID_POLICY)
+        ctxt = ctxt if ctxt.is_admin else ctxt.elevated()
+        return self.volume_rpcapi.get_aggregate_id(ctxt, host)
+
     def check_volume_filters(self,
                              filters: dict,
                              strict: bool = False) -> None:

--- a/cinder/volume/drivers/netapp/dataontap/client/client_cmode_rest.py
+++ b/cinder/volume/drivers/netapp/dataontap/client/client_cmode_rest.py
@@ -2848,5 +2848,5 @@ class RestClient(object):
                                              'get', query=query)
         LOG.info('Volumes response: %s', volumes_response)
         if (volumes_response and volumes_response.get('num_records', 0) > 0):
-            return volumes_response['records'][0]['comment']
+            return volumes_response['records'][0].get('comment')
         return None

--- a/cinder/volume/drivers/netapp/dataontap/nfs_cmode.py
+++ b/cinder/volume/drivers/netapp/dataontap/nfs_cmode.py
@@ -333,26 +333,83 @@ class NetAppCmodeNfsDriver(nfs_base.NetAppNfsDriver,
 
     @volume_utils.trace
     def set_pool_state(self, pool_name, state, state_reason):
-        """Set the pool state for the volume."""
+        """Set the pool state for the volume.
 
+        Reads the existing comment JSON first to preserve any other
+        fields (e.g., aggregate_id), then merges the pool_state and
+        pool_down_reason fields, and writes back.
+        """
         # The pool_name is in the format of
         # <ip_address>:/<volume_name>   or
         # <ip_address>:<volume_name>/<qtree_name>
         # We have to extract the volume_name from the pool_name.
         volume_name = pool_name.split('/')[1]
 
-        pool_json = json.dumps(
-            {'pool_state': state, 'pool_down_reason': state_reason}
-        )
+        # Read existing comment to preserve other fields
+        existing = self._get_volume_comment(volume_name) or {}
+
+        existing['pool_state'] = state
+        existing['pool_down_reason'] = state_reason
+
+        pool_json = json.dumps(existing)
         LOG.info("Setting pool state for %s to '%s'", volume_name, pool_json)
 
-        # Set a json string in the comment field to keep track
-        # of the pool state and the reason for the pool state.
         if hasattr(self.zapi_client, 'set_volume_comment'):
             self.zapi_client.set_volume_comment(volume_name, pool_json)
         else:
             LOG.warning("Driver %s can't set the pool state",
                         self.driver_name)
+
+    @volume_utils.trace
+    def set_aggregate_id(self, pool_name, aggregate_id):
+        """Set or remove the aggregate_id in the flexvol comment field.
+
+        The aggregate_id is stored as part of the JSON comment on the
+        NetApp flexvol. This is used by the scheduler to aggregate
+        allocated capacity across backends sharing the same physical
+        storage.
+
+        :param pool_name: NFS share path (e.g., '10.10.10.10:/vola')
+        :param aggregate_id: The aggregate ID string, or None to remove it
+        """
+        volume_name = pool_name.split('/')[1]
+
+        # Read existing comment to preserve other fields (pool_state, etc.)
+        existing = self._get_volume_comment(volume_name) or {}
+
+        if aggregate_id:
+            existing['aggregate_id'] = aggregate_id
+        else:
+            existing.pop('aggregate_id', None)
+
+        comment_json = json.dumps(existing)
+        LOG.info("Setting aggregate_id for %s to '%s'",
+                 volume_name, aggregate_id)
+
+        if hasattr(self.zapi_client, 'set_volume_comment'):
+            self.zapi_client.set_volume_comment(volume_name, comment_json)
+        else:
+            LOG.warning("Driver %s can't set the aggregate_id",
+                        self.driver_name)
+
+    @volume_utils.trace
+    def get_aggregate_id(self, pool_name):
+        """Get the aggregate_id from the flexvol comment field.
+
+        :param pool_name: NFS share path (e.g., '10.10.10.10:/vola')
+        :returns: The aggregate_id string, or None if not set
+        """
+        volume_name = pool_name.split('/')[1]
+
+        if hasattr(self.zapi_client, 'get_volume_comment'):
+            raw = self.zapi_client.get_volume_comment(volume_name)
+            if raw:
+                try:
+                    info = json.loads(raw)
+                    return info.get('aggregate_id')
+                except Exception:
+                    return None
+        return None
 
     def _update_volume_stats(self):
         """Retrieve stats info from vserver."""
@@ -370,6 +427,16 @@ class NetAppCmodeNfsDriver(nfs_base.NetAppNfsDriver,
             filter_function=self.get_filter_function(),
             goodness_function=self.get_goodness_function())
         data['sparse_copy_volume'] = True
+
+        # SAP: Check if any pool has an aggregate_id set.
+        # This tells the scheduler to run _propagate_aggregate_stats
+        # to sum allocated capacity across backends sharing an aggregate.
+        has_aggregate_pool = False
+        for pool in data['pools']:
+            if pool.get('aggregate_id'):
+                has_aggregate_pool = True
+                break
+        data['has_aggregate_pool'] = has_aggregate_pool
 
         # Used for service state report
         data['replication_enabled'] = self.replication_enabled
@@ -502,6 +569,13 @@ class NetAppCmodeNfsDriver(nfs_base.NetAppNfsDriver,
             if pool_info:
                 pool['pool_state'] = pool_info.get('pool_state', 'up')
                 pool['pool_down_reason'] = pool_info.get('pool_down_reason')
+                # SAP: Check if an aggregate_id is set in the comment.
+                # This is used by the scheduler to aggregate allocated
+                # capacity across multiple backends sharing the same
+                # physical storage (e.g., NetApp NFS + VMware FCD).
+                agg_id = pool_info.get('aggregate_id')
+                if agg_id:
+                    pool['aggregate_id'] = agg_id
             LOG.info('Pool state for volume %s: %s',
                      ssc_vol_name, pool['pool_state'])
 

--- a/cinder/volume/manager.py
+++ b/cinder/volume/manager.py
@@ -696,6 +696,57 @@ class VolumeManager(manager.CleanableManager,
                 self.driver.__class__.__name__
             )
 
+    def set_aggregate_id(self, context, host, aggregate_id):
+        """Set the aggregate_id for a pool on this backend.
+
+        The aggregate_id is used by the scheduler to aggregate allocated
+        capacity across multiple backends sharing the same physical storage.
+        """
+        requested_pool_name = volume_utils.extract_host(host, 'pool')
+        LOG.info(
+            "Setting aggregate_id for pool '%s' to '%s'",
+            requested_pool_name,
+            aggregate_id,
+        )
+
+        # Update in-memory stats
+        for pool_name in self.stats['pools']:
+            pool = self.stats['pools'][pool_name]
+            if pool_name == requested_pool_name:
+                if aggregate_id:
+                    pool['aggregate_id'] = aggregate_id
+                else:
+                    pool.pop('aggregate_id', None)
+
+        # Persist to the driver's storage (flexvol comment field)
+        if hasattr(self.driver, 'set_aggregate_id'):
+            self.driver.set_aggregate_id(
+                requested_pool_name,
+                aggregate_id,
+            )
+        else:
+            LOG.warning(
+                "Driver %s does not support setting aggregate_id.",
+                self.driver.__class__.__name__
+            )
+
+    def get_aggregate_id(self, context, host):
+        """Get the aggregate_id for a pool from the backend driver.
+
+        Reads the authoritative value from the driver's storage
+        (e.g., the NetApp flexvol comment field).
+        """
+        requested_pool_name = volume_utils.extract_host(host, 'pool')
+
+        if hasattr(self.driver, 'get_aggregate_id'):
+            return self.driver.get_aggregate_id(requested_pool_name)
+        else:
+            LOG.warning(
+                "Driver %s does not support getting aggregate_id.",
+                self.driver.__class__.__name__
+            )
+            return None
+
     @coordination.synchronized('volume-stats-{self.host}')
     def _count_host_stats(self, context, export_volumes=False):
         """Recount the number of volumes and allocated capacity."""

--- a/cinder/volume/rpcapi.py
+++ b/cinder/volume/rpcapi.py
@@ -179,6 +179,17 @@ class VolumeAPI(rpc.RPCAPI):
         cctxt = self._get_cctxt(host=host)
         cctxt.cast(ctxt, 'set_pool_state', host=host, status=status)
 
+    @rpc.assert_min_rpc_version('3.18')
+    def set_aggregate_id(self, ctxt, host, aggregate_id):
+        cctxt = self._get_cctxt(host=host)
+        cctxt.cast(ctxt, 'set_aggregate_id', host=host,
+                   aggregate_id=aggregate_id)
+
+    @rpc.assert_min_rpc_version('3.18')
+    def get_aggregate_id(self, ctxt, host):
+        cctxt = self._get_cctxt(host=host)
+        return cctxt.call(ctxt, 'get_aggregate_id', host=host)
+
     def create_volume(self,
                       ctxt: context.RequestContext,
                       volume: 'objects.Volume',


### PR DESCRIPTION
## Summary

- Enable the NetApp NFS driver to participate in the scheduler's aggregate volume feature (previously only VMware FCD)
- Fix `set_pool_state` to read-modify-write the flexvol comment field so it no longer overwrites other fields
- Add `set_aggregate_id` / `get_aggregate_id` driver methods and admin API endpoints
- Add scheduler aggregate propagation unit tests covering cross-driver (FCD + NetApp) scenarios

## Background

The scheduler has a custom aggregate volume feature that sums `allocated_capacity_gb` across backends sharing the same physical storage (identified by `aggregate_id`). This was gated by `has_aggregate_pool` which only the VMware FCD driver set. With this change, the NetApp NFS driver can also report `aggregate_id` (stored in the flexvol comment field as JSON), enabling correct capacity tracking when a NetApp NFS volume and a VMware FCD datastore point to the same physical storage.

## New CLI Commands (requires python-sap-cinderclient-ext update)

- `cinder set-aggregate-id <host@backend#pool> <aggregate_id>` — set or remove (`none`) the aggregate association
- `cinder get-aggregate-id <host@backend#pool>` — query the current aggregate_id from the backend

## Testing

- Unit tests for driver methods (set/get aggregate_id, pool stats reporting)
- Unit tests for scheduler aggregate propagation (cross-driver scenarios)
- Regression test for `set_pool_state` preserving existing comment fields