### PR TITLE
Fix CapacityFilter blocking same-aggregate cross-vCenter migrations

### DIFF
--- a/cinder/scheduler/filters/capacity_filter.py
+++ b/cinder/scheduler/filters/capacity_filter.py
@@ -38,6 +38,24 @@ class CapacityFilter(filters.BaseBackendFilter):
         if backend_state.backend_id == filter_properties.get('vol_exists_on'):
             return True
 
+        # SAP: If this is a migration and the source and destination share
+        # the same aggregate_id, no data movement is required (it's just a
+        # logical re-registration across vcenters). Skip the capacity check
+        # since the volume already occupies space on this aggregate.
+        source_agg_id = filter_properties.get('source_aggregate_id')
+        if source_agg_id:
+            spec = filter_properties.get('request_spec', {})
+            if spec.get('operation') == 'migrate_volume':
+                dest_agg_id = None
+                if backend_state.capabilities:
+                    dest_agg_id = backend_state.capabilities.get(
+                        'aggregate_id')
+                if dest_agg_id and source_agg_id == dest_agg_id:
+                    LOG.debug("Same aggregate_id %s for migration, "
+                              "skipping capacity check for %s",
+                              source_agg_id, backend_state.backend_id)
+                    return True
+
         spec = filter_properties.get('request_spec')
         if spec:
             volid = spec.get('volume_id')

--- a/cinder/scheduler/manager.py
+++ b/cinder/scheduler/manager.py
@@ -317,6 +317,11 @@ class SchedulerManager(manager.CleanableManager, manager.Manager):
         # [SAP] So the filter has the destination host
         request_spec['destination_host'] = backend
 
+        # [SAP] Look up the source volume's aggregate_id so the
+        # CapacityFilter can skip capacity checks for same-aggregate
+        # migrations (no data movement, just logical re-registration).
+        self._set_source_aggregate_id(volume, filter_properties)
+
         def _migrate_volume_set_error(self, context, ex, request_spec):
             if volume.status == 'maintenance':
                 previous_status = (
@@ -348,6 +353,40 @@ class SchedulerManager(manager.CleanableManager, manager.Manager):
                                request_spec, filter_properties=None):
         return self.migrate_volume(context, volume, host, force_host_copy,
                                    request_spec, filter_properties)
+
+    def _set_source_aggregate_id(self, volume, filter_properties):
+        """Set the source volume's aggregate_id in filter_properties.
+
+        For cross-vcenter migrations where source and destination pools
+        share the same aggregate_id, no data movement is required (the
+        volume is just logically re-registered). By passing the source
+        aggregate_id to the filters, the CapacityFilter can skip capacity
+        checks for these same-aggregate migrations.
+        """
+        if filter_properties is None:
+            return
+
+        source_host = volume.host
+        if not source_host:
+            return
+
+        source_backend = vol_utils.extract_host(source_host, 'backend')
+        source_pool = vol_utils.extract_host(source_host, 'pool')
+        if not source_backend or not source_pool:
+            return
+
+        host_manager = self.driver.host_manager
+        backend_state = host_manager.backend_state_map.get(source_backend)
+        if not backend_state:
+            return
+
+        pool_state = backend_state.pools.get(source_pool)
+        if not pool_state or not pool_state.capabilities:
+            return
+
+        aggregate_id = pool_state.capabilities.get('aggregate_id')
+        if aggregate_id:
+            filter_properties['source_aggregate_id'] = aggregate_id
 
     @append_operation_type(name='retype_volume')
     def retype(self, context, volume, request_spec, filter_properties=None):

--- a/cinder/tests/unit/scheduler/test_host_filters.py
+++ b/cinder/tests/unit/scheduler/test_host_filters.py
@@ -596,6 +596,95 @@ class CapacityFilterTestCase(BackendFiltersTestCase):
                                        'service': service})
         self.assertTrue(filt_cls.backend_passes(host, filter_properties))
 
