### PR TITLE
[SAP] Fix race condition in NetApp REST client session handling

### DIFF
--- a/cinder/tests/unit/volume/drivers/netapp/dataontap/client/test_api.py
+++ b/cinder/tests/unit/volume/drivers/netapp/dataontap/client/test_api.py
@@ -684,8 +684,9 @@ class NetAppRestApiServerTests(test.TestCase):
     @ddt.unpack
     def test_send_http_request_http_error(self, error, raised):
         self.mock_object(netapp_api, 'LOG')
-        self.mock_object(self.rest_client, '_build_session')
-        self.rest_client._session = mock.Mock()
+        _mock_session = mock.Mock()
+        self.mock_object(self.rest_client, '_build_session',
+                         mock.Mock(return_value=_mock_session))
         self.mock_object(
             self.rest_client, '_get_request_method', mock.Mock(
                 return_value=mock.Mock(side_effect=error)))
@@ -723,10 +724,10 @@ class NetAppRestApiServerTests(test.TestCase):
         self.mock_object(netapp_api, 'LOG')
         mock_json_dumps = self.mock_object(
             jsonutils, 'dumps', mock.Mock(return_value='fake_dump_body'))
-        mock_build_session = self.mock_object(
-            self.rest_client, '_build_session')
         _mock_session = mock.Mock()
-        self.rest_client._session = _mock_session
+        mock_build_session = self.mock_object(
+            self.rest_client, '_build_session',
+            mock.Mock(return_value=_mock_session))
         response = mock.Mock()
         response.content = resp_content
         response.status_code = 10
@@ -856,13 +857,13 @@ class NetAppRestApiServerTests(test.TestCase):
             mock.Mock(return_value='fake_auth'))
         self.rest_client._ssl_verify = 'fake_ssl'
 
-        self.rest_client._build_session(zapi_fakes.FAKE_HEADERS)
+        result = self.rest_client._build_session(zapi_fakes.FAKE_HEADERS)
 
-        self.assertEqual(fake_session, self.rest_client._session)
-        self.assertEqual('fake_auth', self.rest_client._session.auth)
-        self.assertEqual('fake_ssl', self.rest_client._session.verify)
+        self.assertEqual(fake_session, result)
+        self.assertEqual('fake_auth', result.auth)
+        self.assertEqual('fake_ssl', result.verify)
         self.assertEqual(zapi_fakes.FAKE_HEADERS,
-                         self.rest_client._session.headers)
+                         result.headers)
         mock_requests_session.assert_called_once_with()
         mock_auth.assert_called_once_with()
 
@@ -878,13 +879,13 @@ class NetAppRestApiServerTests(test.TestCase):
         mock_auth = self.mock_object(
             self.rest_client, '_create_certificate_auth_handler',
             mock.Mock(return_value=('fake_cert', 'fake_verify')))
-        self.rest_client._build_session(zapi_fakes.FAKE_HEADERS)
-        self.assertEqual(fake_session, self.rest_client._session)
+
+        result = self.rest_client._build_session(zapi_fakes.FAKE_HEADERS)
+
+        self.assertEqual(fake_session, result)
         self.assertEqual(('fake_cert', 'fake_verify'),
-                         (self.rest_client._session.cert,
-                          self.rest_client._session.verify))
-        self.assertEqual(zapi_fakes.FAKE_HEADERS,
-                         self.rest_client._session.headers)
+                         (result.cert, result.verify))
+        self.assertEqual(zapi_fakes.FAKE_HEADERS, result.headers)
         mock_requests_session.assert_called_once_with()
         mock_auth.assert_called_once_with()
 
@@ -918,15 +919,11 @@ class NetAppRestApiServerTests(test.TestCase):
         """works with default params"""
         self.rest_client._private_key_file = 'fake_key.pem'
         self.rest_client._certificate_file = 'fake_cert.pem'
-        self.rest_client._certificate_host_validation = False
-        cert = self.rest_client._certificate_file, \
-            self.rest_client._private_key_file
-        self.rest_client._session = mock.Mock()
-        if not self.rest_client._certificate_host_validation:
-            self.assertFalse(self.rest_client._certificate_host_validation)
+        self.rest_client._ssl_verify = False
+        cert = (self.rest_client._certificate_file,
+                self.rest_client._private_key_file)
         res = self.rest_client._create_certificate_auth_handler()
-        self.assertEqual(res,
-                         (cert, self.rest_client._certificate_host_validation))
+        self.assertEqual(res, (cert, False))
 
     def test__create_certificate_auth_handler_with_host_validation(self):
         """Test whether create certificate auth handler """
@@ -934,11 +931,8 @@ class NetAppRestApiServerTests(test.TestCase):
         self.rest_client._private_key_file = 'fake_key.pem'
         self.rest_client._certificate_file = 'fake_cert.pem'
         self.rest_client._ca_certificate_file = 'fake_ca_cert.crt'
