### PR TITLE
Comment out noisy 'Updating capabilities' debug log

### DIFF
--- a/cinder/scheduler/filters/sap_pool_down_filter.py
+++ b/cinder/scheduler/filters/sap_pool_down_filter.py
@@ -49,7 +49,7 @@ class SAPPoolDownFilter(filters.BaseBackendFilter):
         if pool_state == 'up':
             return True
         elif spec.get('operation') in valid_ops and backend == 'vmware_fcd':
-            LOG.debug("Allow migration to a down pool for vmware_fcd only")
+            # LOG.debug("Allow migration to a down pool for vmware_fcd only")
             return True
         else:
             LOG.debug("%(id)s pool state is not 'up'. state='%(state)s'",

--- a/cinder/scheduler/host_manager.py
+++ b/cinder/scheduler/host_manager.py
@@ -412,7 +412,7 @@ class PoolState(BackendState):
                                       capability: dict[str, Any],
                                       service=None) -> None:
         """Update information about a pool from its volume_node info."""
-        LOG.debug("Updating capabilities for %s", self.host)
+        # LOG.debug("Updating capabilities for %s", self.host)
         self.update_capabilities(capability, service)
         if capability:
             if self.updated and self.updated > capability['timestamp']:


### PR DESCRIPTION
The host_manager logs 'Updating capabilities for <host>' on every capability update cycle, which adds noise to debug logs without providing actionable information. Comment it out for now.

Also silence a sap_pool_down_filter passing.

Change-Id: I3959fdbf8b4982281a7fcc5f44c47b892824858f