+    def test_filter_passes_same_aggregate_migration(self, _mock_serv_is_up):
+        """Cross-vcenter migration with same aggregate_id should pass.
+
+        When migrating a volume between vcenters where both pools share the
+        same aggregate_id, no data movement occurs (just a logical
+        re-registration). The CapacityFilter should allow this even if the
+        destination pool has insufficient free space for a new volume of that
+        size.
+        """
+        _mock_serv_is_up.return_value = True
+        filt_cls = self.class_map['CapacityFilter']()
+        filter_properties = {
+            'size': 2048,
+            'request_spec': {
+                'volume_id': fake.VOLUME_ID,
+                'operation': 'migrate_volume',
+                'volume_properties': {
+                    'host': 'vc-a-0@vmware_fcd#pool_A',
+                },
+            },
+            'source_aggregate_id': 'agg_123',
+        }
+        service = {'disabled': False}
+        host = fakes.FakeBackendState('vc-b-0@vmware_fcd#pool_B',
+                                      {'total_capacity_gb': 5000,
+                                       'free_capacity_gb': 100,
+                                       'updated_at': None,
+                                       'service': service,
+                                       'capabilities': {
+                                           'aggregate_id': 'agg_123'}})
+        self.assertTrue(filt_cls.backend_passes(host, filter_properties))
+
+    def test_filter_fails_different_aggregate_migration(
+            self, _mock_serv_is_up):
+        """Cross-vcenter migration with different aggregate_id should check.
+
+        When migrating to a pool with a different aggregate_id, actual data
+        movement is required, so the CapacityFilter must enforce its normal
+        capacity checks.
+        """
+        _mock_serv_is_up.return_value = True
+        filt_cls = self.class_map['CapacityFilter']()
+        filter_properties = {
+            'size': 2048,
+            'request_spec': {
+                'volume_id': fake.VOLUME_ID,
+                'operation': 'migrate_volume',
+                'volume_properties': {
+                    'host': 'vc-a-0@vmware_fcd#pool_A',
+                },
+            },
+            'source_aggregate_id': 'agg_123',
+        }
+        service = {'disabled': False}
+        host = fakes.FakeBackendState('vc-b-0@vmware_fcd#pool_B',
+                                      {'total_capacity_gb': 5000,
+                                       'free_capacity_gb': 100,
+                                       'updated_at': None,
+                                       'service': service,
+                                       'capabilities': {
+                                           'aggregate_id': 'agg_456'}})
+        self.assertFalse(filt_cls.backend_passes(host, filter_properties))
+
+    def test_filter_passes_migration_no_aggregate_id(self, _mock_serv_is_up):
+        """Migration without aggregate_id should use normal capacity checks.
+
+        If neither source nor destination has an aggregate_id, the filter
+        should fall through to normal capacity evaluation.
+        """
+        _mock_serv_is_up.return_value = True
+        filt_cls = self.class_map['CapacityFilter']()
+        filter_properties = {
+            'size': 100,
+            'request_spec': {
+                'volume_id': fake.VOLUME_ID,
+                'operation': 'migrate_volume',
+                'volume_properties': {
+                    'host': 'vc-a-0@vmware_fcd#pool_A',
+                },
+            },
+        }
+        service = {'disabled': False}
+        host = fakes.FakeBackendState('vc-b-0@vmware_fcd#pool_B',
+                                      {'total_capacity_gb': 500,
+                                       'free_capacity_gb': 200,
+                                       'updated_at': None,
+                                       'service': service})
+        self.assertTrue(filt_cls.backend_passes(host, filter_properties))
+
 
 class AffinityFilterTestCase(BackendFiltersTestCase):
     @mock.patch('cinder.objects.service.Service.is_up',

--- a/cinder/tests/unit/scheduler/test_scheduler.py
+++ b/cinder/tests/unit/scheduler/test_scheduler.py
@@ -477,6 +477,69 @@ class SchedulerManagerTestCase(test.TestCase):
         _mock_backend_passes.assert_called_once_with(self.context, 'host',
                                                      request_spec, {})
 
+    def test_set_source_aggregate_id_with_aggregate(self):
+        """Test that source aggregate_id is set in filter_properties."""
+        volume = fake_volume.fake_volume_obj(
+            self.context, host='vc-a-0@vmware_fcd#pool_A')
+
+        # Set up mock pool state with aggregate_id in capabilities
+        mock_pool_state = mock.Mock()
+        mock_pool_state.capabilities = {'aggregate_id': 'agg_123'}
+
+        mock_backend_state = mock.Mock()
+        mock_backend_state.pools = {'pool_A': mock_pool_state}
+
+        self.manager.driver.host_manager.backend_state_map = {
+            'vc-a-0@vmware_fcd': mock_backend_state
+        }
+
+        filter_properties = {}
+        self.manager._set_source_aggregate_id(volume, filter_properties)
+
+        self.assertEqual('agg_123',
+                         filter_properties.get('source_aggregate_id'))
+
+    def test_set_source_aggregate_id_without_aggregate(self):
+        """Test that nothing is set when source has no aggregate_id."""
+        volume = fake_volume.fake_volume_obj(
+            self.context, host='vc-a-0@vmware_fcd#pool_A')
+
+        # Pool state without aggregate_id
+        mock_pool_state = mock.Mock()
+        mock_pool_state.capabilities = {}
+
+        mock_backend_state = mock.Mock()
+        mock_backend_state.pools = {'pool_A': mock_pool_state}
+
+        self.manager.driver.host_manager.backend_state_map = {
+            'vc-a-0@vmware_fcd': mock_backend_state
+        }
+
+        filter_properties = {}
+        self.manager._set_source_aggregate_id(volume, filter_properties)
+
+        self.assertNotIn('source_aggregate_id', filter_properties)
+
+    def test_set_source_aggregate_id_backend_not_found(self):
+        """Test graceful handling when source backend is not in state map."""
+        volume = fake_volume.fake_volume_obj(
+            self.context, host='vc-a-0@vmware_fcd#pool_A')
+
+        self.manager.driver.host_manager.backend_state_map = {}
+
+        filter_properties = {}
+        self.manager._set_source_aggregate_id(volume, filter_properties)
+
+        self.assertNotIn('source_aggregate_id', filter_properties)
+
+    def test_set_source_aggregate_id_none_filter_properties(self):
+        """Test graceful handling when filter_properties is None."""
+        volume = fake_volume.fake_volume_obj(
+            self.context, host='vc-a-0@vmware_fcd#pool_A')
+
+        # Should not raise
+        self.manager._set_source_aggregate_id(volume, None)
+
     @mock.patch('cinder.db.volume_update')
     @mock.patch('cinder.db.volume_attachment_get_all_by_volume_id')
     @mock.patch('cinder.quota.QUOTAS.rollback')


### PR DESCRIPTION
## Problem

When migrating a volume between vCenters where both pools share the same `aggregate_id` (same physical NetApp aggregate), no data movement occurs — it's just a logical re-registration. However, the `CapacityFilter` was rejecting these migrations because it treated them as new volume placements requiring additional space.

For example, a 2TB volume on an aggregate with only 100GB free would be rejected, even though zero additional bytes are needed.

## Root Cause

The `migrate_volume` scheduler path does not set `vol_exists_on` in `filter_properties` (unlike the `retype` path), so the CapacityFilter's existing bypass doesn't apply. Combined with `aggregate_id` capacity propagation double-counting the volume's space, the filter always rejects large volumes on heavily-utilized aggregates.

## Fix

1. **CapacityFilter** (`capacity_filter.py`): After the existing `vol_exists_on` check, added aggregate-aware bypass — if the source and destination pools share the same `aggregate_id` during a `migrate_volume` operation, skip the capacity check.

2. **SchedulerManager** (`manager.py`): New `_set_source_aggregate_id()` method looks up the source volume's `aggregate_id` from the host_manager's backend_state_map and passes it through `filter_properties['source_aggregate_id']`.

## Tests

- `test_filter_passes_same_aggregate_migration` — 2TB volume, 100GB free, same aggregate → passes
- `test_filter_fails_different_aggregate_migration` — different aggregate → still enforces capacity
- `test_filter_passes_migration_no_aggregate` — no aggregate_id → normal behavior
- 4 tests for `_set_source_aggregate_id` edge cases (aggregate present, absent, backend not found, None filter_properties)