### PR TITLE
Fix image cache, do the clone on the templates ds

### DIFF
--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -3071,8 +3071,9 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
     def _create_volume_from_cached_image(self, volume, img_backing):
         (host, rp, folder, summary) = self._select_ds_for_volume(
             volume)
-        datastore = summary.datastore
+        tgt_datastore = summary.datastore
         disk_type = VMwareVcVmdkDriver._get_disk_type(volume)
+        datastore = self.volumeops.get_datastore(img_backing)
 
         backing = self.volumeops.clone_backing(
             volume['id'],
@@ -3087,6 +3088,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
 
         self.volumeops.update_backing_uuid(backing, volume['id'])
         self.volumeops.update_backing_disk_uuid(backing, volume['id'])
+        self.volumeops.relocate_backing(backing, tgt_datastore, rp, host)
 
     @volume_utils.trace
     def _create_volume_from_template(self, volume, path):


### PR DESCRIPTION
Fix image cache, do the clone on the templates ds
moves backing to target ds via svmotion post clone
This would workaround the netapp VAAI bug, resulting in poor performance during clone cross nodes

Change-Id: Icc4dda70f98498723c622913dfc383fb27b25da6