### PR TITLE
Allow migrate_volume_by_connector for volumes with clone snapshots

### DIFF
--- a/cinder/tests/unit/api/contrib/test_admin_actions.py
+++ b/cinder/tests/unit/api/contrib/test_admin_actions.py
@@ -1427,3 +1427,153 @@ class AdminActionsAttachDetachTest(BaseAdminTest):
                           None,
                           mountpoint,
                           'ro')
+
+
+class VMwareMigrateByConnectorTest(BaseAdminTest):
+    """Tests for the SAP os-migrate_volume_by_connector extension.
+
+    Mirrors AdminActionsTest setup. Mocks scheduler.find_backend_for_connector
+    and volume_rpcapi.get_capabilities / migrate_volume so the conditional
+    update at cinder/volume/api.py:migrate_volume_by_connector is exercised
+    end-to-end through the WSGI extension layer.
+    """
+
+    def setUp(self):
+        super(VMwareMigrateByConnectorTest, self).setUp()
+
+        self.tempdir = self.useFixture(fixtures.TempDir()).path
+        self.fixture = self.useFixture(config_fixture.Config(lockutils.CONF))
+        self.fixture.config(lock_path=self.tempdir,
+                            group='oslo_concurrency')
+        self.fixture.config(disable_process_locking=True,
+                            group='oslo_concurrency')
+        self.flags(transport_url='fake:/')
+
+        cast_as_call.mock_cast_as_call(self.volume_api.volume_rpcapi.client)
+        cast_as_call.mock_cast_as_call(self.volume_api.scheduler_rpcapi.client)
+
+        self.svc = self.start_service('volume', host='test')
+        self.patch(
+            'cinder.objects.Service.get_minimum_obj_version',
+            return_value=obj_base.OBJ_VERSIONS.get_current())
+
+        def _get_minimum_rpc_version_mock(ctxt, binary):
+            binary_map = {
+                constants.VOLUME_BINARY: rpcapi.VolumeAPI,
+                constants.BACKUP_BINARY: backup_rpcapi.BackupAPI,
+                constants.SCHEDULER_BINARY: scheduler_rpcapi.SchedulerAPI,
+            }
+            return binary_map[binary].RPC_API_VERSION
+
+        self.patch('cinder.objects.Service.get_minimum_rpc_version',
+                   side_effect=_get_minimum_rpc_version_mock)
+
+    def tearDown(self):
+        self.svc.stop()
+        super(VMwareMigrateByConnectorTest, self).tearDown()
+
+    def _prep(self):
+        # Register source and destination volume services. The connector
+        # path uses scheduler.find_backend_for_connector for the destination,
+        # which we mock; we still need the source host's service row in the
+        # DB for objects.Service.get_by_id lookups elsewhere.
+        db.service_create(self.ctx,
+                          {'host': 'test',
+                           'topic': constants.VOLUME_TOPIC,
+                           'binary': constants.VOLUME_BINARY,
+                           'created_at': timeutils.utcnow()})
+        db.service_create(self.ctx,
+                          {'host': 'test2',
+                           'topic': constants.VOLUME_TOPIC,
+                           'binary': constants.VOLUME_BINARY,
+                           'created_at': timeutils.utcnow()})
+        return self._create_volume(self.ctx)
+
+    def _exec(self, ctx, volume, connector, expected_status,
+              lock_volume=False):
+        req = webob.Request.blank('/v3/%s/volumes/%s/action' % (
+            fake.PROJECT_ID, volume['id']))
+        req.method = 'POST'
+        req.headers['content-type'] = 'application/json'
+        body = {'os-migrate_volume_by_connector':
+                {'connector': connector, 'lock_volume': lock_volume}}
+        req.body = jsonutils.dump_as_bytes(body)
+        req.environ['cinder.context'] = ctx
+        resp = req.get_response(app())
+        self.assertEqual(expected_status, resp.status_int)
+        return db.volume_get(self.ctx, volume['id'])
+
+    @mock.patch.object(rpcapi.VolumeAPI, 'migrate_volume')
+    @mock.patch.object(rpcapi.VolumeAPI, 'get_capabilities')
+    @mock.patch.object(scheduler_rpcapi.SchedulerAPI,
+                       'find_backend_for_connector')
+    def test_migrate_by_connector_with_snap_clone_backend_succeeds(
+            self, mock_find, mock_get_caps, mock_migrate):
+        """Volume w/ snapshot on a clone-snapshot backend must migrate."""
+        volume = self._prep()
+        snap = objects.Snapshot(self.ctx, volume_id=volume['id'])
+        snap.create()
+        self.addCleanup(snap.destroy)
+
+        mock_find.return_value = {'host': 'test2',
+                                  'cluster_name': None,
+                                  'capabilities': {}}
+        mock_get_caps.return_value = {'snapshot_type': 'clone'}
+
+        connector = {
+            'connection_capabilities': ['vmware_service_instance_uuid:foo']}
+        volume = self._exec(self.ctx, volume, connector,
+                            HTTPStatus.ACCEPTED)
+        self.assertEqual('starting', volume['migration_status'])
+        mock_migrate.assert_called_once()
+
+    @mock.patch.object(rpcapi.VolumeAPI, 'migrate_volume')
+    @mock.patch.object(rpcapi.VolumeAPI, 'get_capabilities')
+    @mock.patch.object(scheduler_rpcapi.SchedulerAPI,
+                       'find_backend_for_connector')
+    def test_migrate_by_connector_with_snap_cow_backend_fails(
+            self, mock_find, mock_get_caps, mock_migrate):
+        """Volume w/ snapshot on a COW-snapshot backend must be rejected."""
+        volume = self._prep()
+        snap = objects.Snapshot(self.ctx, volume_id=volume['id'])
+        snap.create()
+        self.addCleanup(snap.destroy)
+
+        mock_find.return_value = {'host': 'test2',
+                                  'cluster_name': None,
+                                  'capabilities': {}}
+        mock_get_caps.return_value = {'snapshot_type': 'snapshot'}
+
+        connector = {
+            'connection_capabilities': ['vmware_service_instance_uuid:foo']}
+        self._exec(self.ctx, volume, connector, HTTPStatus.BAD_REQUEST)
+        mock_migrate.assert_not_called()
+
+    @mock.patch.object(rpcapi.VolumeAPI, 'migrate_volume')
+    @mock.patch.object(rpcapi.VolumeAPI, 'get_capabilities')
+    @mock.patch.object(scheduler_rpcapi.SchedulerAPI,
+                       'find_backend_for_connector')
+    def test_migrate_by_connector_no_snap_clone_backend_succeeds(
+            self, mock_find, mock_get_caps, mock_migrate):
+        """Baseline: no snapshot present, clone backend, must succeed."""
+        volume = self._prep()
+
+        mock_find.return_value = {'host': 'test2',
+                                  'cluster_name': None,
+                                  'capabilities': {}}
+        mock_get_caps.return_value = {'snapshot_type': 'clone'}
+
+        connector = {
+            'connection_capabilities': ['vmware_service_instance_uuid:foo']}
+        volume = self._exec(self.ctx, volume, connector,
+                            HTTPStatus.ACCEPTED)
+        self.assertEqual('starting', volume['migration_status'])
+        mock_migrate.assert_called_once()
+
+    def test_migrate_by_connector_empty_connector_fails(self):
+        """Empty connector must keep the existing 400 path."""
+        volume = self._prep()
+        # The action body schema requires `connector` to be a dict; an empty
+        # dict short-circuits in api.migrate_volume_by_connector with
+        # InvalidInput -> HTTP 400.
+        self._exec(self.ctx, volume, {}, HTTPStatus.BAD_REQUEST)