-        self.rest_client._certificate_host_validation = True
-        cert = self.rest_client._certificate_file, \
-            self.rest_client._private_key_file
-        self.rest_client._session = mock.Mock()
-        if self.rest_client._certificate_host_validation:
-            self.assertTrue(self.rest_client._certificate_host_validation)
+        self.rest_client._ssl_verify = True
+        cert = (self.rest_client._certificate_file,
+                self.rest_client._private_key_file)
         res = self.rest_client._create_certificate_auth_handler()
-        self.assertEqual(res, (cert, self.rest_client._ca_certificate_file))
+        self.assertEqual(res, (cert, 'fake_ca_cert.crt'))

--- a/cinder/volume/drivers/netapp/dataontap/client/api.py
+++ b/cinder/volume/drivers/netapp/dataontap/client/api.py
@@ -808,21 +808,29 @@ class RestNaServer(object):
         return '%s://%s:%s/api/' % (self._protocol, host, self._port)
 
     def _build_session(self, headers):
-        """Builds a session in the client."""
-        self._session = requests.Session()
+        """Builds a session for a REST request.
+
+        Returns a new session object each time to avoid race conditions
+        when multiple greenthreads make concurrent REST calls. Previously,
+        the session was stored on self._session, which caused a race where
+        one greenthread's headers (e.g., with X-Dot-SVM-Name tunneling)
+        could be overwritten by another greenthread's _build_session call.
+        """
+        session = requests.Session()
 
         # NOTE(felipe_rodrigues): request resilient of temporary network
         # failures (like name resolution failure), retrying until 5 times.
         max_retries = Retry(total=5, connect=5, read=2, backoff_factor=1)
         adapter = HTTPAdapter(max_retries=max_retries)
-        self._session.mount('%s://' % self._protocol, adapter)
+        session.mount('%s://' % self._protocol, adapter)
         if self._private_key_file and self._certificate_file:
-            self._session.cert, self._session.verify\
+            session.cert, session.verify\
                 = self._create_certificate_auth_handler()
         else:
-            self._session.auth = self._create_basic_auth_handler()
-            self._session.verify = self._ssl_verify
-        self._session.headers = headers
+            session.auth = self._create_basic_auth_handler()
+            session.verify = self._ssl_verify
+        session.headers = headers
+        return session
 
     def _build_headers(self, enable_tunneling):
         """Build and return headers for a REST request."""
@@ -840,18 +848,20 @@ class RestNaServer(object):
         return auth.HTTPBasicAuth(self._username, self._password)
 
     def _create_certificate_auth_handler(self):
-        """Creates and returns a certificate auth handler."""
-        self._certificate_host_validation = self._session.verify
+        """Creates and returns a certificate auth handler.
+
+        Returns a tuple of (cert, verify) to be set on the session.
+        """
+        cert = None
+        verify = self._ssl_verify
         if self._certificate_file and self._private_key_file \
                 and self._ca_certificate_file:
-            self._session.cert = (self._certificate_file,
-                                  self._private_key_file)
-            if self._certificate_host_validation:
-                self._session.verify = self._ca_certificate_file
+            cert = (self._certificate_file, self._private_key_file)
+            if verify:
+                verify = self._ca_certificate_file
         elif self._certificate_file and self._private_key_file:
-            self._session.cert = (self._certificate_file,
-                                  self._private_key_file)
-        return self._session.cert, self._session.verify
+            cert = (self._certificate_file, self._private_key_file)
+        return cert, verify
 
     @volume_utils.trace_api(
         filter_function=na_utils.trace_filter_func_rest_api)
@@ -863,8 +873,8 @@ class RestNaServer(object):
         """
         data = jsonutils.dumps(body) if body else {}
 
-        self._build_session(headers)
-        request_method = self._get_request_method(method, self._session)
+        session = self._build_session(headers)
+        request_method = self._get_request_method(method, session)
 
         try:
             if self._timeout is not None:

--- a/cinder/volume/drivers/vmware/vmdk.py
+++ b/cinder/volume/drivers/vmware/vmdk.py
@@ -3054,8 +3054,9 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
     def _create_volume_from_cached_image(self, volume, img_backing):
         (host, rp, folder, summary) = self._select_ds_for_volume(
             volume)
-        datastore = summary.datastore
+        tgt_datastore = summary.datastore
         disk_type = VMwareVcVmdkDriver._get_disk_type(volume)
+        datastore = self.volumeops.get_datastore(img_backing)
 
         backing = self.volumeops.clone_backing(
             volume['id'],
@@ -3070,6 +3071,7 @@ class VMwareVcVmdkDriver(driver.VolumeDriver):
 
         self.volumeops.update_backing_uuid(backing, volume['id'])
         self.volumeops.update_backing_disk_uuid(backing, volume['id'])
+        self.volumeops.relocate_backing(backing, tgt_datastore, rp, host)
 
     @volume_utils.trace
     def _create_volume_from_template(self, volume, path):


### PR DESCRIPTION
## Summary
- Cherry-pick of ec2db68f9b from stable/2023.1-m3
- Fixes race condition where concurrent greenthreads overwrite each other's session headers (X-Dot-SVM-Name tunneling) by making _build_session() return a local session object instead of storing on self._session
- Includes adaptation for certificate auth support present in 2025.1