### PR TITLE
[SAP] Fix EMS vserver race condition in NetApp REST client

### DIFF
--- a/cinder/tests/unit/volume/drivers/netapp/dataontap/client/test_client_cmode_rest.py
+++ b/cinder/tests/unit/volume/drivers/netapp/dataontap/client/test_client_cmode_rest.py
@@ -1055,7 +1055,8 @@ class NetAppRestCmodeClientTestCase(test.TestCase):
 
         mock_list_vservers.assert_called_once_with()
 
-    def test_send_ems_log_message(self):
+    @mock.patch('copy.deepcopy')
+    def test_send_ems_log_message(self, mock_deepcopy):
 
         message_dict = {
             'computer-name': '25-dev-vm',
@@ -1081,14 +1082,102 @@ class NetAppRestCmodeClientTestCase(test.TestCase):
             'event_description': message_dict['event-description'],
         }
 
+        mock_ems_connection = mock.Mock()
+        mock_ems_connection.invoke_successfully.return_value = (201, {})
+        mock_deepcopy.return_value = mock_ems_connection
+
         self.mock_object(self.client, '_get_ems_log_destination_vserver',
                          return_value='vserver_name')
-        self.mock_object(self.client, 'send_request')
 
         self.client.send_ems_log_message(message_dict)
 
-        self.client.send_request.assert_called_once_with(
-            '/support/ems/application-logs', 'post', body=body)
+        # Verify deepcopy was called with self.connection
+        mock_deepcopy.assert_called_once_with(self.client.connection)
+        # Verify the local copy was configured correctly
+        mock_ems_connection.set_timeout.assert_called_once_with(25)
+        mock_ems_connection.set_vserver.assert_called_once_with('vserver_name')
+        # Verify invoke_successfully was called on the LOCAL copy,
+        # not self.connection
+        mock_ems_connection.invoke_successfully.assert_called_once_with(
+            '/api/support/ems/application-logs', 'post',
+            body=body, enable_tunneling=True)
+
+    @mock.patch('copy.deepcopy')
+    def test_send_ems_log_message_does_not_mutate_connection(self,
+                                                             mock_deepcopy):
+        """Verify send_ems_log_message does not mutate self.connection.
+
+        This test ensures the fix for the EMS vserver race condition:
+        send_ems_log_message must use a local deep copy of self.connection
+        so that concurrent greenthreads are not affected by the temporary
+        vserver change needed for EMS logging.
+        """
+        message_dict = {
+            'computer-name': '25-dev-vm',
+            'event-source': 'Cinder driver NetApp_iSCSI_Cluster_direct',
+            'app-version': '20.1.0.dev|vendor|Linux-5.4.0-120-generic-x86_64',
+            'category': 'provisioning',
+            'log-level': '5',
+            'auto-support': 'false',
+            'event-id': '1',
+            'event-description': 'test'
+        }
+
+        original_vserver = self.client.connection.get_vserver()
+        original_timeout = self.client.connection.get_timeout()
+
+        mock_ems_connection = mock.Mock()
+        mock_ems_connection.invoke_successfully.return_value = (201, {})
+        mock_deepcopy.return_value = mock_ems_connection
+
+        self.mock_object(self.client, '_get_ems_log_destination_vserver',
+                         return_value='cluster_admin_vserver')
+
+        self.client.send_ems_log_message(message_dict)
+
+        # Verify self.connection was NOT mutated
+        self.assertEqual(original_vserver,
+                         self.client.connection.get_vserver())
+        self.assertEqual(original_timeout,
+                         self.client.connection.get_timeout())
+        # Verify the EMS vserver was set on the LOCAL copy only
+        mock_ems_connection.set_vserver.assert_called_once_with(
+            'cluster_admin_vserver')
+
+    @mock.patch('copy.deepcopy')
+    def test_send_ems_log_message_failure_does_not_mutate_connection(
+            self, mock_deepcopy):
+        """Verify connection is not mutated even when EMS call fails."""
+        message_dict = {
+            'computer-name': '25-dev-vm',
+            'event-source': 'Cinder driver NetApp_iSCSI_Cluster_direct',
+            'app-version': '20.1.0.dev|vendor|Linux-5.4.0-120-generic-x86_64',
+            'category': 'provisioning',
+            'log-level': '5',
+            'auto-support': 'false',
+            'event-id': '1',
+            'event-description': 'test'
+        }
+
+        original_vserver = self.client.connection.get_vserver()
+        original_timeout = self.client.connection.get_timeout()
+
+        mock_ems_connection = mock.Mock()
+        mock_ems_connection.invoke_successfully.side_effect = (
+            netapp_api.NaApiError(code='fake'))
+        mock_deepcopy.return_value = mock_ems_connection
+
+        self.mock_object(self.client, '_get_ems_log_destination_vserver',
+                         return_value='cluster_admin_vserver')
+
+        # Should not raise — error is caught internally
+        self.client.send_ems_log_message(message_dict)
+
+        # Verify self.connection was NOT mutated even on failure
+        self.assertEqual(original_vserver,
+                         self.client.connection.get_vserver())
+        self.assertEqual(original_timeout,
+                         self.client.connection.get_timeout())
 
     @ddt.data('cp_phase_times', 'domain_busy')
     def test_get_performance_counter_info(self, counter_name):

