### PR TITLE
[SAP] Fix race condition in NetApp REST client session handling

### DIFF
--- a/cinder/tests/unit/volume/drivers/netapp/dataontap/client/test_api.py
+++ b/cinder/tests/unit/volume/drivers/netapp/dataontap/client/test_api.py
@@ -682,8 +682,9 @@ class NetAppRestApiServerTests(test.TestCase):
     @ddt.unpack
     def test_send_http_request_http_error(self, error, raised):
         self.mock_object(netapp_api, 'LOG')
-        self.mock_object(self.rest_client, '_build_session')
-        self.rest_client._session = mock.Mock()
+        _mock_session = mock.Mock()
+        self.mock_object(self.rest_client, '_build_session',
+                         mock.Mock(return_value=_mock_session))
         self.mock_object(
             self.rest_client, '_get_request_method', mock.Mock(
                 return_value=mock.Mock(side_effect=error)))
@@ -721,10 +722,10 @@ class NetAppRestApiServerTests(test.TestCase):
         self.mock_object(netapp_api, 'LOG')
         mock_json_dumps = self.mock_object(
             jsonutils, 'dumps', mock.Mock(return_value='fake_dump_body'))
-        mock_build_session = self.mock_object(
-            self.rest_client, '_build_session')
         _mock_session = mock.Mock()
-        self.rest_client._session = _mock_session
+        mock_build_session = self.mock_object(
+            self.rest_client, '_build_session',
+            mock.Mock(return_value=_mock_session))
         response = mock.Mock()
         response.content = resp_content
         response.status_code = 10
@@ -852,13 +853,13 @@ class NetAppRestApiServerTests(test.TestCase):
             mock.Mock(return_value='fake_auth'))
         self.rest_client._ssl_verify = 'fake_ssl'
 
-        self.rest_client._build_session(zapi_fakes.FAKE_HEADERS)
+        result = self.rest_client._build_session(zapi_fakes.FAKE_HEADERS)
 
-        self.assertEqual(fake_session, self.rest_client._session)
-        self.assertEqual('fake_auth', self.rest_client._session.auth)
-        self.assertEqual('fake_ssl', self.rest_client._session.verify)
+        self.assertEqual(fake_session, result)
+        self.assertEqual('fake_auth', result.auth)
+        self.assertEqual('fake_ssl', result.verify)
         self.assertEqual(zapi_fakes.FAKE_HEADERS,
-                         self.rest_client._session.headers)
+                         result.headers)
         mock_requests_session.assert_called_once_with()
         mock_auth.assert_called_once_with()
 

--- a/cinder/volume/drivers/netapp/dataontap/client/api.py
+++ b/cinder/volume/drivers/netapp/dataontap/client/api.py
@@ -795,18 +795,26 @@ class RestNaServer(object):
         return '%s://%s:%s/api/' % (self._protocol, host, self._port)
 
     def _build_session(self, headers):
-        """Builds a session in the client."""
-        self._session = requests.Session()
+        """Builds a session for a REST request.
+
+        Returns a new session object each time to avoid race conditions
+        when multiple greenthreads make concurrent REST calls. Previously,
+        the session was stored on self._session, which caused a race where
+        one greenthread's headers (e.g., with X-Dot-SVM-Name tunneling)
+        could be overwritten by another greenthread's _build_session call.
+        """
+        session = requests.Session()
 
         # NOTE(felipe_rodrigues): request resilient of temporary network
         # failures (like name resolution failure), retrying until 5 times.
         max_retries = Retry(total=5, connect=5, read=2, backoff_factor=1)
         adapter = HTTPAdapter(max_retries=max_retries)
-        self._session.mount('%s://' % self._protocol, adapter)
+        session.mount('%s://' % self._protocol, adapter)
 
-        self._session.auth = self._create_basic_auth_handler()
-        self._session.verify = self._ssl_verify
-        self._session.headers = headers
+        session.auth = self._create_basic_auth_handler()
+        session.verify = self._ssl_verify
+        session.headers = headers
+        return session
 
     def _build_headers(self, enable_tunneling):
         """Build and return headers for a REST request."""
@@ -833,8 +841,8 @@ class RestNaServer(object):
         """
         data = jsonutils.dumps(body) if body else {}
 
-        self._build_session(headers)
-        request_method = self._get_request_method(method, self._session)
+        session = self._build_session(headers)
+        request_method = self._get_request_method(method, session)
 
         try:
             if self._timeout is not None:


### PR DESCRIPTION
## Summary

- Fixes a race condition in `RestNaServer.send_http_request()` where `self._session` was rebuilt on every call without locking, allowing concurrent eventlet greenthreads to overwrite each other's session headers (including the `X-Dot-SVM-Name` vserver tunneling header).
- Makes `_build_session()` return a local session object instead of storing on `self`, eliminating shared mutable state between concurrent requests.
- Updates unit tests to match the new return-value pattern.

## Root Cause

The `get_operational_lif_addresses()` REST call was intermittently losing its vserver tunneling header due to this race. This caused the driver to log `Address not found for NFS share` for all configured NFS shares every hour, report zero pools to the scheduler, and make the backend permanently invisible to the volume controller's `_get_all_pools()` cache.

The race window:
1. SSC update greenthread calls `send_http_request` → `_build_session(headers_with_X-Dot-SVM-Name)`
2. Eventlet yields (network I/O)
3. Another greenthread calls `send_http_request` → `_build_session(different_headers)` → **overwrites** `self._session`
4. SSC thread resumes, uses the corrupted session → request goes without vserver scope → wrong/empty LIF list returned

## Evidence

- `cinder pool-list` shows zero KVM pools for the affected backend (down for >24h)
- Logs show hourly `Address not found for NFS share` warnings for all configured shares
- Direct REST API call to the filer from the same pod **does** return the correct LIFs — proving the filer is healthy and the issue is in the client
- This is the same class of bug previously worked around in commit deebedfd62 (`use zapi in _get_flexvol_to_pool_map`)

## Testing

Unit tests updated. The fix is minimal and eliminates shared state — each REST call gets its own isolated `requests.Session`.