### PR TITLE
[SAP] Remove capabilities dict from per-pool update debug log

### DIFF
--- a/cinder/scheduler/host_manager.py
+++ b/cinder/scheduler/host_manager.py
@@ -412,7 +412,7 @@ class PoolState(BackendState):
                                       capability: dict[str, Any],
                                       service=None) -> None:
         """Update information about a pool from its volume_node info."""
-        LOG.debug("Updating capabilities for %s: %s", self.host, capability)
+        LOG.debug("Updating capabilities for %s", self.host)
         self.update_capabilities(capability, service)
         if capability:
             if self.updated and self.updated > capability['timestamp']:


### PR DESCRIPTION
Follow-up to #340.

PR #340 removed the capabilities dump from the HostManager-level 'Received service update' debug logs, but missed the per-pool log in `PoolState.update_from_volume_capability()` at line 415:

```python
LOG.debug("Updating capabilities for %s: %s", self.host, capability)
```

This log fires **once per pool per capability report cycle** and serializes the entire capability dict (15-50KB for multi-pool backends). It's the log still visible in eu-de-2 scheduler after rolling out #340.

This change removes the `capability` dict from the format string while preserving the host identity so update events remain traceable.

Change is consistent with the approach taken in #340 — capability data is still stored in `service_states` and accessible via other debug paths.