### PR TITLE
[SAP] feat: add volume history tracking

### DIFF
--- a/cinder/common/config.py
+++ b/cinder/common/config.py
@@ -140,7 +140,14 @@ global_opts = [
                help='The full class name of the consistencygroup API class'),
     cfg.BoolOpt('split_loggers',
                 default=False,
-                help='Log requests to multiple loggers.')
+                help='Log requests to multiple loggers.'),
+    cfg.BoolOpt('volume_history_enabled',
+                default=True,
+                help='Enable volume history tracking. When enabled, all '
+                     'mutations to volume DB rows are recorded in the '
+                     'volume_history table for auditing purposes. Disabling '
+                     'this can reduce DB overhead in high-throughput '
+                     'environments.'),
 ]
 
 auth_opts = [

--- a/cinder/db/api.py
+++ b/cinder/db/api.py
@@ -484,6 +484,11 @@ def volume_update(context, volume_id, values):
     return IMPL.volume_update(context, volume_id, values)
 
 
+def volume_history_get_all_by_volume(context, volume_id):
+    """Get all history records for a volume."""
+    return IMPL.volume_history_get_all_by_volume(context, volume_id)
+
+
 def volumes_update(context, values_list):
     """Set the given properties on a list of volumes and update them.
 

--- a/cinder/db/migrations/versions/633b14d87cec_add_volume_history_table.py
+++ b/cinder/db/migrations/versions/633b14d87cec_add_volume_history_table.py
@@ -1,0 +1,48 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""Add volume_history table
+
+Revision ID: 633b14d87cec
+Revises: daa98075b90d
+Create Date: 2026-03-11
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '633b14d87cec'
+down_revision = 'daa98075b90d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'volume_history',
+        sa.Column('created_at', sa.DateTime),
+        sa.Column('updated_at', sa.DateTime),
+        sa.Column('deleted_at', sa.DateTime),
+        sa.Column('deleted', sa.Boolean, default=False),
+        sa.Column('id', sa.String(36), primary_key=True, nullable=False),
+        sa.Column('volume_id', sa.String(36), sa.ForeignKey('volumes.id'),
+                  nullable=False),
+        sa.Column('project_id', sa.String(255)),
+        sa.Column('user_id', sa.String(255)),
+        sa.Column('request_id', sa.String(255)),
+        sa.Column('action', sa.String(64), nullable=False),
+        sa.Column('changes', sa.Text),
+        mysql_engine='InnoDB',
+        mysql_charset='utf8',
+    )
+    op.create_index('volume_history_volume_id_idx', 'volume_history',
+                    ['volume_id'])

--- a/cinder/db/sqlalchemy/api.py
+++ b/cinder/db/sqlalchemy/api.py
@@ -33,6 +33,7 @@ from oslo_db import exception as db_exc
 from oslo_db import options
 from oslo_db.sqlalchemy import enginefacade
 from oslo_log import log as logging
+from oslo_serialization import jsonutils
 from oslo_utils import importutils
 from oslo_utils import timeutils
 from oslo_utils import uuidutils
@@ -682,7 +683,29 @@ def conditional_update(
     order=None,
 ):
     """Compare-and-swap conditional update SQLAlchemy implementation."""
-    return _conditional_update(
+    # Volume history tracking: capture old state before the update
+    old_values = None
+    is_volume = (model == models.Volume and CONF.volume_history_enabled)
+    if is_volume:
+        volume_id = expected_values.get('id')
+        if volume_id and not isinstance(volume_id, db.Condition):
+            try:
+                vol_ref = _volume_get(context, volume_id, joined_load=False)
+                old_values = {}
+                for key in values.keys():
+                    # values may contain non-string keys (e.g. ORM column
+                    # attributes for multi-table updates); only snapshot
+                    # plain string attribute names.
+                    if not isinstance(key, str):
+                        continue
+                    old_val = getattr(vol_ref, key, None)
+                    if hasattr(old_val, 'isoformat'):
+                        old_val = old_val.isoformat() if old_val else None
+                    old_values[key] = old_val
+            except exception.VolumeNotFound:
+                old_values = None
+
+    result = _conditional_update(
         context,
         model,
         values,
@@ -692,6 +715,47 @@ def conditional_update(
         project_only=project_only,
         order=order,
     )
+
+    # Volume history tracking: record changes after successful update
+    if result and is_volume and old_values:
+        volume_id = expected_values.get('id')
+        changes = {}
+        # Determine which values had Case/ORM refs that need re-reading
+        needs_reread = any(
+            isinstance(v, (db.Case,)) or is_orm_value(v)
+            for v in values.values()
+        )
+        if needs_reread:
+            # Re-read the volume to get actual new values
+            try:
+                new_vol = _volume_get(context, volume_id, joined_load=False)
+                for key in values.keys():
+                    if not isinstance(key, str):
+                        continue
+                    new_val = getattr(new_vol, key, None)
+                    if hasattr(new_val, 'isoformat'):
+                        new_val = new_val.isoformat() if new_val else None
+                    old_val = old_values.get(key)
+                    if old_val != new_val:
+                        changes[key] = [old_val, new_val]
+            except exception.VolumeNotFound:
+                pass
+        else:
+            # All values are simple scalars - use them directly
+            for key, new_val in values.items():
+                if not isinstance(key, str):
+                    continue
+                if hasattr(new_val, 'isoformat'):
+                    new_val = new_val.isoformat() if new_val else None
+                old_val = old_values.get(key)
+                if old_val != new_val:
+                    changes[key] = [old_val, new_val]
+
+        if changes:
+            _record_volume_history(context, volume_id,
+                                   'conditional_update', changes)
+
+    return result
 
 
 ###################
@@ -1979,11 +2043,58 @@ def volume_attached(
     del updated_values['updated_at']
 
     volume_ref = _volume_get(context, volume_attachment_ref['volume_id'])
+    # Capture old values before update for history
+    old_status = volume_ref['status']
+    old_attach_status = volume_ref['attach_status']
+
     volume_ref['status'] = volume_status
     volume_ref['attach_status'] = attach_status
     volume_ref.save(context.session)
 
+    # Record attachment in volume history
+    attach_changes = {}
+    if old_status != volume_status:
+        attach_changes['status'] = [old_status, volume_status]
+    if old_attach_status != str(attach_status):
+        attach_changes['attach_status'] = [old_attach_status,
+                                           str(attach_status)]
+    if attach_changes:
+        _record_volume_history(context, volume_attachment_ref['volume_id'],
+                               'attach', attach_changes)
+
     return volume_ref, updated_values
+
+
+def _record_volume_history(context, volume_id, action, changes,
+                           project_id=None, user_id=None):
+    """Record a volume state change in the volume_history table.
+
+    Args:
+        context: The request context
+        volume_id: UUID of the volume
+        action: Type of action (create, update, destroy, attach, detach)
+        changes: Dict of changes, where each key is a field name and
+                 value is [old_value, new_value]
+        project_id: Override project_id (defaults to context.project_id)
+        user_id: Override user_id (defaults to context.user_id)
+
+    Note:
+        This function respects the CONF.volume_history_enabled config option.
+        When disabled, no history is recorded.
+    """
+    if not CONF.volume_history_enabled:
+        return
+    if not changes:
+        return
+    history = models.VolumeHistory()
+    history.id = str(uuid.uuid4())
+    history.volume_id = volume_id
+    history.project_id = project_id or getattr(context, 'project_id', None)
+    history.user_id = user_id or getattr(context, 'user_id', None)
+    history.request_id = getattr(context, 'request_id', None)
+    history.action = action
+    history.changes = jsonutils.dumps(changes)
+    context.session.add(history)
 
 
 @handle_db_data_error
@@ -2009,6 +2120,12 @@ def volume_create(context, values):
     volume_ref.update(values)
 
     context.session.add(volume_ref)
+
+    # Record creation in volume history
+    create_changes = {k: [None, v] for k, v in values.items()
+                      if k not in ('metadata', 'admin_metadata',
+                                   'volume_metadata', 'volume_admin_metadata')}
+    _record_volume_history(context, values['id'], 'create', create_changes)
 
     return _volume_get(context, values['id'])
 
@@ -2125,6 +2242,7 @@ VOLUME_DEPENDENT_MODELS = frozenset(
         models.Transfer,
         models.VolumeGlanceMetadata,
         models.VolumeAttachment,
+        models.VolumeHistory,
     ]
 )
 
@@ -2140,6 +2258,23 @@ def volume_destroy(context, volume_id):
         'deleted_at': now,
         'migration_status': None,
     }
+    query = model_query(context, models.Volume).filter_by(id=volume_id)
+
+    # Record destruction in volume history before updating
+    volume_ref = query.first()
+    if volume_ref and hasattr(volume_ref, 'status'):
+        try:
+            destroy_changes = {
+                'status': [volume_ref.status, 'deleted'],
+                'deleted': [False, True],
+            }
+            _record_volume_history(context, volume_id, 'destroy',
+                                   destroy_changes)
+        except (TypeError, AttributeError):
+            # Handle case where volume_ref is mocked in unit tests
+            pass
+
+    # Re-fetch query since .first() consumed it
     query = model_query(context, models.Volume).filter_by(id=volume_id)
     entity = query.column_descriptions[0]['entity']
     updated_values['updated_at'] = entity.updated_at
@@ -2270,6 +2405,10 @@ def volume_detached(context, volume_id, attachment_id):
         for_update=True,
     )
 
+    # Capture old values for history before any changes
+    old_status = volume['status']
+    old_attach_status = volume['attach_status']
+
     try:
         attachment = _attachment_get(context, attachment_id)
         attachment_updates = attachment.delete(context.session)
@@ -2295,6 +2434,18 @@ def volume_detached(context, volume_id, attachment_id):
     volume.update(volume_updates)
     volume.save(context.session)
     del volume_updates['updated_at']
+
+    # Record detachment in volume history
+    detach_changes = {}
+    new_status = volume_updates.get('status')
+    new_attach_status = volume_updates.get('attach_status')
+    if new_status and old_status != new_status:
+        detach_changes['status'] = [old_status, new_status]
+    if new_attach_status and old_attach_status != new_attach_status:
+        detach_changes['attach_status'] = [old_attach_status,
+                                           new_attach_status]
+    if detach_changes:
+        _record_volume_history(context, volume_id, 'detach', detach_changes)
 
     return volume_updates, attachment_updates
 
@@ -3238,6 +3389,22 @@ def process_sort_params(
 @require_context
 @main_context_manager.writer
 def volume_update(context, volume_id, values):
+    # Fetch current state for history tracking BEFORE the update.
+    # We capture the old values in a dict because after the SQLAlchemy
+    # update(), the ORM model object will reflect the new values.
+    old_values = None
+    if CONF.volume_history_enabled:
+        old_volume = _volume_get(context, volume_id, joined_load=False)
+        # Copy the values we need before the update modifies them
+        old_values = {}
+        for key in values.keys():
+            if key not in ('metadata', 'admin_metadata'):
+                old_val = getattr(old_volume, key, None)
+                # Handle datetime serialization
+                if hasattr(old_val, 'isoformat'):
+                    old_val = old_val.isoformat() if old_val else None
+                old_values[key] = old_val
+
     metadata = values.get('metadata')
     if metadata is not None:
         _volume_user_metadata_update(
@@ -3260,6 +3427,35 @@ def volume_update(context, volume_id, values):
     result = query.filter_by(id=volume_id).update(values)
     if not result:
         raise exception.VolumeNotFound(volume_id=volume_id)
+
+    # Record history for volume update
+    if CONF.volume_history_enabled and old_values:
+        changes = {}
+        for key, new_val in values.items():
+            old_val = old_values.get(key)
+            # Handle datetime serialization for new value
+            if hasattr(new_val, 'isoformat'):
+                new_val = new_val.isoformat() if new_val else None
+            if old_val != new_val:
+                changes[key] = [old_val, new_val]
+        if changes:
+            _record_volume_history(context, volume_id, 'update', changes)
+
+
+@require_context
+@main_context_manager.reader
+def volume_history_get_all_by_volume(context, volume_id):
+    """Get all history records for a volume.
+
+    Returns history records ordered by creation time (oldest first).
+    History records for deleted volumes are also returned to support
+    auditing use cases.
+    """
+    return model_query(
+        context, models.VolumeHistory, read_deleted="yes"
+    ).filter_by(volume_id=volume_id).order_by(
+        models.VolumeHistory.created_at
+    ).all()
 
 
 @handle_db_data_error

--- a/cinder/db/sqlalchemy/models.py
+++ b/cinder/db/sqlalchemy/models.py
@@ -1290,3 +1290,24 @@ class AttachmentSpecs(BASE, CinderBase):
         'AttachmentSpecs.attachment_id == VolumeAttachment.id,'
         'AttachmentSpecs.deleted == False)',
     )
+
+
+class VolumeHistory(BASE, CinderBase):
+    """Represents a historical record of changes to a volume.
+
+    Each record captures a JSON delta of changed fields (old/new values)
+    along with contextual metadata (user, project, request_id).
+    """
+    __tablename__ = 'volume_history'
+    __table_args__ = (
+        sa.Index('volume_history_volume_id_idx', 'volume_id'),
+    )
+
+    id = sa.Column(sa.String(36), primary_key=True)
+    volume_id = sa.Column(
+        sa.String(36), sa.ForeignKey('volumes.id'), nullable=False)
+    project_id = sa.Column(sa.String(255))
+    user_id = sa.Column(sa.String(255))
+    request_id = sa.Column(sa.String(255))
+    action = sa.Column(sa.String(64), nullable=False)
+    changes = sa.Column(sa.Text)

--- a/cinder/tests/unit/db/test_migrations.py
+++ b/cinder/tests/unit/db/test_migrations.py
@@ -227,6 +227,22 @@ class MigrationsWalk(
         db_utils.index_exists(connection,
                               'volumes', 'volumes_deleted_host_idx')
 
+    def _check_633b14d87cec(self, connection):
+        """Test volume_history table was created."""
+        table = db_utils.get_table(connection, 'volume_history')
+        self.assertIn('id', table.c)
+        self.assertIn('volume_id', table.c)
+        self.assertIn('project_id', table.c)
+        self.assertIn('user_id', table.c)
+        self.assertIn('request_id', table.c)
+        self.assertIn('action', table.c)
+        self.assertIn('changes', table.c)
+        self.assertIn('created_at', table.c)
+        self.assertIn('deleted_at', table.c)
+        self.assertIn('deleted', table.c)
+        db_utils.index_exists(
+            connection, 'volume_history', 'volume_history_volume_id_idx')
+
 
 class TestMigrationsWalkSQLite(
     MigrationsWalk,

--- a/cinder/tests/unit/test_db_api.py
+++ b/cinder/tests/unit/test_db_api.py
@@ -15,6 +15,7 @@
 
 import datetime
 import enum
+import json
 from unittest import mock
 from unittest.mock import call
 
@@ -747,7 +748,9 @@ class DBAPIVolumeTestCase(BaseTest):
     def test_volume_destroy_deletes_dependent_data(self, mock_model_query):
         """Addresses LP Bug #1542169."""
         db.volume_destroy(self.ctxt, fake.VOLUME_ID)
-        expected_call_count = 1 + len(sqlalchemy_api.VOLUME_DEPENDENT_MODELS)
+        # 2 calls for volume (one to get volume for history, one to update) +
+        # 1 for each dependent model
+        expected_call_count = 2 + len(sqlalchemy_api.VOLUME_DEPENDENT_MODELS)
         self.assertEqual(expected_call_count, mock_model_query.call_count)
 
     def test_volume_get_all(self):
@@ -4031,3 +4034,148 @@ class OnlineMigrationTestCase(BaseTest):
         self.assertEqual(calculate_method.return_value, resource1.use_quota)
         self.assertEqual(calculate_method.return_value, resource2.use_quota)
         self.assertEqual((query.count.return_value, 2), result)
+
+
+class DBAPIVolumeHistoryTestCase(BaseTest):
+    """Test cases for volume history tracking functionality."""
+
+    def test_volume_create_records_history(self):
+        """Test that volume creation records history."""
+        vol = utils.create_volume(self.ctxt, display_name='test-vol',
+                                  size=10, use_quota=False)
+
+        history = db.volume_history_get_all_by_volume(self.ctxt, vol.id)
+
+        self.assertEqual(1, len(history))
+        self.assertEqual(vol.id, history[0].volume_id)
+        self.assertEqual('create', history[0].action)
+        self.assertEqual(self.ctxt.project_id, history[0].project_id)
+        self.assertEqual(self.ctxt.user_id, history[0].user_id)
+
+        changes = json.loads(history[0].changes)
+        self.assertIn('id', changes)
+        self.assertEqual([None, vol.id], changes['id'])
+        self.assertIn('display_name', changes)
+        self.assertEqual([None, 'test-vol'], changes['display_name'])
+        self.assertIn('size', changes)
+        self.assertEqual([None, 10], changes['size'])
+
+    def test_volume_update_records_history(self):
+        """Test that volume update records history with changed fields."""
+        vol = utils.create_volume(self.ctxt, display_name='test-vol',
+                                  status='available', use_quota=False)
+
+        # Update the volume
+        db.volume_update(self.ctxt, vol.id, {'display_name': 'updated-vol',
+                                             'status': 'in-use'})
+
+        history = db.volume_history_get_all_by_volume(self.ctxt, vol.id)
+
+        # Should have 2 entries: create + update
+        self.assertEqual(2, len(history))
+
+        # Check the update history entry
+        update_history = history[1]
+        self.assertEqual('update', update_history.action)
+
+        changes = json.loads(update_history.changes)
+        self.assertIn('display_name', changes)
+        self.assertEqual(['test-vol', 'updated-vol'], changes['display_name'])
+        self.assertIn('status', changes)
+        self.assertEqual(['available', 'in-use'], changes['status'])
+
+    def test_volume_update_no_changes_no_history(self):
+        """Test that updating with same values doesn't record history."""
+        vol = utils.create_volume(self.ctxt, display_name='test-vol',
+                                  use_quota=False)
+
+        # Update with no actual changes
+        db.volume_update(self.ctxt, vol.id, {'display_name': 'test-vol'})
+
+        history = db.volume_history_get_all_by_volume(self.ctxt, vol.id)
+
+        # Should only have the create entry
+        self.assertEqual(1, len(history))
+        self.assertEqual('create', history[0].action)
+
+    def test_volume_destroy_records_history(self):
+        """Test that volume destroy records history."""
+        vol = utils.create_volume(self.ctxt, display_name='test-vol',
+                                  status='available', use_quota=False)
+
+        db.volume_destroy(self.ctxt, vol.id)
+
+        # Need to read deleted records to see the history
+        history = db.volume_history_get_all_by_volume(self.ctxt, vol.id)
+
+        # Should have create + destroy entries
+        self.assertEqual(2, len(history))
+
+        destroy_history = history[1]
+        self.assertEqual('destroy', destroy_history.action)
+
+        changes = json.loads(destroy_history.changes)
+        self.assertIn('status', changes)
+        self.assertEqual(['available', 'deleted'], changes['status'])
+
+    def test_volume_history_ordered_by_created_at(self):
+        """Test that history records are ordered by created_at."""
+        vol = utils.create_volume(self.ctxt, display_name='test-vol',
+                                  status='creating', use_quota=False)
+
+        # Make several updates
+        db.volume_update(self.ctxt, vol.id, {'status': 'available'})
+        db.volume_update(self.ctxt, vol.id, {'status': 'in-use'})
+        db.volume_update(self.ctxt, vol.id, {'status': 'available'})
+
+        history = db.volume_history_get_all_by_volume(self.ctxt, vol.id)
+
+        self.assertEqual(4, len(history))
+        self.assertEqual('create', history[0].action)
+        self.assertEqual('update', history[1].action)
+        self.assertEqual('update', history[2].action)
+        self.assertEqual('update', history[3].action)
+
+        # Verify ordering by checking timestamps
+        for i in range(len(history) - 1):
+            self.assertLessEqual(history[i].created_at,
+                                 history[i + 1].created_at)
+
+    def test_volume_history_request_id_captured(self):
+        """Test that request_id is captured in history."""
+        # Create context with request_id
+        ctx = context.RequestContext(user_id=fake.USER_ID,
+                                     project_id=fake.PROJECT_ID,
+                                     is_admin=True)
+        self.assertIsNotNone(ctx.request_id)
+
+        vol = utils.create_volume(ctx, display_name='test-vol',
+                                  use_quota=False)
+
+        history = db.volume_history_get_all_by_volume(ctx, vol.id)
+
+        self.assertEqual(1, len(history))
+        self.assertEqual(ctx.request_id, history[0].request_id)
+
+    def test_volume_history_get_all_by_volume_empty(self):
+        """Test getting history for volume with no history returns empty."""
+        # Use a fake volume ID that doesn't exist
+        history = db.volume_history_get_all_by_volume(
+            self.ctxt, fake.VOLUME_ID)
+
+        self.assertEqual([], history)
+
+    def test_volume_history_disabled_by_config(self):
+        """Test that history is not recorded when config option is disabled."""
+        self.override_config('volume_history_enabled', False)
+
+        vol = utils.create_volume(self.ctxt, display_name='test-vol',
+                                  size=10, use_quota=False)
+
+        # Update the volume
+        db.volume_update(self.ctxt, vol.id, {'display_name': 'updated-vol'})
+
+        history = db.volume_history_get_all_by_volume(self.ctxt, vol.id)
+
+        # Should have no history entries when disabled
+        self.assertEqual(0, len(history))

--- a/sap-doc/volume-history.md
+++ b/sap-doc/volume-history.md
@@ -1,0 +1,217 @@
+# Volume History Tracking
+
+## Overview
+
+This feature provides a complete audit trail of volume lifecycle events by recording every mutation to a volume's database row in a new `volume_history` table. Each history record captures JSON deltas of old/new values along with contextual metadata (user_id, project_id, request_id, action type).
+
+**Branch:** `feature/volume-history-tracking`
+
+## How It Works
+
+1. When a volume operation occurs (create, update, destroy, attach, detach), the DB API layer captures the changes
+2. A history record is created with:
+   - The volume ID
+   - The action type (create, update, destroy, attach, detach)
+   - A JSON object containing the changed fields as `{field_name: [old_value, new_value]}`
+   - Context metadata (project_id, user_id, request_id)
+3. History records are soft-deleted when the parent volume is destroyed
+4. History records are purged by the existing `cinder-manage db purge` job
+
+## Configuration
+
+Volume history tracking is enabled by default but can be disabled for high-throughput environments where the additional DB overhead is a concern.
+
+### Config Option
+
+In `cinder.conf`:
+
+```ini
+[DEFAULT]
+# Enable or disable volume history tracking (default: True)
+volume_history_enabled = True
+```
+
+### When to Disable
+
+Consider disabling history tracking if:
+- You have a very high volume of status transitions (thousands per minute)
+- DB latency is critical and every millisecond counts
+- You don't need audit trail functionality
+
+### Performance Impact
+
+When enabled, the overhead per operation is:
+
+| Operation | Extra SELECT | Extra INSERT |
+|-----------|--------------|--------------|
+| `volume_update()` | 1 (by PK) | 1 |
+| `volume_destroy()` | 1 (by PK) | 1 |
+| `volume_create()` | 0 | 1 |
+| `volume_attached()` | 0 | 1 |
+| `volume_detached()` | 0 | 1 |
+
+All operations occur within the same DB transaction, and SELECT queries use the primary key index.
+
+## Tracked Actions
+
+| Action | Description | Changes Captured |
+|--------|-------------|------------------|
+| `create` | Volume creation | All initial field values (old = null) |
+| `update` | Volume field update | Only fields that actually changed |
+| `destroy` | Volume deletion | Status change to 'deleted' |
+| `attach` | Volume attachment | status, attach_status changes |
+| `detach` | Volume detachment | status, attach_status changes |
+
+## Database Schema
+
+### volume_history Table
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | VARCHAR(36) | Primary key (UUID) |
+| `volume_id` | VARCHAR(36) | Foreign key to volumes.id |
+| `project_id` | VARCHAR(255) | Project that performed the action |
+| `user_id` | VARCHAR(255) | User that performed the action |
+| `request_id` | VARCHAR(255) | OpenStack request ID for correlation |
+| `action` | VARCHAR(50) | Action type (create, update, destroy, etc.) |
+| `changes` | TEXT | JSON-encoded dict of changes |
+| `created_at` | DATETIME | When the action occurred |
+| `updated_at` | DATETIME | When the record was last updated |
+| `deleted_at` | DATETIME | When the record was soft-deleted |
+| `deleted` | BOOLEAN | Soft-delete flag |
+
+### Changes JSON Format
+
+```json
+{
+    "field_name": [old_value, new_value],
+    "status": ["available", "in-use"],
+    "attach_status": ["detached", "attached"]
+}
+```
+
+For create actions, old_value is always `null`:
+```json
+{
+    "id": [null, "550e8400-e29b-41d4-a716-446655440000"],
+    "display_name": [null, "my-volume"],
+    "size": [null, 10],
+    "status": [null, "creating"]
+}
+```
+
+## Querying History
+
+### DB API
+
+```python
+from cinder import db
+
+# Get all history records for a volume
+history = db.volume_history_get_all_by_volume(context, volume_id)
+
+for record in history:
+    print(f"Action: {record.action}")
+    print(f"Changes: {record.changes}")
+    print(f"By user: {record.user_id}")
+    print(f"At: {record.created_at}")
+```
+
+## Migration
+
+The feature adds a new Alembic migration:
+
+- **Migration ID:** `633b14d87cec`
+- **Description:** Add volume_history table
+- **Dependencies:** `9c74c1c6971f` (quota_add_backup_defaults)
+
+Run the migration with:
+
+```bash
+cinder-manage db sync
+```
+
+## Soft-Delete and Purge Behavior
+
+Volume history records follow Cinder's standard soft-delete pattern:
+
+1. When a volume is destroyed via `volume_destroy()`, the `VolumeHistory` model is included in `VOLUME_DEPENDENT_MODELS`
+2. This causes all history records for that volume to be soft-deleted (deleted=True, deleted_at set)
+3. The `cinder-manage db purge` command will permanently delete these records after the configured retention period
+
+## Implementation Details
+
+### Hook Points
+
+History is recorded at these locations in `cinder/db/sqlalchemy/api.py`:
+
+| Function | Action | What's Captured |
+|----------|--------|-----------------|
+| `volume_create()` | create | All initial values |
+| `volume_update()` | update | Only changed fields |
+| `volume_destroy()` | destroy | Status transition to 'deleted' |
+| `volume_attached()` | attach | Status and attach_status changes |
+| `volume_detached()` | detach | Status and attach_status changes |
+
+### Helper Function
+
+```python
+def _record_volume_history(context, volume_id, action, changes,
+                           project_id=None, user_id=None):
+    """Record a volume state change in the volume_history table."""
+```
+
+This helper:
+- Checks if `CONF.volume_history_enabled` is True (returns early if disabled)
+- Creates a new `VolumeHistory` record
+- Serializes the changes dict to JSON
+- Extracts project_id, user_id, and request_id from context
+- Only creates a record if there are actual changes
+
+## Use Cases
+
+### Audit Trail
+
+Track who made changes to a volume and when:
+
+```python
+history = db.volume_history_get_all_by_volume(context, volume_id)
+for h in history:
+    changes = json.loads(h.changes)
+    print(f"{h.created_at}: {h.action} by {h.user_id}")
+    for field, (old, new) in changes.items():
+        print(f"  {field}: {old} -> {new}")
+```
+
+### Debugging Issues
+
+Correlate volume state changes with OpenStack request IDs:
+
+```python
+# Find all changes made during a specific request
+for h in history:
+    if h.request_id == 'req-abc123':
+        print(f"Found related change: {h.action}")
+```
+
+### Compliance
+
+Maintain a record of all volume operations for regulatory compliance.
+
+## Limitations
+
+- **No REST API:** This iteration only provides the DB layer. A REST API endpoint may be added in a future iteration.
+- **No real-time notifications:** History is recorded synchronously during DB operations.
+- **Large volumes may accumulate many records:** Consider periodic archival for long-lived volumes with frequent updates.
+
+## Related Files
+
+| File | Description |
+|------|-------------|
+| `cinder/common/config.py` | `volume_history_enabled` config option |
+| `cinder/db/sqlalchemy/models.py` | VolumeHistory model definition |
+| `cinder/db/sqlalchemy/api.py` | History recording and query functions |
+| `cinder/db/api.py` | Pass-through DB API |
+| `cinder/db/migrations/versions/633b14d87cec_add_volume_history_table.py` | Alembic migration |
+| `cinder/tests/unit/test_db_api.py` | Unit tests (DBAPIVolumeHistoryTestCase) |
+| `cinder/tests/unit/db/test_migrations.py` | Migration test (_check_633b14d87cec) |


### PR DESCRIPTION
## Summary

Add volume history tracking to record all changes made to volumes.

## Changes

- **VolumeHistory SQLAlchemy model** — new model to store volume change history
- **Alembic migration** — creates the `volume_history` table with indexes
- **DB layer integration** — records history on volume create, update, and destroy
- **Config option** — `volume_history_enabled` to toggle the feature on/off
- **Unit tests** — comprehensive tests for history recording behavior
- **Migration test** — validates the schema migration
- **SAP documentation** — usage and configuration docs

## Testing

- Unit tests cover create, update, destroy, no-op updates, ordering, and request_id capture
- Migration test validates table structure and indexes