--- a/cinder/tests/unit/api/contrib/test_admin_actions.py
+++ b/cinder/tests/unit/api/contrib/test_admin_actions.py
@@ -1468,11 +1468,6 @@ class VMwareMigrateByConnectorTest(BaseAdminTest):
         self.patch('cinder.objects.Service.get_minimum_rpc_version',
                    side_effect=_get_minimum_rpc_version_mock)
 
-    def tearDown(self):
-        self.svc.stop()
-        super(VMwareMigrateByConnectorTest, self).tearDown()
-
-    def _prep(self):
         # Register source and destination volume services. The connector
         # path uses scheduler.find_backend_for_connector for the destination,
         # which we mock; we still need the source host's service row in the
@@ -1487,7 +1482,11 @@ class VMwareMigrateByConnectorTest(BaseAdminTest):
                            'topic': constants.VOLUME_TOPIC,
                            'binary': constants.VOLUME_BINARY,
                            'created_at': timeutils.utcnow()})
-        return self._create_volume(self.ctx)
+        self.volume = self._create_volume(self.ctx)
+
+    def tearDown(self):
+        self.svc.stop()
+        super(VMwareMigrateByConnectorTest, self).tearDown()
 
     def _exec(self, ctx, volume, connector, expected_status,
               lock_volume=False):
