### PR TITLE
Add call to extend_volume from terminate_connection in case KVM host

### DIFF
--- a/cinder/volume/drivers/vmware/fcd.py
+++ b/cinder/volume/drivers/vmware/fcd.py
@@ -444,10 +444,10 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
                 # still contains the old size, so to refresh geometry we call
                 # VslmExtendDisk_Task to fix it
                 fcd_loc = vops.FcdLocation.from_provider_location(
-                            self._provider_location_to_moref_location(
-                                volume.provider_location
-                            )
-                        )
+                    self._provider_location_to_moref_location(
+                        volume.provider_location
+                    )
+                )
                 self.volumeops.extend_fcd(fcd_loc, volume.size * units.Ki)
             except Exception:
                 pass

--- a/cinder/volume/drivers/vmware/fcd.py
+++ b/cinder/volume/drivers/vmware/fcd.py
@@ -438,6 +438,14 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
 
     @volume_utils.trace
     def terminate_connection(self, volume, connector, force=False, **kwargs):
+        if (connector and ('connection_capabilities' not in connector)):
+            try:
+                # If the volume was extended on KVM host, the VMware VMDK file
+                # still contains the old size, so to refresh geometry we call
+                # VslmExtendDisk_Task to fix it
+                self.extend_volume(volume, volume.size)
+            except Exception:
+                pass
         # Checking if the connection was used to restore from a backup. In
         # that case, the VMDK connector in os-brick created a new backing
         # which will replace the initial one. Here we set the proper name

--- a/cinder/volume/drivers/vmware/fcd.py
+++ b/cinder/volume/drivers/vmware/fcd.py
@@ -443,7 +443,12 @@ class VMwareVStorageObjectDriver(vmdk.VMwareVcVmdkDriver):
                 # If the volume was extended on KVM host, the VMware VMDK file
                 # still contains the old size, so to refresh geometry we call
                 # VslmExtendDisk_Task to fix it
-                self.extend_volume(volume, volume.size)
+                fcd_loc = vops.FcdLocation.from_provider_location(
+                            self._provider_location_to_moref_location(
+                                volume.provider_location
+                            )
+                        )
+                self.volumeops.extend_fcd(fcd_loc, volume.size * units.Ki)
             except Exception:
                 pass
         # Checking if the connection was used to restore from a backup. In


### PR DESCRIPTION
If a volume if attached to KVM and during this attached period gets online resized, after detach the VMware VM did not have the new disk geometry info, as it was resized on CHV, and cinder did not have way to access the data file due to locking.
This patch calles extend_volume in terminate_connection to mitigate this case.
Change-Id: Ia6616797d207bb5dbd912c8d81164376adb0eb27