### PR TITLE
Fix copy_image_to_volume when the imported vmdk already has an fcd_id (#347)

### DIFF
--- a/cinder/tests/unit/volume/drivers/vmware/test_fcd.py
+++ b/cinder/tests/unit/volume/drivers/vmware/test_fcd.py
@@ -377,7 +377,8 @@ class VMwareVStorageObjectDriverTestCase(test.TestCase):
         image_service = mock.Mock()
         image_service.show.return_value = image_meta
 
-        datastore = mock.sentinel.datastore
+        datastore = mock.Mock()
+        datastore.value.return_value = "datastore-1"
         summary = mock.Mock(datastore=datastore)
         summary.name = 'ds1'
         vops.get_datastore.return_value = datastore
@@ -411,6 +412,9 @@ class VMwareVStorageObjectDriverTestCase(test.TestCase):
         vops.register_disk.return_value = fcd_loc
         vops.get_backing_by_uuid.return_value = mock.sentinel.backing
         vops.get_disk_size.return_value = 2 * units.Gi
+        vops.get_disk_device.return_value = {'backing': mock.sentinel.backing,
+                                             'capacityInBytes': 2 * units.Gi,
+                                             'unitNumber': 4}
         provider_loc_to_ds_name_loc.return_value = provider_location
 
         extra_specs = {

--- a/cinder/volume/drivers/vmware/fcd.py
+++ b/cinder/volume/drivers/vmware/fcd.py
@@ -543,6 +543,15 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
         ds_ref = self.volumeops.get_datastore(backing)
         dc_ref = self.volumeops.get_dc(ds_ref)
         vmdk_path = self.volumeops.get_vmdk_path(backing)
+        device = self.volumeops.get_disk_device(backing, vmdk_path)
+        fcd_id_imp = None
+        if hasattr(device, 'vDiskId'):
+            fcd_id_imp = device.vDiskId.id
+            fcd_loc = vops.FcdLocation.from_provider_location("%s@%s" %
+                                                              (fcd_id_imp,
+                                                               ds_ref.value))
+            self.volumeops.rename_fcd(fcd_loc, ds_ref, volume.name)
+
         self._destroy_backing(backing)
         ds_path = datastore.DatastorePath.parse(vmdk_path)
         dc_path = self.volumeops.get_inventory_path(dc_ref)
@@ -550,9 +559,9 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
         vmdk_url = datastore.DatastoreURL(
             'https', self.configuration.vmware_host_ip, ds_path.rel_path,
             dc_path, ds_path.datastore)
-
-        fcd_loc = self.volumeops.register_disk(
-            str(vmdk_url), volume.name, ds_ref)
+        if not fcd_id_imp:
+            fcd_loc = self.volumeops.register_disk(
+                str(vmdk_url), volume.name, ds_ref)
 
         profile_id = self._get_storage_profile_id(volume)
         if profile_id:

--- a/cinder/volume/drivers/vmware/volumeops.py
+++ b/cinder/volume/drivers/vmware/volumeops.py
@@ -2203,6 +2203,19 @@ class VMwareVolumeOps(object):
         size_mb = fcd_obj.config.capacityInMB
         return size_mb
 
+    def rename_fcd(self, fcd_loc, ds_ref, name):
+        cf = self._session.vim.client.factory
+        disk_id = fcd_loc.id(cf)
+        vstorage_mgr = self._session.vim.service_content.vStorageObjectManager
+        self._session.invoke_api(
+            self._session.vim,
+            'RenameVStorageObject',
+            vstorage_mgr,
+            id=disk_id,
+            datastore=ds_ref,
+            name=name)
+        return
+
     @volume_utils.trace
     def update_fcd_vmdk_uuid(self, ds_ref, vmdk_path, cinder_uuid):
         def cinder_uuid_to_vmwhex(cinder_uuid):


### PR DESCRIPTION
Cherry-picks commit 49e3e1e5 from `stable/2023.1-m3` into `stable/2025.1-m3`.

## Description

Fixes `copy_image_to_volume` when the imported vmdk already has an `fcd_id`.

When we do a cross region transport, the fcd `obj_id` can remain in the glance export. If we re-import this object the `register_fcd` call will fail. This patch mitigates the issue by checking the existence of `vDiskId` before trying to register it.

## Files changed

- `cinder/volume/drivers/vmware/fcd.py`
- `cinder/volume/drivers/vmware/volumeops.py` (new `rename_fcd` helper)
- `cinder/tests/unit/volume/drivers/vmware/test_fcd.py`

Original author: Csaba Seres
Original PR: #347
Change-Id: I3d4fee3df37b486d1020b59e9f834ac7530bfc79

(cherry picked from commit 49e3e1e55c4213ff15df6c09431dd43d039992ea)