@@ -1510,8 +1509,7 @@ class VMwareMigrateByConnectorTest(BaseAdminTest):
     def test_migrate_by_connector_with_snap_clone_backend_succeeds(
             self, mock_find, mock_get_caps, mock_migrate):
         """Volume w/ snapshot on a clone-snapshot backend must migrate."""
-        volume = self._prep()
-        snap = objects.Snapshot(self.ctx, volume_id=volume['id'])
+        snap = objects.Snapshot(self.ctx, volume_id=self.volume['id'])
         snap.create()
         self.addCleanup(snap.destroy)
 
@@ -1522,7 +1520,7 @@ class VMwareMigrateByConnectorTest(BaseAdminTest):
 
         connector = {
             'connection_capabilities': ['vmware_service_instance_uuid:foo']}
-        volume = self._exec(self.ctx, volume, connector,
+        volume = self._exec(self.ctx, self.volume, connector,
                             HTTPStatus.ACCEPTED)
         self.assertEqual('starting', volume['migration_status'])
         mock_migrate.assert_called_once()
@@ -1534,8 +1532,7 @@ class VMwareMigrateByConnectorTest(BaseAdminTest):
     def test_migrate_by_connector_with_snap_cow_backend_fails(
             self, mock_find, mock_get_caps, mock_migrate):
         """Volume w/ snapshot on a COW-snapshot backend must be rejected."""
-        volume = self._prep()
-        snap = objects.Snapshot(self.ctx, volume_id=volume['id'])
+        snap = objects.Snapshot(self.ctx, volume_id=self.volume['id'])
         snap.create()
         self.addCleanup(snap.destroy)
 
@@ -1546,7 +1543,7 @@ class VMwareMigrateByConnectorTest(BaseAdminTest):
 
         connector = {
             'connection_capabilities': ['vmware_service_instance_uuid:foo']}
-        self._exec(self.ctx, volume, connector, HTTPStatus.BAD_REQUEST)
+        self._exec(self.ctx, self.volume, connector, HTTPStatus.BAD_REQUEST)
         mock_migrate.assert_not_called()
 
     @mock.patch.object(rpcapi.VolumeAPI, 'migrate_volume')
@@ -1556,8 +1553,6 @@ class VMwareMigrateByConnectorTest(BaseAdminTest):
     def test_migrate_by_connector_no_snap_clone_backend_succeeds(
             self, mock_find, mock_get_caps, mock_migrate):
         """Baseline: no snapshot present, clone backend, must succeed."""
-        volume = self._prep()
-
         mock_find.return_value = {'host': 'test2',
                                   'cluster_name': None,
                                   'capabilities': {}}
@@ -1565,15 +1560,33 @@ class VMwareMigrateByConnectorTest(BaseAdminTest):
 
         connector = {
             'connection_capabilities': ['vmware_service_instance_uuid:foo']}
-        volume = self._exec(self.ctx, volume, connector,
+        volume = self._exec(self.ctx, self.volume, connector,
+                            HTTPStatus.ACCEPTED)
+        self.assertEqual('starting', volume['migration_status'])
+        mock_migrate.assert_called_once()
+
+    @mock.patch.object(rpcapi.VolumeAPI, 'migrate_volume')
+    @mock.patch.object(rpcapi.VolumeAPI, 'get_capabilities')
+    @mock.patch.object(scheduler_rpcapi.SchedulerAPI,
+                       'find_backend_for_connector')
+    def test_migrate_by_connector_no_snap_cow_backend_succeeds(
+            self, mock_find, mock_get_caps, mock_migrate):
+        """Baseline: no snapshot present, COW backend, must also succeed."""
+        mock_find.return_value = {'host': 'test2',
+                                  'cluster_name': None,
+                                  'capabilities': {}}
+        mock_get_caps.return_value = {'snapshot_type': 'snapshot'}
+
+        connector = {
+            'connection_capabilities': ['vmware_service_instance_uuid:foo']}
+        volume = self._exec(self.ctx, self.volume, connector,
                             HTTPStatus.ACCEPTED)
         self.assertEqual('starting', volume['migration_status'])
         mock_migrate.assert_called_once()
 
     def test_migrate_by_connector_empty_connector_fails(self):
         """Empty connector must keep the existing 400 path."""
-        volume = self._prep()
         # The action body schema requires `connector` to be a dict; an empty
         # dict short-circuits in api.migrate_volume_by_connector with
         # InvalidInput -> HTTP 400.
-        self._exec(self.ctx, volume, {}, HTTPStatus.BAD_REQUEST)
+        self._exec(self.ctx, self.volume, {}, HTTPStatus.BAD_REQUEST)

--- a/cinder/volume/api.py
+++ b/cinder/volume/api.py
@@ -984,7 +984,24 @@ class API(base.Base):
                     'group_id': (None, '')}
 
         expected['host'] = db.Not(dest['host'])
-        filters = [~db.volume_has_snapshots_filter()]
+
+        # SAP: If the backend's snapshots are clones, then we don't
+        # have to filter out volumes that have snapshots.  We can find out
+        # if a backend has clones for snapshots by fetching the backend
+        # capabilities and looking for snapshot_type=='clone'.
+        # This mirrors the operator-driven migrate_volume() path so that
+        # Nova-driven migrate_volume_by_connector retries are not blocked
+        # by snapshot presence when the backend uses independent (clone)
+        # snapshots, e.g. VMware FCD with vmware_snapshot_format != 'COW'.
+        caps = self.volume_rpcapi.get_capabilities(
+            ctxt, volume.service_topic_queue, discover=False)
+
+        if caps.get('snapshot_type') == 'clone':
+            # This has to be (), not [] as the default filters param in the
+            # conditional_update is ()
+            filters = ()
+        else:
+            filters = [~db.volume_has_snapshots_filter()]
 
         updates = {'migration_status': 'starting',
                    'previous_status': volume.model.status}

--- a/cinder/volume/api.py
+++ b/cinder/volume/api.py
@@ -985,14 +985,10 @@ class API(base.Base):
 
         expected['host'] = db.Not(dest['host'])
 
-        # SAP: If the backend's snapshots are clones, then we don't
-        # have to filter out volumes that have snapshots.  We can find out
-        # if a backend has clones for snapshots by fetching the backend
-        # capabilities and looking for snapshot_type=='clone'.
-        # This mirrors the operator-driven migrate_volume() path so that
-        # Nova-driven migrate_volume_by_connector retries are not blocked
-        # by snapshot presence when the backend uses independent (clone)
-        # snapshots, e.g. VMware FCD with vmware_snapshot_format != 'COW'.
+        # SAP: When the backend reports snapshot_type=='clone', snapshots
+        # are independent clones of the source volume and the source can be
+        # relocated without affecting them; skip the snapshot filter in that
+        # case. Mirrors the same exemption in migrate_volume() below.
         caps = self.volume_rpcapi.get_capabilities(
             ctxt, volume.service_topic_queue, discover=False)
 


### PR DESCRIPTION
## Problem

The Nova-driven `os-migrate_volume_by_connector` action in `cinder/volume/api.py` unconditionally applied `volume_has_snapshots_filter` to its `conditional_update`, rejecting any volume that had snapshots regardless of the backend's snapshot semantics. This blocks Nova's HTTP-406 attach-retry orchestration when a customer's VM live-migrates to a different vCenter shard and the volume has snapshots.

## Production failure

`req-0765c759-d278-4741-815d-99c595dabfda` in **eu-de-2** at `2026-06-21 14:46:55`:

- Volume `a95cab3b-2d99-42d7-9a41-4128a553f8e1` on `cinder-volume-vmware-vc-a-1@vmware_fcd`.
- Connector targeted `vc-a-5.cc.eu-de-2.cloud.sap` (different shard).
- Volume status `reserved`, `migration_status='success'`, no replication, no group — only the snapshot filter could fail. ES confirms continuous CSI snapshot activity on the volume across the failure timestamp.

Error from `cinder/volume/api.py:1016:migrate_volume_by_connector`:

```
ERROR cinder.volume.api Volume a95cab3b-... status must be available or
reserved, must not be migrating, have snapshots, be replicated, be part
of a group and destination host/cluster must be different than the
current one
cinder.exception.InvalidVolume
```

Nova received HTTP 400 and could not complete the cross-shard attach.

## Fix

The sibling operator-driven `migrate_volume()` path in the same module (api.py:1898-1913) already skips this filter when the backend reports `snapshot_type='clone'` (VMware FCD with `vmware_snapshot_format != 'COW'`), because in that mode snapshots are independent clones and the source volume can be relocated without affecting them.

This patch mirrors that exemption into `migrate_volume_by_connector`:

```python
caps = self.volume_rpcapi.get_capabilities(
    ctxt, volume.service_topic_queue, discover=False)
if caps.get('snapshot_type') == 'clone':
    filters = ()
else:
    filters = [~db.volume_has_snapshots_filter()]
```

Source-backend capabilities are checked (matching the operator path). The error message and all other behavior are preserved verbatim.

## Tests

Adds a new `VMwareMigrateByConnectorTest` class in `cinder/tests/unit/api/contrib/test_admin_actions.py` covering the previously-untested `os-migrate_volume_by_connector` action:

- `test_migrate_by_connector_with_snap_clone_backend_succeeds` — snapshot present, clone backend -> `202 ACCEPTED`, `migration_status='starting'`.
- `test_migrate_by_connector_with_snap_cow_backend_fails` — snapshot present, COW backend -> `400 BAD_REQUEST` (preserved).
- `test_migrate_by_connector_no_snap_clone_backend_succeeds` — baseline, no snapshot, clone backend -> `202 ACCEPTED`.
- `test_migrate_by_connector_empty_connector_fails` — empty connector -> `400 BAD_REQUEST` (preserved).

All 4 new tests pass. All 32 pre-existing migrate tests in the same file continue to pass.

## Risk

- Non-VMware backends and backends reporting non-`clone` snapshot semantics: behavior unchanged (snapshot filter still applied).
- Operator-driven `migrate_volume` path: untouched.
- One additional `get_capabilities` RPC per `os-migrate_volume_by_connector` request; matches the cost the operator path already pays.