### PR TITLE
Add configurable option to use the aggr free space pool stat

### DIFF
--- a/cinder/tests/unit/volume/drivers/netapp/dataontap/test_nfs_base.py
+++ b/cinder/tests/unit/volume/drivers/netapp/dataontap/test_nfs_base.py
@@ -101,6 +101,7 @@ class NetAppNfsDriverTestCase(test.TestCase):
         expected = fake.CAPACITY_VALUES
         get_capacity = self.driver.zapi_client.get_flexvol_capacity
         get_capacity.return_value = fake.CAPACITIES
+        self.driver.configuration.netapp_nfs_report_aggr_free_capacity = False
 
         result = self.driver._get_capacity_info(fake.NFS_SHARE_IPV4)
 
@@ -112,6 +113,7 @@ class NetAppNfsDriverTestCase(test.TestCase):
         expected = fake.CAPACITY_VALUES
         get_capacity = self.driver.zapi_client.get_flexvol_capacity
         get_capacity.return_value = fake.CAPACITIES
+        self.driver.configuration.netapp_nfs_report_aggr_free_capacity = False
 
         result = self.driver._get_capacity_info(fake.NFS_SHARE_IPV6)
 

--- a/cinder/volume/drivers/netapp/dataontap/nfs_base.py
+++ b/cinder/volume/drivers/netapp/dataontap/nfs_base.py
@@ -1044,7 +1044,15 @@ class NetAppNfsDriver(driver.ManageableVD,
         export_path = nfs_share.rsplit(':', 1)[1]
         capacity = self.zapi_client.get_flexvol_capacity(
             flexvol_path=export_path)
-        return capacity['size-total'], capacity['size-available']
+        if self.configuration.netapp_nfs_report_aggr_free_capacity:
+            vol = self.zapi_client.get_flexvol(flexvol_path=export_path)
+            aggr = self.zapi_client.get_aggregate_capacities(vol['aggregate'])
+            size_available = 0.0
+            for agg_name in vol['aggregate']:
+                size_available += aggr[agg_name]['size-available']
+            return capacity['size-total'], size_available
+        else:
+            return capacity['size-total'], capacity['size-available']
 
     def _check_volume_type(self, volume, share, file_name, extra_specs):
         """Match volume type for share file."""

--- a/cinder/volume/drivers/netapp/options.py
+++ b/cinder/volume/drivers/netapp/options.py
@@ -165,7 +165,12 @@ netapp_nfs_extra_opts = [
                       'terminate_connection. This requires the REST client '
                       '(netapp_use_legacy_client = False); if the legacy '
                       'ZAPI client is active this option has no effect.'
-                      'Primary use-case is instance HA failover.')), ]
+                      'Primary use-case is instance HA failover.')),
+    cfg.BoolOpt('netapp_nfs_report_aggr_free_capacity',
+                default=True,
+                help=('When enabled, report the free space from the'
+                      'aggr free capacity instead of calulated vol capacity'
+                      'This avoid unwanted overprovisioning situation')), ]
 netapp_san_opts = [
     cfg.StrOpt('netapp_lun_ostype',
                help=('This option defines the type of operating system that'


### PR DESCRIPTION
Add configurable option to use the aggr free space in the volume space reporting
New default use the aggr free space
Change-Id: Iccfd48ffcf46a4c61ab29c44c0baf969deb77a39