--- a/cinder/volume/drivers/netapp/dataontap/client/client_cmode_rest.py
+++ b/cinder/volume/drivers/netapp/dataontap/client/client_cmode_rest.py
@@ -856,7 +856,23 @@ class RestClient(object):
         raise exception.NotFound("No Vserver found to receive EMS messages.")
 
     def send_ems_log_message(self, message_dict):
-        """Sends a message to the Data ONTAP EMS log."""
+        """Sends a message to the Data ONTAP EMS log.
+
+        NOTE: This method uses a deep copy of self.connection to avoid a race
+        condition with concurrent greenthreads. The EMS log must be sent to
+        the cluster admin vserver, which requires changing the vserver used
+        for SVM tunneling (X-Dot-SVM-Name header). Previously, this method
+        mutated self.connection._vserver directly, which caused concurrent
+        REST calls (e.g., during _update_ssc / volume discovery at startup)
+        to pick up the wrong vserver in their X-Dot-SVM-Name header, resulting
+        in "Volume not found" errors when the request was tunneled to the
+        wrong SVM.
+
+        By using a local deep copy of the connection, we ensure that:
+        1. self.connection is never mutated (no shared state corruption)
+        2. Concurrent greenthreads continue using the correct data vserver
+        3. The EMS request is isolated with its own connection/session state
+        """
 
         body = {
             'computer_name': message_dict['computer-name'],
@@ -869,28 +885,21 @@ class RestClient(object):
             'event_description': message_dict['event-description'],
         }
 
-        bkp_connection = copy.copy(self.connection)
-        bkp_timeout = self.connection.get_timeout()
-        bkp_vserver = self.vserver
-
-        self.connection.set_timeout(25)
+        # Use a deep copy of the connection to avoid mutating shared state.
+        # This prevents a race condition where concurrent greenthreads could
+        # read the wrong vserver from self.connection while EMS temporarily
+        # switches it to the cluster admin vserver.
+        ems_connection = copy.deepcopy(self.connection)
+        ems_connection.set_timeout(25)
         try:
-            # TODO(nahimsouza): Vserver is being set to replicate the ZAPI
-            # behavior, but need to check if this could be removed in REST API
-            self.connection.set_vserver(
+            ems_connection.set_vserver(
                 self._get_ems_log_destination_vserver())
-            self.send_request('/support/ems/application-logs',
-                              'post', body=body)
+            ems_connection.invoke_successfully(
+                '/api/support/ems/application-logs', 'post',
+                body=body, enable_tunneling=True)
             LOG.debug('EMS executed successfully.')
         except netapp_api.NaApiError as e:
             LOG.warning('Failed to invoke EMS. %s', e)
-        finally:
-            # Restores the data
-            timeout = (
-                bkp_timeout if bkp_timeout is not None else DEFAULT_TIMEOUT)
-            self.connection.set_timeout(timeout)
-            self.connection = copy.copy(bkp_connection)
-            self.connection.set_vserver(bkp_vserver)
 
     def get_performance_counter_info(self, object_name, counter_name):
         """Gets info about one or more Data ONTAP performance counters."""


### PR DESCRIPTION
The send_ems_log_message method previously mutated self.connection's vserver to temporarily switch to the cluster admin vserver for EMS logging. This caused a race condition with concurrent greenthreads (e.g., _update_ssc / volume discovery at startup) that would read the wrong vserver from self.connection, resulting in REST calls being tunneled to the wrong SVM and returning 'Volume not found' errors.

Fix by using a deep copy of self.connection for the EMS request, ensuring that self.connection is never mutated and concurrent operations continue using the correct data vserver.

Change-Id: IF426ECCD93A24707ADF25C3CB843B5C7